### PR TITLE
Add code to allow pre fpath entries via zstyle.

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -12,7 +12,8 @@ if [[ "$TERM" == 'dumb' ]]; then
 fi
 
 # Add zsh-completions to $fpath.
-fpath=("${0:h}/external/src" $fpath)
+zstyle -s ':prezto:module:completion' path 'prefpath'
+fpath=("$prefpath" "${0:h}/external/src" $fpath)
 
 # Load and initialize the completion system ignoring insecure directories.
 autoload -Uz compinit && compinit -i


### PR DESCRIPTION
I want to add the home-brew zsh/site-packages path to the front of fpath so that any completion functions there will have precedent over the ones in prezto.  This patch allows doing this via a zstyle setup in the .zshrc file before prezto is sourced.
