### PR TITLE
Provide option to list directory contents after changing directory

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -101,6 +101,12 @@ alias lc='lt -c'         # Lists sorted by date, most recent last, shows change 
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
 alias sl='ls'            # I often screw this up.
 
+# List directory after cd
+if zstyle -t ':prezto:module:utility' ls-after-cd; then
+  function list-directory { ls }
+  chpwd_functions=($chpwd_functions list-directory)
+fi
+
 # Mac OS X Everywhere
 if [[ "$OSTYPE" == darwin* ]]; then
   alias o='open'

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -45,6 +45,13 @@ zstyle ':prezto:module:editor' keymap 'emacs'
 # zstyle ':prezto:module:editor' dot-expansion 'yes'
 
 #
+# Utility
+#
+
+# List directory contents after changing directory
+#zstyle ':prezto:module:utility' ls-after-cd 'yes'
+
+#
 # Git
 #
 


### PR DESCRIPTION
This adds an option to list directory contents after changing directory.  This time it's actually elegant and uses a proper ZSH hook.  (I previously did this by overriding cd, which was ugly.)
