### PR TITLE
Make Sorin's prompt more friendly with solarized colours

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -47,9 +47,9 @@ function prompt_sorin_setup {
   add-zsh-hook precmd prompt_sorin_precmd
 
   zstyle ':prezto:module:editor:info:completing' format '%B%F{red}...%f%b'
-  zstyle ':prezto:module:editor:info:keymap:primary' format ' %B%F{red}❯%F{yellow}❯%F{green}❯%f%b'
+  zstyle ':prezto:module:editor:info:keymap:primary' format " ${1-%B}%F{red}❯%F{yellow}❯%F{green}❯%f${1-%b}"
   zstyle ':prezto:module:editor:info:keymap:primary:overwrite' format ' %F{red}♺%f'
-  zstyle ':prezto:module:editor:info:keymap:alternate' format ' %B%F{green}❮%F{yellow}❮%F{red}❮%f%b'
+  zstyle ':prezto:module:editor:info:keymap:alternate' format " ${2-%B}%F{green}❮%F{yellow}❮%F{red}❮%f${2-%b}"
   zstyle ':prezto:module:git:info:action' format ':%%B%F{yellow}%s%f%%b'
   zstyle ':prezto:module:git:info:added' format ' %%B%F{green}✚%f%%b'
   zstyle ':prezto:module:git:info:ahead' format ' %%B%F{yellow}⬆%f%%b'


### PR DESCRIPTION
Since solarized uses the _bright_ version of colour as some variation of the background colour, the bright versions of yellow and green doesn't exist, looking like this:

![sorin-solarized](https://f.cloud.github.com/assets/275754/101469/4a2e14c2-68cd-11e2-8a23-0ed93b1baf2a.png)

Without using brighter colours looks like this:

![sorin-solarized-friendly](https://f.cloud.github.com/assets/275754/101471/5a3240c8-68cd-11e2-86df-4eb5b761f5ca.png)

Since the solarized colourscheme is quite popular I thought it could be helpful.
