### PR TITLE
Use the init.zsh parent folder as the PREZTO_HOME folder

### DIFF
--- a/helper.zsh
+++ b/helper.zsh
@@ -40,7 +40,7 @@ function pmodload {
   pmodules=("$argv[@]")
 
   # Add functions to $fpath.
-  fpath=(${pmodules:+${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions(/FN)} $fpath)
+  fpath=(${pmodules:+$PREZTO_HOME/modules/${^pmodules}/functions(/FN)} $fpath)
 
   function {
     local pfunction
@@ -49,7 +49,7 @@ function pmodload {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
     # Load Prezto functions.
-    for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions/$~pfunction_glob; do
+    for pfunction in $PREZTO_HOME/modules/${^pmodules}/functions/$~pfunction_glob; do
       autoload -Uz "$pfunction"
     done
   }
@@ -58,12 +58,12 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded; then
       continue
-    elif [[ ! -d "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule" ]]; then
+    elif [[ ! -d "$PREZTO_HOME/modules/$pmodule" ]]; then
       print "$0: no such module: $pmodule" >&2
       continue
     else
-      if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh" ]]; then
-        source "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh"
+      if [[ -s "$PREZTO_HOME/modules/$pmodule/init.zsh" ]]; then
+        source "$PREZTO_HOME/modules/$pmodule/init.zsh"
       fi
 
       if (( $? == 0 )); then
@@ -80,7 +80,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in $PREZTO_HOME/modules/$pmodule/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }

--- a/init.zsh
+++ b/init.zsh
@@ -18,6 +18,9 @@ if [[ -s "${ZDOTDIR:-$HOME}/.zpreztorc" ]]; then
   source "${ZDOTDIR:-$HOME}/.zpreztorc"
 fi
 
+# Set prezto location
+export PREZTO_HOME="${0:h}"
+
 # Disable color and theme in dumb terminals.
 if [[ "$TERM" == 'dumb' ]]; then
   zstyle ':prezto:*:*' color 'no'
@@ -35,10 +38,9 @@ for zfunction ("$zfunctions[@]") autoload -Uz "$zfunction"
 unset zfunction{s,}
 
 # Source files (the order matters).
-source "${0:h}/helper.zsh"
+source "$PREZTO_HOME/helper.zsh"
 
 # Load Prezto modules.
 zstyle -a ':prezto:load' pmodule 'pmodules'
 pmodload "$pmodules[@]"
 unset pmodules
-


### PR DESCRIPTION
Instead of hardcoding `.prezto` and using that multiple time, we can easily say that the prezto folder is the one where init.zsh was present.
