### PR TITLE
Improve GPG agent startup.

### DIFF
--- a/modules/gpg-agent/init.zsh
+++ b/modules/gpg-agent/init.zsh
@@ -4,6 +4,7 @@
 # Authors:
 #   Florian Walch <florian.walch@gmx.at>
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   neersighted <neersighted@myopera.com>
 #
 
 # Return if requirements are not found.
@@ -11,7 +12,8 @@ if (( ! $+commands[gpg-agent] )); then
   return 1
 fi
 
-_gpg_env="$HOME/.gnupg/gpg-agent.env"
+# Make sure to use the $GNUPGHOME first.
+_gpg_env="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.env"
 
 function _gpg-agent-start {
   local ssh_support
@@ -20,7 +22,8 @@ function _gpg-agent-start {
     || ssh_support=''
 
   gpg-agent \
-    --daemon ${ssh_support:+'--enable-ssh-support'}
+    --daemon \
+    ${ssh_support:+'--enable-ssh-support'} \
     --write-env-file "${_gpg_env}" > /dev/null
 
   chmod 600 "${_gpg_env}"
@@ -41,4 +44,3 @@ export GPG_AGENT_INFO
 export SSH_AUTH_SOCK
 export SSH_AGENT_PID
 export GPG_TTY="$(tty)"
-


### PR DESCRIPTION
Use the value of $GNUPGHOME, to facilitate moving GPG's home.

Also clean up the launching function's arguments.
