### PR TITLE
Support emacs terminals

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -91,8 +91,8 @@ if [[ -s "${ZDOTDIR:-$HOME}/.zpreztorc" ]]; then
   source "${ZDOTDIR:-$HOME}/.zpreztorc"
 fi
 
-# Disable color and theme in dumb terminals.
-if [[ "$TERM" == 'dumb' ]]; then
+# Disable color and theme in dumb terminals (unless we're in emacs).
+if [[ "$TERM" == 'dumb' && "$EMACS" != 't' ]]; then
   zstyle ':prezto:*:*' color 'no'
   zstyle ':prezto:module:prompt' theme 'off'
 fi

--- a/modules/spectrum/init.zsh
+++ b/modules/spectrum/init.zsh
@@ -7,7 +7,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$TERM" == 'dumb' ]]; then
+if [[ "$TERM" == 'dumb' && "$EMACS" != 't' ]]; then
   return 1
 fi
 


### PR DESCRIPTION
I use shell mode in emacs all the time, which has the wonderful trait of setting TERM=dumb whilst still supporting colours and ansi escapes.

Bah.

So, here's a patch to enable the parts of prezto that work with emacs.
