### PR TITLE
Do not define the open alias on Linux

### DIFF
--- a/environment.zsh
+++ b/environment.zsh
@@ -80,7 +80,7 @@ if (( $+commands[xdg-open] )); then
   export BROWSER='xdg-open'
 fi
 
-if (( $+commands[open] )); then
+if [[ $OSTYPE == darwin && 1 == $+commands[open] ]]; then
   export BROWSER='open'
 fi
 


### PR DESCRIPTION
Some linux distro's symlink /bin/openvt to /bin/open. This causes the alias created in enviornment.zsh to misbehave.
