### PR TITLE
Update the gnu-utility module loading order

### DIFF
--- a/modules/gnu-utility/README.md
+++ b/modules/gnu-utility/README.md
@@ -10,7 +10,7 @@ utilities will be broken.
 However, for interactive use, prefixed commands can be wrapped in their
 non-prefixed counterparts.
 
-This module must be loaded **before** the *alias* module.
+This module must be loaded **before** the *utility* module.
 
 Settings
 --------


### PR DESCRIPTION
The README of `gnu-utility` still referred to the `alias` module. This patch fixes the README to correctly refer to the `utility` module.
