### PR TITLE
plugins/ssh-agent: make it work properly

### DIFF
--- a/plugins/ssh-agent/init.zsh
+++ b/plugins/ssh-agent/init.zsh
@@ -27,14 +27,21 @@ function _ssh-agent-start() {
   local -a identities
 
   # Start ssh-agent and setup the environment.
-  /usr/bin/env ssh-agent | sed 's/^print/#print/' > "${_ssh_agent_env}"
+  rm -f "${_ssh_agent_env}"
+  ssh-agent > "${_ssh_agent_env}"
   chmod 600 "${_ssh_agent_env}"
   source "${_ssh_agent_env}" > /dev/null
 
   # Load identies.
   zstyle -a ':omz:plugin:ssh-agent' identities 'identities'
-  print starting...
-  /usr/bin/ssh-add "$HOME/.ssh/${^identities}"
+
+  print starting ssh-agent...
+
+  if [[ ! -n "${identities}" ]]; then
+    ssh-add
+  else
+    ssh-add "$HOME/.ssh/${^identities}"
+  fi
 }
 
 # Test if agent-forwarding is enabled.


### PR DESCRIPTION
I made it work, I think the breakage came from an update of ssh or something like that.

If it's the case I think it should work properly even with older versions.

I removed the sed because we already redirect to `/dev/null` when sourcing the file so we won't get the echos anyway.

If no identities were set it wasn't adding the default ones, so in case of absence of identities it adds the default when ssh-add is called without parameters.

Question though, wouldn't it be better to remove `/usr/bin/env ssh-agent` and `/usr/bin/ssh-add` and make it just `ssh-agent` and `ssh-add`?
