### PR TITLE
Move WORDCHARS to the editor module?

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -30,9 +30,6 @@ setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a traili
 unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
 unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 
-# Treat these characters as part of a word.
-WORDCHARS='*?_-.[]~&;!#$%^(){}<>'
-
 #
 # Styles
 #

--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -53,6 +53,9 @@ fi
 # Beep on error in line editor.
 setopt BEEP
 
+# Treat these characters as part of a word.
+WORDCHARS='*?_-.[]~&;!#$%^(){}<>'
+
 #
 # Variables
 #


### PR DESCRIPTION
I was looking for the definition of the WORDCHARS variable, and was surprised to see it in the completion module. It looks like it's been there since oh-my-zsh, but it seems like it belongs in the editor module rather than completion.

It's such a trivial thing it almost doesn't seem worth changing, but then again, as I said it was surprising to find it where it is now.

This pull request just moves the definition from completion/init.zsh to editor/init.zsh.
