### PR TITLE
Added user-controllable prefix for window and tab titles

### DIFF
--- a/modules/terminal/README.md
+++ b/modules/terminal/README.md
@@ -13,6 +13,13 @@ directory, add the following to *zpreztorc*:
 
     zstyle ':prezto:module:terminal' auto-title 'yes'
 
+A user-defined prefix may be added to the title using the following
+styles, which undergo prompt expansion:
+
+    zstyle ':prezto:module:terminal' prefix '%n @ %m: '
+    zstyle ':prezto:module:terminal' tabprefix '%n @ %m: '
+
+
 Functions
 ---------
 

--- a/modules/terminal/init.zsh
+++ b/modules/terminal/init.zsh
@@ -28,14 +28,18 @@ function set-screen-window-title {
 # Sets the terminal window title.
 function set-terminal-window-title {
   if [[ "$TERM" == ((x|a|ml|dt|E)term*|(u|)rxvt*) ]]; then
-    printf "\e]2;%s\a" ${(V)argv}
+    local prefix
+    zstyle -s ':prezto:module:terminal' prefix 'prefix'
+    printf "\e]2;%s%s\a" ${(V%)prefix} ${(V)argv}
   fi
 }
 
 # Sets the terminal tab title.
 function set-terminal-tab-title {
   if [[ "$TERM" == ((x|a|ml|dt|E)term*|(u|)rxvt*) ]]; then
-    printf "\e]1;%s\a" ${(V)argv}
+    local prefix
+    zstyle -s ':prezto:module:terminal' prefix 'tabprefix'
+    printf "\e]1;%s%s\a" ${(V%)prefix} ${(V)argv}
   fi
 }
 


### PR DESCRIPTION
These new styles that may be used to add a prefix to the window and
tab title strings.  These undergo prompt expansion.

  zstyle ':prezto:module:terminal' prefix '%n @ %m: '
  zstyle ':prezto:module:terminal' tabprefix '%m: '
