### PR TITLE
Added plugin 'last-working-dir' borrowed from omz

### DIFF
--- a/modules/last-working-dir/README.md
+++ b/modules/last-working-dir/README.md
@@ -1,0 +1,13 @@
+last-working-dir
+================
+
+This plugin enables your new terminals opened to automatically enter in the last directory worked
+
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][1].*
+
+[1]: https://github.com/sorin-ionescu/prezto/issues
+

--- a/modules/last-working-dir/init.zsh
+++ b/modules/last-working-dir/init.zsh
@@ -1,0 +1,24 @@
+# Keeps track of the last used working directory and automatically jumps
+# into it for new shells.
+
+# Flag indicating if we've previously jumped to last directory.
+typeset -g ZSH_LAST_WORKING_DIRECTORY
+
+# Updates the last directory once directory is changed.
+function chpwd() {
+    local cache_file="$HOME/.cache/zsh/last-working-dir"
+    # Use >| in case noclobber is set to avoid "file exists" error
+    pwd >| "$cache_file"
+}
+
+# Changes directory to the last working directory.
+function lwd() {
+    local cache_file="$HOME/.cache/zsh/last-working-dir"
+    [[ -s "$cache_file" ]] && cd "$(cat "$cache_file")"
+}
+
+# Automatically jump to last working directory unless this isn't the first time
+# this plugin has been loaded.
+if [[ -z "$ZSH_LAST_WORKING_DIRECTORY" ]]; then
+    lwd 2>/dev/null && ZSH_LAST_WORKING_DIRECTORY=1 || true
+fi


### PR DESCRIPTION
This is a small but very useful plugin borrowed from oh-my-zsh so that works in prezto, just enable the plugin and each new terminal will have its "pwd" same as the last worked place

Thanks
