### PR TITLE
Set title in screen even when using Apple Terminal

### DIFF
--- a/modules/terminal/init.zsh
+++ b/modules/terminal/init.zsh
@@ -79,7 +79,7 @@ autoload -Uz add-zsh-hook
 # Sets the tab and window titles before the prompt is displayed.
 function set-title-precmd {
   if zstyle -t ':prezto:module:terminal' auto-title; then
-    if [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
+    if [[ "$TERM_PROGRAM" == 'Apple_Terminal' && "$TERM" != screen* ]]; then
       # Set the current working directory in Apple Terminal.
       printf '\e]7;%s\a' "file://$HOST${PWD// /%20}"
     else
@@ -96,7 +96,7 @@ add-zsh-hook precmd set-title-precmd
 # Sets the tab and window titles before command execution.
 function set-title-preexec {
   if zstyle -t ':prezto:module:terminal' auto-title; then
-    if [[ "$TERM_PROGRAM" != 'Apple_Terminal' ]]; then
+    if [[ "$TERM_PROGRAM" != 'Apple_Terminal' || "$TERM" == screen*  ]]; then
       set-title-by-command "$2"
     fi
   fi


### PR DESCRIPTION
In modules/terminal/init.zsh, the auto-title code currently will only
set the screen title if $TERM_PROGRAM != 'Apple_Terminal'. As a result,
if you use screen within an Apple Terminal, the screen title will not be
correctly set.

To fix this, I changed the logic such that the screen title will be set
even if the $TERM_PROGRAM == 'Apple Terminal'.
