### PR TITLE
[Fix #268] Get entire history for history-stat

### DIFF
--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -36,5 +36,4 @@ setopt HIST_BEEP                 # Beep when accessing non-existent history.
 #
 
 # Lists the ten most used commands.
-alias history-stat="history . | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
-
+alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"


### PR DESCRIPTION
The 'history' command is the same as 'fc -l', using a '.' as the first
parameter will get the history from the first command starting with a '.'.
Instead a '0' should be used, meaning that the history is taken from the very
first entry in the history.
