### PR TITLE
Launch tmux start-server for auto-start

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -19,6 +19,9 @@ if [[ -z "$TMUX" ]] && zstyle -t ':prezto:module:tmux' auto-start; then
   tmux_session='#Prezto'
 
   if ! tmux has-session -t "$tmux_session" 2> /dev/null; then
+    # Esnure that tmux server is started
+    tmux start-server
+
     # Disable the destruction of unattached sessions globally.
     tmux set-option -g destroy-unattached off &> /dev/null
 


### PR DESCRIPTION
Ensure that `tmux start-server` is called to avoid errors such as:

> failed to connect to server
