### PR TITLE
Look for gnu-coreutils commands instead of $OSTYPE

### DIFF
--- a/modules/utility/functions/duh
+++ b/modules/utility/functions/duh
@@ -8,7 +8,7 @@
 
 function duh {
   (( $# == 0 )) && set -- *
-  if [[ "$OSTYPE" == linux* ]]; then
+  if (( $+commands[dircolors] )); then
     du -khsc "$@" | sort -h -r
   else
     du -kcs "$@" | awk '{ printf "%9.1fM    %s\n", $1 / 1024, $2 } ' | sort -n -r
@@ -17,4 +17,3 @@ function duh {
 compdef _du duh
 
 duh "$@"
-


### PR DESCRIPTION
It's possible to have the gnu-coreutils on other environments than Linux
