### PR TITLE
Fix URLs in tmux documentation

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -49,8 +49,7 @@ Authors
   - [Colin Hebert](https://github.com/ColinHebert)
 
 [1]: http://tmux.sourceforge.net
-[2]: http://git.io/jkPqHg
-[3]: ChrisJohnsen/tmux-MacOSX-pasteboard
-[4]: mxcl/homebrew
+[2]: https://github.com/sorin-ionescu/prezto/issues/62
+[3]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
+[4]: https://github.com/mxcl/homebrew
 [5]: https://github.com/sorin-ionescu/prezto/issues
-


### PR DESCRIPTION
Use canonic urls instead of relative urls
Update link for kernel issues with tmux in Mac OS X

Copy of #286

The line removed has been removed on purpose, there is currently two empty lines at the end of the file, only one is needed
