### PR TITLE
More control over multiplexer auto-start and SSH

### DIFF
--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -10,9 +10,15 @@ Settings
 
 Starts a GNU Screen session automatically when Zsh is launched.
 
-To enable this feature, add the following line to *zpreztorc*:
+To enable this feature when launching Zsh on a local terminal, add the
+following line to *zpreztorc*:
 
-    zstyle ':prezto:module:screen' auto-start 'yes'
+    zstyle ':prezto:module:screen:auto-start' local 'yes'
+
+To enable this feature when launching Zsh on a SSH connection, add the
+following line to *zpreztorc*:
+
+    zstyle ':prezto:module:screen:auto-start' remote 'yes'
 
 Aliases
 -------
@@ -28,6 +34,7 @@ Authors
 *The authors of this module should be contacted via the [issue tracker][2].*
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
+  - [Georges Discry](https://github.com/gdiscry)
 
 [1]: http://www.gnu.org/software/screen/
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/screen/init.zsh
+++ b/modules/screen/init.zsh
@@ -3,6 +3,7 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Georges Discry <georges@discry.be>
 #
 
 # Return if requirements are not found.
@@ -14,7 +15,9 @@ fi
 # Auto Start
 #
 
-if [[ -z "$STY" ]] && zstyle -t ':prezto:module:screen' auto-start; then
+if [[ -z "$STY" ]] && ( \
+    ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:screen:auto-start' remote ) || \
+    ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:screen:auto-start' local ) ); then
   session="$(
     screen -list 2> /dev/null \
       | sed '1d;$d' \

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -10,12 +10,18 @@ Settings
 
 Starts a tmux session automatically when Zsh is launched.
 
-To enable this feature, add the following line to *zpreztorc*:
+To enable this feature when launching Zsh on a local terminal, add the
+following line to *zpreztorc*:
 
-    zstyle ':prezto:module:tmux' auto-start 'yes'
+    zstyle ':prezto:module:tmux:auto-start' local 'yes'
 
-It will create a background session named _#Prezto_ and attach every new shell
-to it.
+To enable this feature when launching Zsh on a SSH connection, add the
+following line to *zpreztorc*:
+
+    zstyle ':prezto:module:tmux:auto-start' remote 'yes'
+
+In both cases, it will create a background session named _#Prezto_ and attach
+every new shell to it.
 
 To avoid keeping open sessions, this module sets `destroy-unattached off` on
 the background session and `destroy-unattached on` on every other session
@@ -47,6 +53,7 @@ Authors
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
   - [Colin Hebert](https://github.com/ColinHebert)
+  - [Georges Discry](https://github.com/gdiscry)
 
 [1]: http://tmux.sourceforge.net
 [2]: https://github.com/sorin-ionescu/prezto/issues/62

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -4,6 +4,7 @@
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #   Colin Hebert <hebert.colin@gmail.com>
+#   Georges Discry <georges@discry.be>
 #
 
 # Return if requirements are not found.
@@ -15,7 +16,9 @@ fi
 # Auto Start
 #
 
-if [[ -z "$TMUX" ]] && zstyle -t ':prezto:module:tmux' auto-start; then
+if [[ -z "$TMUX" ]] && ( \
+    ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' remote ) || \
+    ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' local ) ); then
   tmux_session='#Prezto'
 
   if ! tmux has-session -t "$tmux_session" 2> /dev/null; then

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -91,8 +91,11 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 # Screen
 #
 
-# Auto start a session when Zsh is launched.
-# zstyle ':prezto:module:screen' auto-start 'yes'
+# Auto start a session when Zsh is launched on a local terminal.
+# zstyle ':prezto:module:screen:auto-start' local 'yes'
+
+# Auto start a session when Zsh is launched on a SSH connection.
+# zstyle ':prezto:module:screen:auto-start' remote 'yes'
 
 #
 # SSH
@@ -132,6 +135,9 @@ zstyle ':prezto:module:terminal' auto-title 'yes'
 # Tmux
 #
 
-# Auto start a session when Zsh is launched.
-# zstyle ':prezto:module:tmux' auto-start 'yes'
+# Auto start a session when Zsh is launched on a local terminal.
+# zstyle ':prezto:module:tmux:auto-start' local 'yes'
+
+# Auto start a session when Zsh is launched on a SSH connection.
+# zstyle ':prezto:module:tmux:auto-start' remote 'yes'
 


### PR DESCRIPTION
Setting the auto-start style for the screen and tmux modules to 'remote' automatically starts a session only with SSH connections and to 'local' only for local terminals. The behaviour when the style is set to a boolean value is unchanged.

This was discussed in #292.
