### PR TITLE
Fix non-working alias gSu

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -165,7 +165,7 @@ alias gSI='git submodule update --init --recursive'
 alias gSl='git submodule status'
 alias gSm='git-submodule-move'
 alias gSs='git submodule sync'
-alias gSu='git submodule foreach git pull origin master'
+alias gSu='git submodule update'
 alias gSx='git-submodule-remove'
 
 # Working Copy (w)


### PR DESCRIPTION
I'm guessing the current alias `alias gSu='git submodule foreach git pull origin master'` is from the early days of git? The command doesn't work for me, but my proposed change to `alias gSu='git submodule update'` does. It's also possible I've misinterpreted what `gSu` is supposed to do and am using it wrong (hopefully not!)
