### PR TITLE
Add gdircolors support for OS X in lieu of gnu-utils

### DIFF
--- a/alias.zsh
+++ b/alias.zsh
@@ -20,6 +20,18 @@ if (( $+commands[dircolors] )); then
   else
     alias ls="$aliases[ls] -F"
   fi
+elif (( $+commands[gdircolors] )); then
+  # GNU core utilities on OS X.
+  alias ls='/usr/local/bin/gls --group-directories-first'
+
+  if zstyle -t ':omz:alias:ls' color; then
+    if [[ -f "$HOME/.dir_colors" ]]; then
+      eval $(gdircolors "$HOME/.dir_colors")
+    fi
+    alias ls="$aliases[ls] --color=auto"
+  else
+    alias ls="$aliases[ls] -F"
+  fi
 else
   # BSD core utilities.
   if zstyle -t ':omz:alias:ls' color; then


### PR DESCRIPTION
All GNU coreutils commands are installed with the prefix 'g' on Mac OS
X via homebrew. This fix adds support for GNU ls without losing the git
alias 'gls'.

Any feedback is welcome.
