### PR TITLE
GNU core utilities ls aliases are broken

### DIFF
--- a/alias.zsh
+++ b/alias.zsh
@@ -16,7 +16,7 @@ if zstyle -t ':omz:alias:ls' color; then
     export CLICOLOR=1
     export LSCOLORS="exfxcxdxbxegedabagacad"
     ls --color -d . &>/dev/null 2>&1
-    if [[ $? == 0 ]]; then
+    if (( $? == 0 )); then
       alias ls='ls --color=auto -F'
     else
       alias ls='ls -GF'


### PR DESCRIPTION
In Linux, `ls -G` is "--no-group", whereas in BSD-derived systems, `-G` requests colour.  In Linux, you need `--color=auto`.  I just copied this test from RobbyRussel-OMZ, which detects the difference correctly.
