### PR TITLE
Use correct option for pacman search aliases

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -55,10 +55,10 @@ alias pacq='pacman --sync --info'
 alias pacQ='pacman --query --info'
 
 # Searches for packages in the repositories.
-alias pacs='pacman --sync --recursive'
+alias pacs='pacman --sync --search'
 
 # Searches for packages in the local database.
-alias pacS='pacman --query --recursive'
+alias pacS='pacman --query --search'
 
 # Lists orphan packages.
 alias pacman-list-orphans='sudo pacman --query --deps --unrequired'


### PR DESCRIPTION
Pacman search aliases should use the '--search' option, not '--recursive'. It works anyway because '--recursive' is mapped to '-s' which is the same as '--search', but it's still wrong.
