### PR TITLE
Enable server time-stamp by default for curl and wget

### DIFF
--- a/modules/alias/init.zsh
+++ b/modules/alias/init.zsh
@@ -75,10 +75,10 @@ alias type='type -a'
 # Mac OS X
 if [[ "$OSTYPE" == darwin* ]]; then
   alias o='open'
-  alias get='curl --continue-at - --location --progress-bar --remote-name'
+  alias get='curl --continue-at - --location --progress-bar --remote-name --remote-time'
 else
   alias o='xdg-open'
-  alias get='wget --continue --progress=bar'
+  alias get='wget --continue --progress=bar --timestamping'
 
   if (( $+commands[xclip] )); then
     alias pbcopy='xclip -selection clipboard -in'


### PR DESCRIPTION
Yes, I agree that personal customizations can stay in own fork, but this one would be a reasonable default for most cases, I suppose.
