### PR TITLE
Don't attempt to enter screen/tmux environment when in Emacs

### DIFF
--- a/modules/screen/init.zsh
+++ b/modules/screen/init.zsh
@@ -15,7 +15,7 @@ fi
 # Auto Start
 #
 
-if [[ -z "$STY" ]] && ( \
+if [[ -z "$STY" && ( -n "$INSIDE_EMACS" || -n "$EMACS") ]] && ( \
   ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:screen:auto-start' remote ) ||
   ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:screen:auto-start' local ) \
 ); then

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -16,7 +16,7 @@ fi
 # Auto Start
 #
 
-if [[ -z "$TMUX" ]] && ( \
+if [[ -z "$TMUX" && ( -n "$INSIDE_EMACS" || -n "$EMACS") ]] && ( \
   ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' remote ) ||
   ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' local ) \
 ); then


### PR DESCRIPTION
If launching Emacs from outside an interactive shell (say from Upstart,
Gnome3, an OS X .app bundle), $TMUX and $STY won't be set. We shouldn't
launch ssh/tmux when running emacs, because emacs can't handle the
termcaps of such multiplexers.

Emacs sets $INSIDE_EMACS and (on older versions) $EMACS, so if those are
set we shouldn't attempt to autostart a tmux/screen session.

See issue #541

Reproduction steps: Launch Emacs.app in OSX or a GUI Emacs via Ubuntu's Unity GUI. Previous to the fix, Emacs won't successfully perform a M-x shell. With this fix, Emacs should successfully launch a shell.
