### PR TITLE
Less is broken in Linux

### DIFF
--- a/environment.zsh
+++ b/environment.zsh
@@ -88,7 +88,7 @@ fi
 export LESSCHARSET="UTF-8"
 export LESSHISTFILE='-'
 export LESSEDIT='vim ?lm+%lm. %f'
-export LESS='-F -g -i -M -R -S -w -X -z-4'
+export LESS='-F -g -i -M -R -S -w -z-4'
 
 if (( $+commands[lesspipe.sh] )); then
   export LESSOPEN='| /usr/bin/env lesspipe.sh %s 2>&-'


### PR DESCRIPTION
The `-X` option breaks mouse wheel scrolling for me in ArchLinux.  It doesn't look like it does anything particularly useful; maybe BSD less is different?

```
-X or --no-init
       Disables sending the termcap initialization and deinitialization strings to the ter‐
       minal.   This  is  sometimes desirable if the deinitialization string does something
       unnecessary, like clearing the screen.
```
