### PR TITLE
Add omz-readme to show the READMEs of modules

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -12,6 +12,7 @@ Aliases
 Functions
 ---------
 
+  - `omz-readme` shows the README of OMZ or OMZ modules
   - `mkdcd` makes a directory and changes to it.
   - `cdls` changes to a directory and lists its contents.
   - `pushdls` pushes an entry onto the directory stack and lists its contents.

--- a/modules/utility/functions/omz-readme
+++ b/modules/utility/functions/omz-readme
@@ -1,0 +1,28 @@
+#
+# Displays a README of OMZ or OMZ modules
+#
+# Authors:
+#   Sebastian Wiesner <lunaryorn@googlemail.com>
+#
+
+local -a readmes
+local readme
+
+if (( $# == 0 )); then
+  readmes=("$OMZ/README.md")
+else
+  for module in "$argv[@]"; do
+    readme="$OMZ/modules/$module/README.md"
+    if [[ -f $readme ]]; then
+      readmes+=("$readme")
+    elif [[ ! -d "$OMZ/modules/$module" ]]; then
+      print "unknown module $module" >&2
+    else
+      print "no README in module $module" >&2
+    fi
+  done
+fi
+
+if (( $#readmes )); then
+  $PAGER "$readmes[@]"
+fi


### PR DESCRIPTION
A utility to view the README of OMZ or one or more of its modules in the `$PAGER`.  Lacks a completion function, but I have no clue how to write one.
