### PR TITLE
Add support for pythonz

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -1,7 +1,23 @@
 Python
 ======
 
-Enables local Python package installation.
+Enables local Python builds and package installation.
+
+Local Python builds
+-------------------
+
+[pythonz][6] builds and installs multiple Python versions locally in the home
+directory. It supports CPython, Stackless Python, Jython and PyPy.
+
+This module prepends the pythonz directory to the path variable to make
+`pythonz` available.
+
+### Usage
+
+Install Python versions with `pythonz install` into into `~/.pythonz/pythons`.
+To make these Python versions generally available, add symbolic links to
+`~/.pythonz/bin`.
+
 
 Local Package Installation
 --------------------------
@@ -44,4 +60,4 @@ Authors
 [3]: http://pypi.python.org/pypi/virtualenv
 [4]: http://www.doughellmann.com/docs/virtualenvwrapper/#introduction
 [5]: https://github.com/sorin-ionescu/oh-my-zsh/issues
-
+[6]: http://saghul.github.com/pythonz/

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -22,3 +22,11 @@ if [[ -n "$WORKON_HOME" ]] && (( $+commands[virtualenvwrapper.sh] )); then
   source "$commands[virtualenvwrapper.sh]"
 fi
 
+# Load pythonz into the shell session, if available
+if [[ -s $HOME/.pythonz/bin/pythonz ]]; then
+  path=($HOME/.pythonz/bin $path)
+
+  function pythonz {
+    command pythonz "$@" && builtin hash -r
+  }
+fi


### PR DESCRIPTION
[pythonz](http://saghul.github.com/pythonz/) builds and installs python locally in $HOME.  It's a cleaner and simpler fork of pythonbrew. Unlike pythonbrew it does only this one thing, and does it well, supporting more versions and more implementations.  Plus, it's got a nice website :), and seems to be more maintained.

Pythonbrew is bloated and tries to do too much like wrapping virtualenv or buildout, or managing the default Python version.  All these features are rather superfluous, because virtualenv and buildout can perfectly create environments for local Python builds on their own, and changing the default Python version is just a matter of prepending the corresponding `/bin` directory of the Python build to `$path`.
