### PR TITLE
force tmux to use 256 colors by adding the -2 flag

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -30,7 +30,7 @@ if [[ -z "$TMUX" ]] && ( \
     tmux set-option -g destroy-unattached off &> /dev/null
 
     # Create a new session.
-    tmux new-session -d -s "$tmux_session"
+    tmux -2 new-session -d -s "$tmux_session"
 
     # Disable the destruction of the new, unattached session.
     tmux set-option -t "$tmux_session" destroy-unattached off &> /dev/null
@@ -40,7 +40,7 @@ if [[ -z "$TMUX" ]] && ( \
     tmux set-option -g destroy-unattached on &> /dev/null
   fi
 
-  exec tmux new-session -t "$tmux_session"
+  exec tmux -2 new-session -t "$tmux_session"
 fi
 
 #


### PR DESCRIPTION
When I'm in  tmux mode via  `zstyle ':prezto:module:tmux:auto-start' local 'yes'` the colorscheme I have set in vim does not show up. 

-2 option will force tmux to assume the terminal supports 256 colours.
