### PR TITLE
Git plugin: Replace calls to git status with porcelain commands

### DIFF
--- a/plugins/git/functions/git-info
+++ b/plugins/git/functions/git-info
@@ -206,7 +206,7 @@ function git-info() {
   _git_info_executing=true
 
   # Use short status for easy parsing.
-  status_cmd='git status --short --branch'
+  status_cmd='git status --porcelain'
   # Get remote's name.
   remote_cmd='git rev-parse --verify HEAD@{upstream} --symbolic-full-name'
   # Get commits count between the local and the remote branch


### PR DESCRIPTION
Clean the git plugin to avoid calls to git status.

Right now, most of the git plugin depends on the git-status command which is called  like a user would do.
There is plenty of plumbing tools more adapted to get this kind of data and even more information.

A possible issue with git-status is the fact that if colors.ui is set to always, it will screw up colors in the prompt.

Another neat feature if the dirty count. Now we can know how many dirty files are in the current repository.
