### PR TITLE
Fix command for setting highlighting styles

### DIFF
--- a/modules/syntax-highlighting/init.zsh
+++ b/modules/syntax-highlighting/init.zsh
@@ -23,8 +23,7 @@ fi
 typeset -A syntax_highlighting_styles
 zstyle -a ':prezto:module:syntax-highlighting' styles 'syntax_highlighting_styles'
 for syntax_highlighting_style in "${(k)syntax_highlighting_styles[@]}"; do
-  ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]=\
-    "$syntax_highlighting_styles[$syntax_highlighting_style]"
+  ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]="$syntax_highlighting_styles[$syntax_highlighting_style]"
 done
 unset syntax_highlighting_style{s,}
 


### PR DESCRIPTION
When trying to set up some styles with the syntax-highlighting plugin, as per the examples in zpreztorc:

```
# Set syntax highlighting styles.
zstyle ':prezto:module:syntax-highlighting' styles \
 'builtin' 'bg=blue' \
 'command' 'bg=blue' \
 'function' 'bg=blue'
```

I get the following errors:

```
/home/foo/.zprezto/modules/syntax-highlighting/init.zsh:26: command not found: bg=blue
/home/foo/.zprezto/modules/syntax-highlighting/init.zsh:26: command not found: bg=blue
/home/foo/.zprezto/modules/syntax-highlighting/init.zsh:26: command not found: bg=blue
```

I found this can be resolved by amending line 26 of the syntax highlighting init.zsh to be only on one line, without the backslash for the line break.

```
ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]="$syntax_highlighting_styles[$syntax_highlighting_style]"
```

Not sure if this problem is specific to just myself or not -  I'm on Ubuntu 13.04, with zsh 5.0.0, running in tmux, with latest prezto sources.
