### PR TITLE
allow aliased ls for gnu coreutils

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -61,7 +61,7 @@ alias type='type -a'
 # ls
 if is-callable 'dircolors'; then
   # GNU Core Utilities
-  alias ls='ls --group-directories-first'
+  alias ls="${aliases[ls]:-ls} --group-directories-first"
 
   if zstyle -t ':prezto:module:utility:ls' color; then
     if [[ -s "$HOME/.dir_colors" ]]; then


### PR DESCRIPTION
osx uses bsd coreutils but GNU coreutils has a nicer ls with --group-directories-first :)
