### PR TITLE
Update ruby module documentation specific to RVM environment loading

### DIFF
--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -18,7 +18,8 @@ allows for managing multiple, isolated Ruby installations and gem sets in the
 home directory.
 
 Since RVM is loaded into the shell and is known to override shell commands, it
-may conflict with shell scripts.
+may conflict with shell scripts.  It may be best to load ruby last in .zpreztorc
+as RVM will complain if it's not first in the load path.
 
 rbenv
 -----


### PR DESCRIPTION
Given that RVM is autoloaded, an issue can arise if RVM isn't injected into the PATH as the first element.  This can present if the ruby module is loaded before other modules that modify the PATH environment variable.  Simple workaround, and pointer to the user, is to just load the ruby module last.
