### PR TITLE
Use rebase for brew update

### DIFF
--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -20,6 +20,6 @@ alias brewi='brew install'
 alias brewl='brew list'
 alias brews='brew search'
 alias brewu='brew upgrade'
-alias brewU='brew update && brew upgrade'
+alias brewU='brew update --rebase && brew upgrade'
 alias brewx='brew remove'
 


### PR DESCRIPTION
Use `brew update --rebase` to make Homebrew use `git pull --rebase` when updating.

This prevents homebrew from doing lots of merge commits or even prompting for merge messages, if the user has disabled fast-forward merges in her `.gitconfig`.
