### PR TITLE
Add haskell module

### DIFF
--- a/modules/haskell/README.md
+++ b/modules/haskell/README.md
@@ -1,0 +1,27 @@
+Haskell
+=======
+
+Enables per user Haskell package installation.
+
+Per-user Package Installation
+-----------------------------
+
+[`cabal`][1], the Haskell package manager, can install packages into per user
+directories.
+
+This module prepends per user directories to the relevant path variables to
+enable the execution of user installed executables and the reading of
+documentation.
+
+### Usage
+
+Install packages into per user directories with `cabal install --user`.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the GitHub issue tracker.*
+
+ - [Sebastian Wiesner](/lunaryorn)
+
+[1]: http://www.haskell.org/cabal/

--- a/modules/haskell/init.zsh
+++ b/modules/haskell/init.zsh
@@ -1,0 +1,15 @@
+#
+# Enables user installation of haskell packages
+#
+# Authors:
+#   Sebastian Wiesner <lunaryorn@googlemail.com>
+#
+
+# Prepend cabal per user directories to PATH/MANPATH
+if [[ "$OSTYPE" == darwin* ]]; then
+  path=($HOME/Library/Haskell/bin $path)
+  manpath=($HOME/Library/Haskell/man $manpath)
+else
+  path=($HOME/.cabal/bin $path)
+  manpath=($HOME/.cabal/man $path)
+fi


### PR DESCRIPTION
This module provides support for per user haskell packages (as installed by `cabal install --user`) by prepending the per user directories to PATH/MANPATH.
