### PR TITLE
Disable glob for bower

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -43,6 +43,7 @@ alias rake='noglob rake'
 alias rsync='noglob rsync'
 alias scp='noglob scp'
 alias sftp='noglob sftp'
+alias bower='noglob bower'
 
 # Define general aliases.
 alias _='sudo'


### PR DESCRIPTION
Bower uses # as semver separator and [require to escape searches or disable noblog](http://bower.io/)
