### PR TITLE
Modifies Git Module `glg` for more relevant info.

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -14,7 +14,7 @@
 zstyle -s ':prezto:module:git:log:medium' format '_git_log_medium_format' \
   || _git_log_medium_format='%C(bold)Commit:%C(reset) %C(green)%H%C(red)%d%n%C(bold)Author:%C(reset) %C(cyan)%an <%ae>%n%C(bold)Date:%C(reset)   %C(blue)%ai (%ar)%C(reset)%n%+B'
 zstyle -s ':prezto:module:git:log:oneline' format '_git_log_oneline_format' \
-  || _git_log_oneline_format='%C(green)%h%C(reset) %s%C(red)%d%C(reset)%n'
+  || _git_log_oneline_format='[%C(yellow)%h%Creset][%C(red)%cn%Creset] %s - %Cgreen%cr%Creset'
 zstyle -s ':prezto:module:git:log:brief' format '_git_log_brief_format' \
   || _git_log_brief_format='%C(green)%h%C(reset) %s%n%C(blue)(%ar by %an)%C(red)%d%C(reset)%n'
 


### PR DESCRIPTION
The old style added too much uneeded white space, it also didn't show
the comitter's name & time of the commit.

Example of how it looks:
https://dl.dropbox.com/s/j4ybllu0l2j8rrg/2013-05-10_at_7.47.47_PM%20%281%29.png
