### PR TITLE
Moves the path settings to zprofile.

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -5,3 +5,19 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+#
+# Paths
+#
+
+typeset -gU cdpath fpath mailpath path
+
+# Set the the list of directories that cd searches.
+# cdpath=(
+#   $cdpath
+# )
+
+# Set the list of directories that Zsh searches for programs.
+path=(
+  /usr/local/{bin,sbin}
+  $path
+)

--- a/runcoms/zshenv
+++ b/runcoms/zshenv
@@ -30,23 +30,6 @@ if [[ -z "$LANG" ]]; then
 fi
 
 #
-# Paths
-#
-
-typeset -gU cdpath fpath mailpath path
-
-# Set the the list of directories that cd searches.
-# cdpath=(
-#   $cdpath
-# )
-
-# Set the list of directories that Zsh searches for programs.
-path=(
-  /usr/local/{bin,sbin}
-  $path
-)
-
-#
 # Less
 #
 


### PR DESCRIPTION
This is needed on Mac OS X (10.9) because `/etc/zprofile` is loaded after
`~/.zshenv` and overwrites the path settings with a call to `path_helper`.
