### PR TITLE
Sped up rbenv startup times.

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -17,11 +17,11 @@ if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
 # Load manually installed rbenv into the shell session.
 elif [[ -s "$HOME/.rbenv/bin/rbenv" ]]; then
   path=("$HOME/.rbenv/bin" $path)
-  eval "$(rbenv init - zsh)"
+  eval "$(rbenv init - --no-rehash zsh)"
 
 # Load package manager installed rbenv into the shell session.
 elif (( $+commands[rbenv] )); then
-  eval "$(rbenv init - zsh)"
+  eval "$(rbenv init - --no-rehash zsh)"
 
 # Install local gems according to operating system conventions.
 else


### PR DESCRIPTION
Rbenv attempts to rehash EVERY gem on startup time, and for users with a lot of gems, this can slow the terminal down DRAMATICALLY.

Adding `--no-rehash` to the init command can speed up terminal load time dramatically, at the cost of users having to rehash manually more often.

This fixes issue sorin-ionescu/prezto#335
