### PR TITLE
Module command-not-found: Added command-not-found hook for Arch Linux

### DIFF
--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -1,7 +1,7 @@
 Command-Not-Found
 =================
 
-Loads the [command-not-found][1] tool on Debian-based distributions.
+Loads the [command-not-found][1] tool on Debian-based distributions or Arch Linux.
 
 Authors
 -------

--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -6,9 +6,10 @@
 #
 
 # Return if requirements are not found.
-if [[ ! -s '/etc/zsh_command_not_found' ]]; then
+if [[ -s '/etc/zsh_command_not_found' ]]; then
+  source '/etc/zsh_command_not_found' # Debian-based distributions
+elif [[ -s '/usr/share/doc/pkgfile/command-not-found.zsh' ]]; then
+  source '/usr/share/doc/pkgfile/command-not-found.zsh' # Arch Linux
+else
   return 1
 fi
-
-source '/etc/zsh_command_not_found'
-


### PR DESCRIPTION
Arch Linux also has a command-not-found tool: https://wiki.archlinux.org/index.php/Pkgfile
I've changed the command-not-found module so that the pkgfile hook gets sourced when it is found. :)

This is my first GitHub pull request, so please tell me if I made a mistake or should improve the code.
