### PR TITLE
Allow function loading to work with symbolic links

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -25,7 +25,7 @@ unset min_zsh_version
 function pmodload {
   local -a pmodules
   local pmodule
-  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(.N:t)'
+  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(.,@N:t)'
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")


### PR DESCRIPTION
This changes allows for the loading of function that are symbolic links in the case where the functions are linked to files elsewhere or to work with home management systems like ghar.
