### PR TITLE
Git-plugin: Don't truncate commit number

### DIFF
--- a/plugins/git/functions/git-info
+++ b/plugins/git/functions/git-info
@@ -137,10 +137,10 @@ function git-info() {
   local branch_info
   local branch_format
   local branch_formatted
+  local branch_is_set
   local clean
   local clean_formatted
   local commit
-  local commit_short
   local commit_format
   local deleted=0
   local deleted_format
@@ -219,9 +219,8 @@ function git-info() {
   commit="$(git rev-parse HEAD 2>/dev/null)"
 
   # Format commit (short).
-  commit_short="$commit[1,7]"
   zstyle -s ':omz:plugin:git:prompt' commit 'commit_format'
-  zformat -f commit_formatted "$commit_format" "c:$commit_short"
+  zformat -f commit_formatted "$commit_format" "c:$commit"
 
   # Stashed
   if [[ -f "$(_git-dir)/refs/stash" ]]; then
@@ -237,9 +236,6 @@ function git-info() {
     (( line_number++ ))
 
     if (( line_number == 1 )) && [[ "$line" == *'(no branch)'* ]]; then
-      # Set branch to commit (short) when the branch is not found.
-      branch="$commit_short"
-
       # Get action.
       action="$(_git-action)"
       if [[ -n "$action" ]]; then
@@ -298,6 +294,7 @@ function git-info() {
   # Format branch.
   zstyle -s ':omz:plugin:git:prompt' branch 'branch_format'
   zformat -f branch_formatted "$branch_format" "b:$branch"
+  branch_is_set=$#branch
 
   # Format remote.
   if [[ "$branch" != "$commit" ]]; then
@@ -379,6 +376,7 @@ function git-info() {
       "c:$commit_formatted" \
       "d:$deleted_formatted" \
       "D:$dirty_formatted" \
+      "h:$branch_is_set" \
       "m:$modified_formatted" \
       "R:$remote_formatted" \
       "r:$renamed_formatted" \

--- a/themes/sorin/prompt_sorin_setup
+++ b/themes/sorin/prompt_sorin_setup
@@ -35,11 +35,11 @@ function prompt_sorin_setup() {
   zstyle ':omz:plugin:git:prompt' deleted ' %%B%F{red}✖%f%%b'
   zstyle ':omz:plugin:git:prompt' modified ' %%B%F{blue}✱%f%%b'
   zstyle ':omz:plugin:git:prompt' renamed ' %%B%F{magenta}➜%f%%b'
-  zstyle ':omz:plugin:git:prompt' commit '%c'
+  zstyle ':omz:plugin:git:prompt' commit '%.7c'
   zstyle ':omz:plugin:git:prompt' stashed ' %%B%F{cyan}✭%f%%b'
   zstyle ':omz:plugin:git:prompt' unmerged ' %%B%F{yellow}═%f%%b'
   zstyle ':omz:plugin:git:prompt' untracked ' %%B%F{white}◼%f%%b'
-  zstyle ':omz:plugin:git:prompt' prompt ' %F{blue}git%f%b%s'
+  zstyle ':omz:plugin:git:prompt' prompt ' %F{blue}git%f%0(h.%c.%b)%s'
   zstyle ':omz:plugin:git:prompt' rprompt '%A%B%S%a%d%m%r%U%u'
 
   PROMPT='%F{cyan}%1~%f${git_prompt_info} %(!.%B%F{red}#%f%b.%B%F{green}❯%f%b) '


### PR DESCRIPTION
A branch name shouldn't be a commit number, and a commit number should always be in the long format.
Themes can reduce the size of the commit id, and they should be able to choose between the branch name or the commit id.
