### PR TITLE
Add interactive commit alias

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -44,6 +44,7 @@ alias gbS='git show-branch -a'
 # Commit (c)
 alias gc='git commit --verbose'
 alias gca='git commit --verbose --all'
+alias gci='git commit --interactive'
 alias gcm='git commit --message'
 alias gco='git checkout'
 alias gcO='git checkout --patch'


### PR DESCRIPTION
git commit --interactive is incredibly useful for workflows where you make a lot of related changes at once but wish to flexibly commit portions independently, as well as general commit workflow activities. I've been using this alias for years and would like to stop rebasing it when I update prezto :)
