### PR TITLE
Git-plugin: Dirty should count the number of dirty files (instead of being on/off)

### DIFF
--- a/plugins/git/functions/git-info
+++ b/plugins/git/functions/git-info
@@ -145,7 +145,8 @@ function git-info() {
   local deleted=0
   local deleted_format
   local deleted_formatted
-  local dirty
+  local dirty=0
+  local dirty_format
   local dirty_formatted
   local line_number=0
   local modified=0
@@ -277,13 +278,7 @@ function git-info() {
         branch="$match[1]"
       fi
     else
-      # Format dirty.
-      if [[ -z "$dirty" ]]; then
-        zstyle -s ':omz:plugin:git:prompt' dirty 'dirty_formatted'
-        if [[ -z "$dirty_formatted" ]]; then
-          unset clean_formatted
-        fi
-      fi
+      (( dirty++ ))
 
       # Count: added/deleted/modified/renamed/unmerged/untracked
       [[ "$line" == (((A|M|D|T) )|(AD|AM|AT|MM))\ * ]] && (( added++ ))
@@ -357,6 +352,12 @@ function git-info() {
   if (( $untracked > 0 )); then
     zstyle -s ':omz:plugin:git:prompt' untracked 'untracked_format'
     zformat -f untracked_formatted "$untracked_format" "u:$untracked"
+  fi
+
+  # Format dirty.
+  if [[  $dirty > 0 ]]; then
+    zstyle -s ':omz:plugin:git:prompt' dirty 'dirty_format'
+    zformat -f dirty_formatted "$dirty_format" "D:$dirty"
   fi
 
   # Format prompts.

--- a/plugins/git/style.zsh
+++ b/plugins/git/style.zsh
@@ -29,8 +29,8 @@ zstyle ':omz:plugin:git:prompt' commit 'commit:%c'
 # %d - Indicator to notify of deleted files.
 zstyle ':omz:plugin:git:prompt' deleted 'deleted:%d'
 
-# %D - Indicator to notify of dirty branch.
-zstyle ':omz:plugin:git:prompt' dirty 'dirty'
+# %D - Indicator to notify of dirty files on branch.
+zstyle ':omz:plugin:git:prompt' dirty 'dirty:%D'
 
 # %m - Indicator to notify of modified files.
 zstyle ':omz:plugin:git:prompt' modified 'modified:%m'


### PR DESCRIPTION
It doesn't cost much more to actually get the number of dirty files instead of knowing if the current repo is considered as dirty.

This change could imply the removal of everything related to `clean_formatted` as clean would just be dirty with a value of 0 (could be used with ternary operator, see #41).
