### PR TITLE
xdg-open calls $BROWSER if set and it's not in a "known" DE

### DIFF
--- a/environment.zsh
+++ b/environment.zsh
@@ -85,8 +85,8 @@ fi
 if [[ "$OSTYPE" == darwin* ]]; then
   export BROWSER='open'
 else
-  if (( $+commands[xdg-open] )); then
-    export BROWSER='xdg-open'
+  if (( $+commands[xdg-settings] )); then
+    export BROWSER=$(xdg-settings get default-web-browser 2>/dev/null)
   fi
 fi
 
@@ -113,4 +113,3 @@ if zstyle -t ':omz:environment:termcap' color; then
   export LESS_TERMCAP_ue=$'\E[0m'          # end underline
   export LESS_TERMCAP_us=$'\E[01;32m'      # begin underline
 fi
-


### PR DESCRIPTION
.And this causes a fork bomb for people like me who run minimal-distros.

This is probably a crappy way of setting it, since I'm not a zsh guru, but it uses xdg-setings to pull the default browser. It'll get set to an empty string if it's not set, and xdg-open will do "the right thing" in that case, trying some known values.
