### PR TITLE
Disable auto-start for multiplexers with SSH

### DIFF
--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -14,6 +14,15 @@ To enable this feature, add the following line to *zpreztorc*:
 
     zstyle ':prezto:module:screen' auto-start 'yes'
 
+#### SSH and auto-start
+
+To avoid having screen sessions inside screen sessions, auto-start is disabled for
+SSH access.
+
+It is possible to re-enable auto-start for SSH sessions with
+
+    zstyle ':prezto:module:screen' remote 'yes'
+
 Aliases
 -------
 

--- a/modules/screen/init.zsh
+++ b/modules/screen/init.zsh
@@ -14,7 +14,8 @@ fi
 # Auto Start
 #
 
-if [[ -z "$STY" ]] && zstyle -t ':prezto:module:screen' auto-start; then
+if ( [[ -z "$SSH_CLIENT" ]] || zstyle -t ':prezto:module:screen' remote ) &&
+    ( [[ -z "$STY" ]] && zstyle -t ':prezto:module:screen' auto-start ); then
   session="$(
     screen -list 2> /dev/null \
       | sed '1d;$d' \

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -21,6 +21,15 @@ To avoid keeping open sessions, this module sets `destroy-unattached off` on
 the background session and `destroy-unattached on` on every other session
 (global setting).
 
+#### SSH and auto-start
+
+To avoid having tmux sessions inside tmux sessions, auto-start is disabled for
+SSH access.
+
+It is possible to re-enable auto-start for SSH sessions with
+
+    zstyle ':prezto:module:tmux' remote 'yes'
+
 Aliases
 -------
 

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -15,7 +15,8 @@ fi
 # Auto Start
 #
 
-if [[ -z "$TMUX" ]] && zstyle -t ':prezto:module:tmux' auto-start; then
+if ( [[ -z "$SSH_CLIENT" ]] || zstyle -t ':prezto:module:tmux' remote ) &&
+    ( [[ -z "$TMUX" ]] && zstyle -t ':prezto:module:tmux' auto-start ); then
   tmux_session='#Prezto'
 
   if ! tmux has-session -t "$tmux_session" 2> /dev/null; then

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -81,6 +81,9 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 # Auto start a session when Zsh is launched.
 # zstyle ':prezto:module:screen' auto-start 'yes'
 
+# Allow auto-start with an SSH connection
+# zstyle ':prezto:module:screen' remote 'yes'
+
 #
 # SSH-Agent
 #
@@ -118,3 +121,5 @@ zstyle ':prezto:module:terminal' auto-title 'yes'
 # Auto start a session when Zsh is launched.
 # zstyle ':prezto:module:tmux' auto-start 'yes'
 
+# Allow auto-start with an SSH connection
+# zstyle ':prezto:module:tmux' remote 'yes'


### PR DESCRIPTION
I was playing with SSH and ended up on my own machine (don't ask) which is for me, the only one using the `auto-start` option (`tmux`/`screen`).

The problem is that I ended up with a multiplexer session inside another multiplexer session which is really confusing (even more in my case, where the two sessions were actually the same...).

---

In general having a multiplexer inside another multiplexer is just plain bad, but when it comes to remote connections there is no way to tell if the user is already in a multiplexer or not.

I guess the best action against that, is disabling `auto-start` for remote connections by default.
Then the user will be able to start the multiplexer manually if he wants to.

---

I understand that some people only use a multiplexer on the server side (so, there is no way that the user could already be in a multiplexer), and want `auto-start` to work properly with a remote access.

I added a new option for `screen` and `tmux` forcing `auto-start` to work with remote connections:

```
zstyle ':prezto:module:tmux' remote 'yes'
```

This will allow auto-start for an SSH connection on a server.

---

The documentation and `zpreztorc` have been upgraded
