### PR TITLE
Don't use -t to enable auto-start on tmux

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -18,7 +18,7 @@ Start a tmux session automatically when a Zsh session is opened.
 
 To enable this feature, one line has to be added to the configuration file:
 
-    zstyle -t ':omz:plugin:tmux' auto-start 'yes'
+    zstyle ':omz:plugin:tmux' auto-start 'yes'
 
 This will automatically create a background session named "#OMZ" and attach every new shell to it.
 

--- a/plugins/tmux/init.zsh
+++ b/plugins/tmux/init.zsh
@@ -9,7 +9,7 @@
 #   To auto start it, add the following to zshrc:
 #
 #     # Auto launch tmux at start-up.
-#     zstyle -t ':omz:plugin:tmux' auto-start 'yes'
+#     zstyle ':omz:plugin:tmux' auto-start 'yes'
 #
 # Warning:
 #   Tmux is known to cause kernel panics on Mac OS X.


### PR DESCRIPTION
A small mistake has been made and copied everywhere
