### PR TITLE
Git-plugin: Update the status parsing

### DIFF
--- a/plugins/git/functions/git-info
+++ b/plugins/git/functions/git-info
@@ -278,8 +278,9 @@ function git-info() {
         branch="$match[1]"
       fi
     else
-      # Count: added/deleted/modified/renamed/unmerged/untracked
-      # T (type change) is undocumented, see https://raw.github.com/gitster/git/master/Documentation/RelNotes/1.7.8.2.txt
+      # Count added, deleted, modified, renamed, unmerged, untracked, dirty.
+      # T (type change) is undocumented, see http://git.io/FnpMGw.
+      # For a table of scenarii, see http://i.imgur.com/2YLu1.png.
       [[ "$line" == ([ACDMT][\ MT]|[ACMT]D)\ * ]] && (( added++ ))
       [[ "$line" == [\ ACMRT]D\ * ]] && (( deleted++ ))
       [[ "$line" == ?[MT]\ * ]] && (( modified++ ))


### PR DESCRIPTION
Counters for added/unmerged/etc. were following a strange rule. This patch changes the detection to respect the documentation : http://linux.die.net/man/1/git-status
