### PR TITLE
Remove gnu-utils ls aliases

### DIFF
--- a/modules/gnu-utils/init.zsh
+++ b/modules/gnu-utils/init.zsh
@@ -62,16 +62,3 @@ function hash {
 function rehash {
   hash -r "$@"
 }
-
-# A sensible default for ls.
-alias ls='ls --group-directories-first'
-
-if zstyle -t ':omz:alias:ls' color; then
-  if [[ -f "$HOME/.dir_colors" ]]; then
-    eval $(gdircolors "$HOME/.dir_colors")
-  fi
-  alias ls="$aliases[ls] --color=auto"
-else
-  alias ls="$aliases[ls] -F"
-fi
-


### PR DESCRIPTION
There is no need to define aliases that are already defined somewhere else.
Gnu-utils shoud olny load the gnu-utils commands

Related to #81
