### PR TITLE
Fix lesspipe.sh detection in custom PATH

### DIFF
--- a/runcoms/zshenv
+++ b/runcoms/zshenv
@@ -30,20 +30,6 @@ if [[ -z "$LANG" ]]; then
 fi
 
 #
-# Less
-#
-
-# Set the default Less options.
-# Mouse-wheel scrolling has been disabled by -X (disable screen clearing).
-# Remove -X and -F (exit if the content fits on one screen) to enable it.
-export LESS='-F -g -i -M -R -S -w -X -z-4'
-
-# Set the Less input preprocessor.
-if (( $+commands[lesspipe.sh] )); then
-  export LESSOPEN='| /usr/bin/env lesspipe.sh %s 2>&-'
-fi
-
-#
 # Paths
 #
 
@@ -87,6 +73,20 @@ for path_file in /etc/paths.d/*(.N); do
   path+=($(<$path_file))
 done
 unset path_file
+
+#
+# Less
+#
+
+# Set the default Less options.
+# Mouse-wheel scrolling has been disabled by -X (disable screen clearing).
+# Remove -X and -F (exit if the content fits on one screen) to enable it.
+export LESS='-F -g -i -M -R -S -w -X -z-4'
+
+# Set the Less input preprocessor.
+if (( $+commands[lesspipe.sh] )); then
+  export LESSOPEN='| /usr/bin/env lesspipe.sh %s 2>&-'
+fi
 
 #
 # Temporary Files


### PR DESCRIPTION
The detection of lesspipe.sh has to be done after setting PATH as it
could be installed in a non-standard bin directory. For example,
Homebrew installs lesspipe in /usr/local.
