### PR TITLE
Error is shown when no theme is configured

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -88,6 +88,7 @@ autoload -Uz promptinit && promptinit
 
 # Load the prompt theme.
 zstyle -a ':omz:prompt' theme 'prompt_argv'
+[[ ${#prompt_argv} == 0 ]] && prompt_argv=("off")
 prompt "$prompt_argv[@]"
 unset prompt_argv
 


### PR DESCRIPTION
Fix the error that displays if the user doesn't have a prompt theme configured, by defaulting the prompt theme to "off".
