### PR TITLE
Fix __bundler-within-bundled-project function call

### DIFF
--- a/plugins/bundler/init.zsh
+++ b/plugins/bundler/init.zsh
@@ -41,7 +41,7 @@ function _bundler-within-bundled-project() {
 }
 
 function _bundler-run() {
-  if _bundler-installed && __bundler-within-bundled-project; then
+  if _bundler-installed && _bundler-within-bundled-project; then
     bundle exec $@
   else
     $@


### PR DESCRIPTION
There's a call to `__bundler-within-bundled-project` function call, which doesn't exists. Instead  `_bundler-within-bundled-project` should be called.
