### PR TITLE
Set path in Terminal.app tab title

### DIFF
--- a/modules/terminal/init.zsh
+++ b/modules/terminal/init.zsh
@@ -41,12 +41,6 @@ function set-terminal-tab-title {
 
 # Sets the tab and window titles with a given command.
 function set-titles-with-command {
-  # Do not set the window and tab titles in Terminal.app because they are not
-  # reset upon command termination.
-  if [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]]; then
-    return 1
-  fi
-
   emulate -L zsh
   setopt EXTENDED_GLOB
 


### PR DESCRIPTION
These commits fix the Apple Terminal tab title behavior. Commit 0b7e47b sets the tab title to the current path in the precmd hook (it was only setting the window title before) and commit b4f1983 removes the early return from setting the current command as the tab title because the other commit fixes the "not reset after command terminates" problem as a side effect.

I'm happy to squash these two commits as per your contribution guidelines, but I wanted to leave them as-is for now so you can see how they are related to each other.
