### PR TITLE
Allow end user to customize Prezto and ZSH

### DIFF
--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -5,10 +5,17 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# Prezto customizations...
+for before_prezto in "${ZDOTDIR:-$HOME}"/.zprezto.before/*.zsh; do
+  source "$before_prezto"
+done
+
 # Source Prezto.
 if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
 fi
 
-# Customize to your needs...
-
+# Your zsh customizations outside of Prezto...
+for after_prezto in "${ZDOTDIR:-$HOME}"/.zprezto.after/*.zsh; do
+  source "$after_prezto"
+done


### PR DESCRIPTION
[Fix #456]  Introduce .zprezto.before and .zprezto.after conventions
- If .zprezto.before exists, its .zsh files are sourced before Prezto is initialized
- If .zprezto.after exists, its .zsh files are sourced after Prezto is initialized
- .zprezto.before files are for customizing Prezto such as calling zstyle
- .zprezto.after files are for general ZSH customization outside the scope of Prezto
