### PR TITLE
Adding utility function to ease use of sudoedit

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -101,6 +101,10 @@ alias lc='lt -c'         # Lists sorted by date, most recent last, shows change 
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
 alias sl='ls'            # I often screw this up.
 
+# Sudo-Edit
+function se { SUDO_EDITOR="$1" sudoedit ${*:2} }
+alias se="nocorrect se"
+
 # Mac OS X Everywhere
 if [[ "$OSTYPE" == darwin* ]]; then
   alias o='open'


### PR DESCRIPTION
This is a handy shortcut to editing root-owned files, like this:

```
se vim /etc/hosts
se vimdiff /etc/hosts /etc/hosts.old
se "gvimdiff -f" /etc/hosts /etc/hosts.old
```
