### PR TITLE
'completion:*:*:*:users ignored-patterns' more robust

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -100,10 +100,10 @@ zstyle -e ':completion:*:hosts' hosts 'reply=(
 
 # Don't complete uninteresting users...
 zstyle ':completion:*:*:*:users' ignored-patterns nobody nobody4 noaccess '_*' \
-  $([[ $OSTYPE = *(linux|darwin|cygwin)* ]] && min_uid=500 || min_uid=100
+  $([[ "$OSTYPE" = SunOS ]] && uid_min=100 || uid_min=500
     IFS=:
     while read -r user pass uid remainder; do
-      [[ "$user" != (\#*|root) ]] && ((uid < min_uid)) && echo $user
+      [[ "$user" != (\#*|root) ]] && ((uid < uid_min)) && echo $user
     done </etc/passwd
   )
 


### PR DESCRIPTION
Calculates ignored users at runtime by looking at passwd database and stripping all users with UID < 500. This should work on most unices except perhaps Solaris, which supposedly starts normal users at UID=100.

By my timings, this makes it only some 0.010s slower.
