### PR TITLE
Tmux plugin launchmsg

### DIFF
--- a/plugins/tmux/init.zsh
+++ b/plugins/tmux/init.zsh
@@ -27,7 +27,7 @@ if (( $SHLVL == 1 )) && zstyle -t ':omz:plugin:tmux:auto' start; then
   if [[ -n "$session" ]]; then
     exec tmux attach-session -t "$session"
   else
-    exec tmux new-session "$SHELL -l"
+    exec tmux new-session
   fi
 fi
 


### PR DESCRIPTION
tmux, launch_msg(): Socket is not connected is thrown due to an error by launch_ctl
By default tmux starts the first login shell available, so no need to force it.

Fix #56
