### PR TITLE
Fix typo in modules/alias/init.zsh

### DIFF
--- a/modules/alias/init.zsh
+++ b/modules/alias/init.zsh
@@ -138,7 +138,7 @@ if zstyle -t ':omz:module:alias:make' color; then
     if (( $+commands[colormake] )); then
       colormake "$@"
     else
-      "$comamnds[make]" "$@"
+      "$commands[make]" "$@"
     fi
   }
 fi


### PR DESCRIPTION
Now we can use make again :)
