### PR TITLE
Fixes rvm error about autodotfiles by adding "$HOME/.rvm/bin" to path

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -13,6 +13,7 @@ if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
 
   # Source RVM.
   source "$HOME/.rvm/scripts/rvm"
+  path=($path "$HOME/.rvm/bin")
 
 # Load manually installed rbenv into the shell session.
 elif [[ -s "$HOME/.rbenv/bin/rbenv" ]]; then


### PR DESCRIPTION
Resolves rvm error where it complains about the dot files not being configured properly.  For some reason the ruby module was not adding ~/.rvm/bin to the path.  
