### PR TITLE
updater globing doesn't work on Zsh 4.3.11

### DIFF
--- a/functions/omz-update
+++ b/functions/omz-update
@@ -14,7 +14,7 @@ if ! git \
       --git-dir="${OMZ}/.git" \
       --work-tree="$OMZ" \
       pull \
-      "${auto_commit:---no-commit}" \
+      $(is-true auto_commit || echo --no-commit) \
       --strategy=recursive \
       -X ours \
       "${remote_name:-origin}" \


### PR DESCRIPTION
Fix the globbing for auto-update, fix the git command for people who do want auto-commit.
