### PR TITLE
Update tmux documentation

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -53,4 +53,3 @@ Authors
 [3]: ChrisJohnsen/tmux-MacOSX-pasteboard
 [4]: mxcl/homebrew
 [5]: https://github.com/sorin-ionescu/prezto/issues
-


### PR DESCRIPTION
Use canonic urls instead of relative urls
Update link for kernel issues with tmux in Mac OS X
