### PR TITLE
git-info: modify Ctrl+C behavior to be more explicit

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -104,6 +104,9 @@ This process may be time-intensive for certain repositories.
 To disable zsh git prompt for this repository, execute:
   git-info off
 
+To disable zsh git prompt for all repositories, add to zpreztorc:
+  zstyle ':prezto:module:git:info' disable-prompt 'yes'
+
 EOF
 
   unset _git_info_executing
@@ -147,6 +150,7 @@ function git-info {
   local dirty=0
   local dirty_format
   local dirty_formatted
+  local disable_prompt
   local ignore_submodules
   local -A info_formats
   local info_format
@@ -197,6 +201,12 @@ function git-info {
 
   # Return if git-info is disabled.
   if ! is-true "${$(git config --bool prompt.showinfo):-true}"; then
+    return 1
+  fi
+
+  # Return if git-info is disabled
+  zstyle -b ':prezto:module:git:info' disable-prompt 'disable_prompt'
+  if [[ "$disable_prompt" == "yes" ]]; then
     return 1
   fi
 


### PR DESCRIPTION
(Update: looks like it's related to #307)

I find git-info's auto-disable behavior confusing and too implicit. I'm referring to the case of Ctrl+C press while git-info is running.

Even though it prints a warning message once, it's easy to miss it. Happened to me, and I've also seen others with disabled-git-prompts, while they weren't aware to why it was actually disabled. The git prompt is very cool, and I believe that in many cases users don't want it to automatically go away.

I suggest to make the behavior more expected and explicit, that is:
1. Ctrl+C merely aborts the current call, doesn't modify settings, but displays an informative message.
2. Suggests running 'git-info off' to disable git prompt in current repo.
3. Suggests adding a zstyle setting to disable git prompt for all repos.

This way, the user is fully aware of the disable action.
