### PR TITLE
Fix setting the 'pac' alias

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -36,7 +36,7 @@ fi
 #
 
 # Pacman.
-alias pac= "${_pacman_frontend}"
+alias pac="${_pacman_frontend}"
 
 # Installs packages from repositories.
 alias paci="${_pacman_sudo}${_pacman_frontend} --sync"


### PR DESCRIPTION
After a recent change to the pacman module, the 'pac'  alias was not being set. This turned out to be caused by an unintended space in alias line.
