### PR TITLE
Fix pacman-list-explicit function

### DIFF
--- a/modules/pacman/functions/pacman-list-explicit
+++ b/modules/pacman/functions/pacman-list-explicit
@@ -6,8 +6,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-sudo pacman --query --explicit --info \
-  $(pacman --query --upgrades | cut -d' ' -f 1) \
+pacman --query --explicit --info \
   | awk '
       BEGIN {
         FS=":"


### PR DESCRIPTION
Currently the function only works when there are no updates available, since then --query --upgrades returns nothing and --query --explicit lists info for all packages when given no arguments. If there are updates available, the function currently lists only the available updates.

I'm not sure why that line was there to begin with but I simply fixed the problem by removing it. Pacman can also list installed packages without root so I removed the sudo bit too.
