### PR TITLE
make creation of git aliases optional

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -28,6 +28,11 @@ This setting affects all aliases and functions that call `git-status`.
 Aliases
 -------
 
+By default several short aliases are set up for quick access to often needed commands.
+If you do not want this use:
+
+    zstyle ':prezto:module:git' aliases 'no'
+
 ### Git
 
   - `g` is short for `git`.

--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -14,5 +14,7 @@ fi
 pmodload 'helper'
 
 # Source module files.
-source "${0:h}/alias.zsh"
+if zstyle -T ':prezto:module:git' aliases; then
+  source "${0:h}/alias.zsh"
+fi
 


### PR DESCRIPTION
As I do not use the git aliases provided by the git module but do not want to miss out on the defined functions I propose aliases to be optional (on by default). Is `:prezto:module:git` → `aliases` okay?
