### PR TITLE
Use a daemon session in Tmux plugin

### DIFF
--- a/plugins/tmux/init.zsh
+++ b/plugins/tmux/init.zsh
@@ -18,16 +18,15 @@ alias tl="tmux list-sessions"
 
 # Auto Start
 if [[ -z "$TMUX" ]] && zstyle -t ':omz:plugin:tmux:auto' start; then
+  tmux_session='#OMZ'
 
-  session="$(
-    tmux list-sessions 2> /dev/null \
-      | cut -d':' -f1 \
-      | head -1)"
-
-  if [[ -n "$session" ]]; then
-    exec tmux attach-session -t "$session"
-  else
-    exec tmux new-session
+  if ! tmux has-session -t "$tmux_session" 2> /dev/null; then
+    # Override potential tmux configuration
+    tmux set-option -g destroy-unattached off &> /dev/null
+    tmux new-session -d -s "$tmux_session"
+    tmux set-option -t "$tmux_session" destroy-unattached off &> /dev/null
+    # Mandatory, or we'll end up with a lot of open session detached
+    tmux set-option -g destroy-unattached on &> /dev/null
   fi
+  exec tmux new-session -t "$tmux_session"
 fi
-


### PR DESCRIPTION
Instead of just attaching to the first session available, create a new session based on the windows of a "main session"

The main session is a "daemon", other sessions are automatically destroyed when no client is attached
