### PR TITLE
Screen plugin: Use $STY instead of $SHLVL

### DIFF
--- a/plugins/screen/init.zsh
+++ b/plugins/screen/init.zsh
@@ -17,9 +17,7 @@ alias sn="screen -U -S"
 alias sr="screen -a -A -U -D -R"
 
 # Auto Start
-if (( $SHLVL == 1 )) && zstyle -t ':omz:plugin:screen:auto' start; then
-  (( SHLVL += 1 )) && export SHLVL
-
+if [[ -z $STY ]] && zstyle -t ':omz:plugin:screen:auto' start; then
   session="$(
     screen -list 2> /dev/null \
       | sed '1d;$d' \


### PR DESCRIPTION
As @sorin-ionescu said [here](https://github.com/sorin-ionescu/oh-my-zsh/commit/17a4505a0afba4978e07e6065ca690efc7eb4542#commitcomment-1131550) SHLVL isn't reliable.

`$STY` is automatically set by screen to know if there is a screen session already started.

See http://linux.die.net/man/1/screen
