### PR TITLE
Fix for ssh-agent with multiple identities 

### DIFF
--- a/plugins/ssh-agent/init.zsh
+++ b/plugins/ssh-agent/init.zsh
@@ -38,7 +38,7 @@ function _ssh-agent-start() {
   if [[ ! -n "${identities}" ]]; then
     ssh-add
   else
-    ssh-add "${HOME}/.ssh/${^identities}"
+    ssh-add "${HOME}/.ssh/${^identities[@]}"
   fi
 }
 


### PR DESCRIPTION
Surrounding the ssh-add parameter in quotes caused it to treat all identities as a single parameter. This change ensures they are split.
