### PR TITLE
[Fix #122] Add documentation for yum

### DIFF
--- a/modules/yum/README.md
+++ b/modules/yum/README.md
@@ -1,0 +1,29 @@
+yum
+===
+
+Defines [`yum`][1] aliases.
+
+Aliases
+-------
+
+- `ys` searches packages.
+- `yp` shows package info.
+- `yl` lists packages.
+- `yli` lists installed packages.
+- `yu` updates installed packages.
+- `yi` installs packages.
+- `yr` removes packages.
+- `yrl` removes packages, including any unused dependencies (with
+  `yum-plugin-remove-with-leaves`).
+- `yc` cleans the cache.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+
+[1]: http://yum.baseurl.org/
+[2]: https://github.com/sorin-ionescu/oh-my-zsh/issues
+


### PR DESCRIPTION
Quite rudimentary, but should do the job.

I've documented the module as is, but the `yrl` needs to be removed from the module, because its functionality is provided by `yum` itself now, and the underlying `yum` plugin is not even available anymore in the latest release of Fedora.
