### PR TITLE
Add different describe commands

### DIFF
--- a/plugins/git/functions/git-info
+++ b/plugins/git/functions/git-info
@@ -143,6 +143,7 @@ function git-info {
   local modified_format
   local modified_formatted
   local position
+  local position_cmd
   local position_format
   local position_formatted
   local prompt_format
@@ -203,6 +204,20 @@ function git-info {
 
   # Gets the commit difference counts between local and remote.
   ahead_and_behind_cmd='git rev-list --count --left-right HEAD...@{upstream}'
+
+  # Use describe to get the current position
+  zstyle -s 'omz:plugin:git:prompt:position' style 'position_style'
+  case "$position_style" in
+    (contains)
+      position_cmd='git describe --contains --tags HEAD'
+    ;;
+    (references)
+      position_cmd='git describe --contains --all HEAD'
+    ;;
+    (tags)
+      position_cmd='git describe --tags HEAD'
+    ;;
+  esac
 
   # Ignore submodule status.
   zstyle -b \
@@ -279,7 +294,7 @@ function git-info {
     fi
   else
     # Format position.
-    position="$(git describe --contains --all HEAD 2> /dev/null)"
+    position="$(${(z)position_cmd} 2> /dev/null)"
     if [[ -n "$position" ]]; then
       zstyle -s ':omz:plugin:git:prompt' position 'position_format'
       zformat -f position_formatted "$position_format" "p:$position"

--- a/plugins/git/style.zsh
+++ b/plugins/git/style.zsh
@@ -56,6 +56,9 @@ zstyle ':omz:plugin:git:prompt' prompt ' git:(%b %D)'
 # Right prompt.
 zstyle ':omz:plugin:git:prompt' rprompt ''
 
+# Position style "contains", "references", "tags"
+zstyle ':omz:plugin:git:prompt:position' style 'references'
+
 # Ignore submodule.
 zstyle ':omz:plugin:git:prompt:ignore' submodule 'no'
 


### PR DESCRIPTION
Allows the user to change the describe command when looking for the current position in a git repo.

Add :
- `contains`, looking only for annotated tags after the current position
- `branch`, looking for any reference after the current position (current default)
- `describe`, looking for annotated tags before the current position
- `tags`, looking any tag before the current position
