### PR TITLE
Fix gnu coreutils recognition on Solaris

### DIFF
--- a/modules/gnu-utility/init.zsh
+++ b/modules/gnu-utility/init.zsh
@@ -9,7 +9,7 @@
 zstyle -s ':omz:module:gnu-utility' prefix '_gnu_utility_p' || _gnu_utility_p='g'
 
 # Check for the presence of GNU Core Utilities.
-if (( ! ${+commands[${_gnu_utility_p}dircolors]} )); then
+if (( ! ${+commands[${_gnu_utility_p}dircolors]} && ! ${+commands[dircolors]} )); then
   return 1
 fi
 


### PR DESCRIPTION
I know it's retarded, but for some reason on Solaris dircolors has no g prefix while the rest of the utils do.
