### PR TITLE
Minor fixes on utility

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -17,23 +17,23 @@ alias pmine='ps -U "$USER" -o pid,%cpu,%mem,command'
 function mkdcd {
   [[ -n "$1" ]] && mkdir -p "$1" && cd "$1"
 }
-compdef _mkdir mkdcd 2> /dev/null
+compdef _cd mkdcd 2> /dev/null
 
 # Changes to a directory and lists its contents.
 function cdll {
-  builtin cd "$1" && ll
+  cd "$1" && ll
 }
 compdef _cd cdll 2> /dev/null
 
 # Pushes an entry onto the directory stack and lists its contents.
 function pushdll {
-  builtin pushd "$1" && ll
+  pushd "$1" && ll
 }
 compdef _cd pushdll 2> /dev/null
 
 # Pops an entry off the directory stack and lists its contents.
 function popdll {
-  builtin popd "$1" && ll
+  popd "$1" && ll
 }
 compdef _cd popdll 2> /dev/null
 


### PR DESCRIPTION
- mkdcd should use cd's completion, as only the first parameter is used
- no need to force builtins commands, if the user wants to wrap them,
  those wraps should be used
