### PR TITLE
Complete in word, not prefix

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -174,7 +174,7 @@ function expand-or-complete-with-indicator {
   local indicator
   zstyle -s ':omz:module:editor' completing 'indicator'
   print -Pn "$indicator"
-  zle expand-or-complete-prefix
+  zle expand-or-complete
   zle redisplay
 }
 zle -N expand-or-complete-with-indicator


### PR DESCRIPTION
Allow people to opt-out for COMPLETE_IN_WORD by using expand-or-complete instead of expand-or-complete-prefix

Described in: http://www.zsh.org/mla/users/2003/msg00610.html
