### PR TITLE
Add Emacs module

### DIFF
--- a/modules/emacs/README.md
+++ b/modules/emacs/README.md
@@ -1,0 +1,33 @@
+Emacs
+=====
+
+Enables Emacs dependency management.
+
+Dependency management
+---------------------
+
+[Carton][1] installs and manages Emacs packages for Emacs package development
+and Emacs configuration.
+
+This module prepends the Carton directory to the path variable to enable the
+execution of `carton`.
+
+Aliases
+-------
+
+### Carton
+
+  - `cai` installs dependencies.
+  - `cau` updates dependencies.
+  - `caI` initializes the current directory for dependency management.
+  - `cae` executes a command which correct dependencies.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Sebastian Wiesner](https://github.com/lunaryorn)
+
+[1]: https://github.com/rejeep/carton
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/emacs/init.zsh
+++ b/modules/emacs/init.zsh
@@ -1,0 +1,15 @@
+#
+# Configures Emacs dependency management.
+#
+# Authors: Sebastian Wiesner <lunaryorn@gmail.com>
+#
+
+# Enable Carton
+if [[ -d "$HOME/.carton" ]]; then
+    path=($HOME/.carton/bin $path)
+
+    alias cai='carton install'
+    alias cau='carton update'
+    alias caI='carton init'
+    alias cae='carton exec'
+fi


### PR DESCRIPTION
Enables Emacs dependency management with [Carton](https://github.com/rejeep/carton).
