### PR TITLE
Fix rprompt doc mistake in modules/git/README.md

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -292,7 +292,7 @@ Second, format how the above attributes are displayed in prompts.
       'prompt'  ' git(%b)' \
       'rprompt' '[%R]'
 
-Last, add `$git_info[prompt]` to `$PROMPT` and `$git_info[prompt]` to
+Last, add `$git_info[prompt]` to `$PROMPT` and `$git_info[rprompt]` to
 `$RPROMPT` respectively and call `git-info` in the `prompt_name_preexec` hook
 function.
 


### PR DESCRIPTION
There is a spelling mistake/omission in the git modules README.md that might confuse some users. This branch fixes that.
