### PR TITLE
Pkgfile support in the command-not-found module

### DIFF
--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -1,15 +1,17 @@
 Command-Not-Found
 =================
 
-Loads the [command-not-found][1] tool on Debian-based distributions.
+Loads the [command-not-found][1] tool on Debian-based distributions and [pkgfile][2]'s bundled tool on ones that use Pacman.
 
 Authors
 -------
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+*The authors of this module should be contacted via the [issue tracker][4].*
 
   - [Joseph Booker](https://github.com/sargas)
+  - [ne](https://github.com/neeee)
 
 [1]: https://code.launchpad.net/command-not-found
-[2]: https://github.com/sorin-ionescu/prezto/issues
-
+[2]: https://github.com/falconindy/pkgfile
+[3]: http://www.archlinux.org/pacman/
+[4]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -3,12 +3,16 @@
 #
 # Authors:
 #   Joseph Jon Booker <joe@neoturbine.net>
+#   neeee <ne.tetewi@gmail.com>
 #
 
-# Return if requirements are not found.
-if [[ ! -s '/etc/zsh_command_not_found' ]]; then
-  return 1
+if [[ -r '/etc/zsh_command_not_found' ]]; then
+    source '/etc/zsh_command_not_found'
+elif [[ -r '/usr/share/doc/pkgfile/command-not-found.zsh' ]]  
+    source '/usr/share/doc/pkgfile/command-not-found.zsh'
+else
+    # Return if requirements are not found.
+    return 1
 fi
 
-source '/etc/zsh_command_not_found'
 


### PR DESCRIPTION
Adds support for [pkgfile](https://github.com/falconindy/pkgfile) using the command-not-found tool bundled with it.
