### PR TITLE
sorin prompt: move PWD color to a variable

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -53,7 +53,8 @@ function prompt_sorin_setup {
     'rprompt' '%A%B%S%a%d%m%r%U%u'
 
   # Define prompts.
-  PROMPT='%F{cyan}%1~%f${git_info:+${(e)git_info[prompt]}}%(!. %B%F{red}#%f%b.)${editor_info[keymap]} '
+  SORIN_PROMPT_PWD_COLOR=cyan
+  PROMPT='%F{${SORIN_PROMPT_PWD_COLOR}}%1~%f${git_info:+${(e)git_info[prompt]}}%(!. %B%F{red}#%f%b.)${editor_info[keymap]} '
   RPROMPT='${editor_info[overwrite]}%(?:: %F{red}⏎%f)${VIM:+" %B%F{green}V%f%b"}${git_info[rprompt]}'
   SPROMPT='zsh: correct %F{red}%R%f to %F{green}%r%f [nyae]? '
 }


### PR DESCRIPTION
This is useful for case in which you log in to multiple servers all using prezto. In this case you can customize the prompt color with a single parameter override.
