### PR TITLE
show system ruby version as last resort on ruby-info

### DIFF
--- a/modules/ruby/functions/ruby-info
+++ b/modules/ruby/functions/ruby-info
@@ -18,6 +18,8 @@ if (( $+commands[rvm-prompt] )); then
   version="$(rvm-prompt)"
 elif (( $+commands[rbenv] )); then
   version="$(rbenv version-name)"
+elif (( $+commands[ruby] )); then
+  version="$(ruby --version | cut -d' ' -f2)"
 fi
 
 # Format version.


### PR DESCRIPTION
Simple fix to the ruby-info function. It only considered systems with rvm or rbenv installed.
