### PR TITLE
fix completion for .ssh/known_hosts where hosts saved with non-standard port

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -96,7 +96,7 @@ zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-va
 
 # Populate hostname completion.
 zstyle -e ':completion:*:hosts' hosts 'reply=(
-  ${=${=${=${${(f)"$(cat {/etc/ssh_,~/.ssh/known_}hosts(|2)(N) 2>/dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/}//\[/}
+  ${=${=${=${${(f)"$(cat {/etc/ssh_,~/.ssh/known_}hosts(|2)(N) 2>/dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/ }//\[/ }
   ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%\#*}
   ${=${${${${(@M)${(f)"$(cat ~/.ssh/config 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}}
 )'


### PR DESCRIPTION
This commit fixes a problem with tab-completion for ssh 
examples:
before fix

```
$ ssh myh<tab> 
$ ssh \[myhost\]:2222
```

after fix:

```
$ ssh myh<TAB>
$ ssh myhost
```
