### PR TITLE
GNU-utils should be loaded before aliases

### DIFF
--- a/modules/gnu-utils/init.zsh
+++ b/modules/gnu-utils/init.zsh
@@ -81,18 +81,3 @@ function hash {
 function rehash {
   hash -r "$@"
 }
-
-# A sensible default for ls.
-alias ls='ls --group-directories-first'
-
-if zstyle -t ':omz:alias:ls' color; then
-  if [[ -f "$HOME/.dir_colors" ]]; then
-    eval "$(dircolors "$HOME/.dir_colors")"
-  else
-    eval "$(dircolors)"
-  fi
-  alias ls="$aliases[ls] --color=auto"
-else
-  alias ls="$aliases[ls] -F"
-fi
-


### PR DESCRIPTION
There is no need to define aliases that are already defined somewhere else.
Gnu-utils shoud only load the gnu-utils commands, aliases will take care of the rest
