### PR TITLE
Remove the builtin keyword before mkdir in mkdcd

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -15,7 +15,7 @@ alias pmine='ps -U "$USER" -o pid,%cpu,%mem,command'
 
 # Makes a directory and changes to it.
 function mkdcd {
-  [[ -n "$1" ]] && builtin mkdir -p "$1" && builtin cd "$1"
+  [[ -n "$1" ]] && mkdir -p "$1" && builtin cd "$1"
 }
 compdef '_path_files -/' mkdcd 2> /dev/null
 


### PR DESCRIPTION
`mkdcd` from `modules/utility` fails with:

```
$ mkdcd foo
mkdcd:1: no such builtin: mkdir
```

Caused by a `mkdir` invocation prefixed with `builtin` modifier, though `mkdir` is no builtin command. This commit fixes this by simply removing this modifier.
