### PR TITLE
Mention virtualenvwrapper support in summary of Python documentation

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -1,7 +1,7 @@
 Python
 ======
 
-Enables local Python package installation.
+Enables local Python package installation and virtualenvwrapper.
 
 Local Package Installation
 --------------------------


### PR DESCRIPTION
The Python module enables virtualenvwrapper, but this isn't mentioned in the summary of README.md.
