### PR TITLE
Add utility aliases for Cygwin

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -105,6 +105,12 @@ alias sl='ls'            # I often screw this up.
 if [[ "$OSTYPE" == darwin* ]]; then
   alias o='open'
   alias get='curl --continue-at - --location --progress-bar --remote-name --remote-time'
+elif [[ "$OSTYPE" == cygwin* ]]; then
+  alias open='cygstart'
+  alias o='open'
+  alias get='wget --continue --progress=bar --timestamping'
+  alias pbcopy='tee > /dev/clipboard'
+  alias pbpaste='cat /dev/clipboard'
 else
   alias o='xdg-open'
   alias get='wget --continue --progress=bar --timestamping'


### PR DESCRIPTION
This patch adds support for the OS X-inspired aliases (`o`, `get`, `pbcopy`, `pbpaste`) for Cygwin users.
