### PR TITLE
Fasd module

### DIFF
--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -9,6 +9,9 @@ you can quickly reference them in the command line.
 You should define your own aliases to utilize the full power of fasd. For more
 information please see `man fasd` or visit [fasd][1].
 
+For completion to work, this module should be loaded **after** the *completion*
+module.
+
 Aliases
 -------
 
@@ -19,8 +22,29 @@ Aliases
   - `sd` interactive directory selection
   - `sf` interactive file selection
   - `z`  changes the directory to most *frecent* match.
-  - `j`  the same as `z` for [autojump][2] converts.
   - `zz` interactive z
+  - `j`  the same as `z` for [autojump][2] converts.
+  - `v`  open recently vim-edited files
+
+Note: loading `fasd` module will override alias `d` defined in `directory`
+module.
+
+Completion
+----------
+
+You can do tab completion on any fasd command (d, f, z, v, etc.).
+
+You can type a comma-separated query on *any command* and use the following key
+combination:
+
+  - Ctrl-x Ctrl-a to complete files and directories
+  - Ctrl-x Ctrl-d to complete directories
+  - Ctrl-x Ctrl-f to complete files
+
+Alternatively, you can type extra `f,`, `d,` `,` in front of your
+comma-separated query, or type extra `,,f`, `,,d`, `,,` at the end of your
+comma-separated query. Such formated command-line arguments will be tab
+completed via fasd.
 
 Authors
 -------

--- a/modules/fasd/init.zsh
+++ b/modules/fasd/init.zsh
@@ -11,7 +11,7 @@ if (( ! $+commands[fasd] )); then
 fi
 
 cache_file="${0:h}/cache.zsh"
-if [[ "$(which fasd)" -nt "$cache_file" || ! -s "$cache_file"  ]]; then
+if [[ "${commands[fasd]}" -nt "$cache_file" || ! -s "$cache_file"  ]]; then
   # Base init arguments
   init_args='posix-alias zsh-hook'
 
@@ -29,7 +29,6 @@ source "$cache_file"
 unset cache_file init_args
 
 alias j='z'                      # For autojump converts
-alias o="a -e $aliases[o]"       # Quickly open paths with open.
 alias v='f -t -e vim -b viminfo' # Quickly open files with vim.
 
 for keymap in 'emacs' 'viins'; do


### PR DESCRIPTION
It works under my testings. There're probably many things that can be done the zsh-way, for instance "$(which fasd)". Unfortunately I don't know much "zshisms."

For further improvements, I think completion can be user congifurable vai zstyle. But then the cache process would become more complex.

Also I noticed fasd default alias will overide some omz aliases. Maybe that should be put into README?
