### PR TITLE
Improve Tmux startup logic.

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -17,10 +17,6 @@ To enable this feature, add the following line to *zpreztorc*:
 It will create a background session named _#Prezto_ and attach every new shell
 to it.
 
-To avoid keeping open sessions, this module sets `destroy-unattached off` on
-the background session and `destroy-unattached on` on every other session
-(global setting).
-
 Aliases
 -------
 
@@ -47,6 +43,7 @@ Authors
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
   - [Colin Hebert](https://github.com/ColinHebert)
+  - [neersighted](https://github.com/neersighted)
 
 [1]: http://tmux.sourceforge.net
 [2]: https://github.com/sorin-ionescu/prezto/issues/62

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -4,6 +4,7 @@
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #   Colin Hebert <hebert.colin@gmail.com>
+#   neersighted <neersighted@myopera.com>
 #
 
 # Return if requirements are not found.
@@ -18,22 +19,14 @@ fi
 if [[ -z "$TMUX" ]] && zstyle -t ':prezto:module:tmux' auto-start; then
   tmux_session='#Prezto'
 
+  # Check that the default session exists.
   if ! tmux has-session -t "$tmux_session" 2> /dev/null; then
-    # Disable the destruction of unattached sessions globally.
-    tmux set-option -g destroy-unattached off &> /dev/null
-
-    # Create a new session.
+    # Create a new, detached session only if needed.
     tmux new-session -d -s "$tmux_session"
-
-    # Disable the destruction of the new, unattached session.
-    tmux set-option -t "$tmux_session" destroy-unattached off &> /dev/null
-
-    # Enable the destruction of unattached sessions globally to prevent
-    # an abundance of open, detached sessions.
-    tmux set-option -g destroy-unattached on &> /dev/null
   fi
 
-  exec tmux new-session -t "$tmux_session"
+  # Attach to the session.
+  TERM=xterm-256color tmux attach -t "$tmux_session"
 fi
 
 #


### PR DESCRIPTION
Instead of creating a Tmux session, and then moving to the background session,
just create the background session if needed, and always attach to it.

This fixes the need for setting destroy-session on, and thus enables the use
of multiple background sessions.
