### PR TITLE
Fallback to standard cabal location on OS X

### DIFF
--- a/modules/haskell/init.zsh
+++ b/modules/haskell/init.zsh
@@ -11,11 +11,10 @@ if (( ! $+commands[ghc] )); then
 fi
 
 # Prepend Cabal per user directories to PATH/MANPATH.
-if [[ "$OSTYPE" == darwin* ]]; then
+if [[ "$OSTYPE" == darwin* && -d $HOME/Library/Haskell ]]; then
   path=($HOME/Library/Haskell/bin(/N) $path)
   manpath=($HOME/Library/Haskell/man(/N) $manpath)
 else
   path=($HOME/.cabal/bin(/N) $path)
   manpath=($HOME/.cabal/man(/N) $manpath)
 fi
-


### PR DESCRIPTION
If `~/Library/Haskell` does not exist fall back to `~/.cabal/bin`.

Ideally, we'd parse `~/.cabal/config`here, but cabal does not provide an interface to get configuration settings.
