### PR TITLE
add git-escape-magic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "modules/completion/external"]
 	path = modules/completion/external
 	url = https://github.com/zsh-users/zsh-completions.git
-[submodule "modules/git-escape-magic/external"]
-	path = modules/git-escape-magic/external
+[submodule "modules/git/external"]
+	path = modules/git/external
 	url = https://github.com/knu/zsh-git-escape-magic

--- a/modules/git-escape-magic/README.md
+++ b/modules/git-escape-magic/README.md
@@ -1,1 +1,0 @@
-/Users/areece/.zprezto/modules/git-escape-magic/external/README.md

--- a/modules/git-escape-magic/init.zsh
+++ b/modules/git-escape-magic/init.zsh
@@ -1,4 +1,0 @@
-# Add git-escape-magic to $fpath
-fpath=("${0:h}/external" $fpath)
-
-autoload -Uz git-escape-magic && git-escape-magic

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -26,6 +26,19 @@ Submodules may be ignored when they are *dirty*, *untracked*, *all*, or *none*.
 
 This setting affects all aliases and functions that call `git-status`.
 
+### No Aliases
+
+The loading of the git aliases can be disabled:
+
+    zstyle ':prezto:module:git' no-aliases 'yes'
+
+### Magic escaping
+
+Automatic escaping of special characters in git refspecs (i.e, `HEAD^`) can be
+enabled via adding the following to your *zpreztorc*:
+
+    zstyle ':prezto:module:git' escape-magic 'yes'
+
 Aliases
 -------
 

--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -13,6 +13,13 @@ fi
 # Load dependencies.
 pmodload 'helper'
 
-# Source module files.
-source "${0:h}/alias.zsh"
+if ! zstyle -t ':prezto:modules:git' no-aliases; then
+  # Source module files.
+  source "${0:h}/alias.zsh"
+fi
 
+if zstyle -t ':prezto:modules:git' escape-magic; then
+  fpath=("${0:h}/external" $fpath)
+
+  autoload -Uz git-escape-magic && git-escape-magic
+fi


### PR DESCRIPTION
https://github.com/knu/zsh-git-escape-magic

"If you are a hard-core zsh user that takes extended_glob seriously for granted, you must be annoyed with git's refspec (notation to point a commit, tree, etc.) that goes like HEAD^ or blahblah~3 because the signs like [^~{}] are globbing meta-characters for zsh that require escaping to be passed through to the git command.

Here is what this tweak is about. It eliminates the need for manually escaping those meta-characters."
