### PR TITLE
Define $LS_COLORS on systems without dircolors

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -77,6 +77,7 @@ else
   # BSD Core Utilities
   if zstyle -t ':prezto:module:utility:ls' color; then
     export LSCOLORS="exfxcxdxbxegedabagacad"
+    export LS_COLORS="di=34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:"
     alias ls="ls -G"
   else
     alias ls='ls -F'


### PR DESCRIPTION
On systems that do not have the dircolors command, only the LSCOLORS environment variable is set in the utility module (https://github.com/sorin-ionescu/prezto/blob/master/modules/utility/init.zsh#L79). As such, when the completion module attempts to set the colors for completion using the LS_COLORS variable (https://github.com/sorin-ionescu/prezto/blob/master/modules/completion/init.zsh#L82), completions do not get colored correctly since that variable has not been defined.

In this commit, I simply added the LS_COLORS variable in addition to the LSCOLORS variable. I generated the LS_COLORS based on the existing LSCOLORS using the utility located at http://geoff.greer.fm/lscolors/
