### PR TITLE
Add an alias to set the URL of a remote

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -159,6 +159,7 @@ Aliases
   - `gRa` adds a new remote.
   - `gRx` removes a remote.
   - `gRm` renames a remote.
+  - `gRe` sets the URL of a remote.
   - `gRu` fetches remotes updates.
   - `gRp` prunes all stale remote tracking branches.
   - `gRs` displays information about a given remote.

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -3,6 +3,7 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Joel Kuzmarski <leoj3n@gmail.com>
 #
 
 #
@@ -137,6 +138,7 @@ alias gRl='git remote --verbose'
 alias gRa='git remote add'
 alias gRx='git remote rm'
 alias gRm='git remote rename'
+alias gRe='git remote set-url'
 alias gRu='git remote update'
 alias gRp='git remote prune'
 alias gRs='git remote show'


### PR DESCRIPTION
Found this command useful after we moved a couple of our repos to our org.
