### PR TITLE
Read the entire history in history-stat

### DIFF
--- a/utility.zsh
+++ b/utility.zsh
@@ -8,7 +8,7 @@
 #
 
 # Lists the ten most used commands.
-alias history-stat="history | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
+alias history-stat="history . | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
 
 # Serves a directory via HTTP.
 alias http-serve='python -m SimpleHTTPServer'


### PR DESCRIPTION
By default history acts like 'fc -l' which only gives the last 16 entries of the history
