### PR TITLE
Do not `ln -s` dotfiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ version is 4.3.10.
 
         setopt EXTENDED_GLOB
         for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
-          ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+          cp "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
         done
 
   4. Set Zsh as your default shell:


### PR DESCRIPTION
Why does prezto create symbolic links for rcfiles?
1. It prevents prezto from simple updates (`git pull`) because the files are local to user’s machine.
2. It prevents from keeping local [dotfiles](http://dotfiles.github.com) repo. I’ve been doing symlinking with dotfiles for a while, for example.
