### PR TITLE
[Fix #257] Add zstyle from readmes to zpreztorc

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -3,22 +3,18 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Colin Hebert <hebert.colin@gmail.com>
 #
 
-# Set the key mapping style to 'emacs' or 'vi'.
-zstyle ':prezto:module:editor' keymap 'emacs'
-
-# Auto convert .... to ../..
-zstyle ':prezto:module:editor' dot-expansion 'no'
+#
+# Global
+#
 
 # Set case-sensitivity for completion, history lookup, etc.
 zstyle ':prezto:*:*' case-sensitive 'no'
 
 # Color output (auto set to 'no' on dumb terminals).
 zstyle ':prezto:*:*' color 'yes'
-
-# Auto set the tab and window titles.
-zstyle ':prezto:module:terminal' auto-title 'yes'
 
 # Set the Zsh modules to load (man zshmodules).
 # zstyle ':prezto:load' zmodule 'attr' 'stat'
@@ -39,8 +35,84 @@ zstyle ':prezto:load' pmodule \
   'completion' \
   'prompt'
 
+#
+# Editor
+#
+
+# Set the key mapping style to 'emacs' or 'vi'.
+zstyle ':prezto:module:editor' keymap 'emacs'
+
+# Auto convert .... to ../..
+zstyle ':prezto:module:editor' dot-expansion 'no'
+
+#
+# Git
+#
+
+# Ignore git submodules when they are 'dirty', 'untracked', 'all', or 'none'.
+# Can improve drastically git-info performances but reduces its accuracy
+# in projects with many submodules
+#zstyle ':prezto:module:git:ignore' submodule ''
+
+#
+# GNU Utility
+#
+
+# Gnu-utils prefix on non-GNU systems
+#zstyle ':prezto:module:gnu-utility' prefix 'g'
+
+#
+# Pacman
+#
+
+# Enable a Pacman frontend, for example, Yaourt
+#zstyle ':prezto:module:pacman' frontend 'yaourt'
+
+#
+# Prompt
+#
+
 # Set the prompt theme to load.
 # Setting it to 'random' loads a random theme.
 # Auto set to 'off' on dumb terminals.
 zstyle ':prezto:module:prompt' theme 'sorin'
 
+#
+# Screen
+#
+
+# Automatically start screen with Zsh
+#zstyle ':prezto:module:screen' auto-start 'yes'
+
+#
+# SSH Agent
+#
+
+# Enable ssh-agent forwarding
+#zstyle ':prezto:module:ssh-agent' forwarding 'yes'
+
+#Load ssh-agent identities
+#zstyle ':prezto:module:ssh-agent' identities 'id_rsa' 'id_rsa2' 'id_github'
+
+#
+# Syntax Highlighting
+#
+
+# Syntax highlighter used in Zsh (main, brackets, pattern, cursor, root)
+# By default main, brackets and cursor
+#zstyle ':prezto:module:syntax-highlighting' highlighters 'main' 'brackets' \
+#  'pattern' 'cursor' 'root'
+
+#
+# Terminal
+#
+
+# Auto set the tab and window titles.
+zstyle ':prezto:module:terminal' auto-title 'yes'
+
+#
+# Tmux
+#
+
+# Automatically start tmux with Zsh
+#zstyle ':prezto:module:tmux' auto-start 'yes'


### PR DESCRIPTION
Add commented zstyles for each switch available in prezto modules.

Everything related to color and case-sensitivity hasn't been copied in zpreztorc, it's a standard option, maybe there should be a listing of modules using those options.

Prompt related zstyles aren't listed in zpreztorc either.
