### PR TITLE
allow functions in a module to be symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -25,7 +25,7 @@ unset min_zsh_version
 function pmodload {
   local -a pmodules
   local pmodule
-  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(.N:t)'
+  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(-.N:t)'
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")


### PR DESCRIPTION
add the '-' flag to the function glob which makes the other flag test
against the target of the symlink, and not the symlink itself

when using rcm (https://github.com/thoughtbot/rcm) the function files
are symlinked by default, but the current glob excludes them by
targeting normal files (with the '.' flag)
