### PR TITLE
fix variable name

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -30,7 +30,7 @@ fi
 # Load identities.
 if ssh-add -l 2>&1 | grep 'The agent has no identities'; then
   zstyle -a ':prezto:module:ssh:load' identities '_ssh_identities'
-  if (( ${#identities} > 0 )); then
+  if (( ${#_ssh_identities} > 0 )); then
     ssh-add "$_ssh_dir/${^_ssh_identities[@]}"
   else
     ssh-add


### PR DESCRIPTION
ssh identities configured in ~/.zprestorc were never added
