### PR TITLE
Make sure the terminal is in application mode when zle is active

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -144,18 +144,20 @@ zle -N editor-info
 # Ensures that $terminfo values are valid and updates editor information when
 # the keymap changes.
 function zle-keymap-select zle-line-init zle-line-finish {
-  # The terminal must be in application mode when ZLE is active for $terminfo
-  # values to be valid.
-  case "$0" in
-    (zle-line-init)
-      # Enable terminal application mode.
-      echoti smkx
-    ;;
-    (zle-line-finish)
-      # Disable terminal application mode.
-      echoti rmkx
-    ;;
-  esac
+  # If it has the respective capability, the terminal should be in application
+  # mode when ZLE is active for $terminfo values to be valid.
+  if (( ${+terminfo[smkx]} )) && (( ${+terminfo[rmkx]} )); then
+    case "$0" in
+      (zle-line-init)
+        # Enable terminal application mode.
+        echoti smkx
+      ;;
+      (zle-line-finish)
+        # Disable terminal application mode.
+        echoti rmkx
+      ;;
+    esac
+  fi
 
   # Update editor information.
   zle editor-info


### PR DESCRIPTION
Prezto's editor/key-binding setup makes heavy use of `terminfo`, what of course can be considered a good practice. However, values from there are only reliable if the terminal is in "application mode".

Different terminal modes seem to be a relict of the past and one can't find much documentation on them nowadays, but [this article](http://homes.mpimf-heidelberg.mpg.de/~rohm/computing/mpimf/notes/terminal.html) provides some insights.
What I came across as well is [this post](http://www.zsh.org/mla/users/2010/msg00052.html) on the _zsh-users_ mailing list, which says:

> Editors are _expected_ to switch to "application" mode using the "smkx" terminfo capability when they start, and to go back to the normal "cursor" mode ("rmkx") when they exit.

And that also seems to apply to `zle`.

I couldn't discover any code where Prezto already sets the terminal mode and doing so fixed some key binding issues for me. (Those I can't entirely reconstruct, as Ubuntu 12.10's `/etc/zsh/zshrc` should already enable application mode, see [my blog post](https://www.f30.me/2012/10/oh-my-zsh-key-bindings-on-ubuntu-12-10/) on the topic). 
My fix isn't extensively tested, but so far I can't imagine any downsides of forcing application mode.
