### PR TITLE
Make prefix in completion menu of separate color

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -76,7 +76,7 @@ zstyle ':completion:*:functions' ignored-patterns '(_*|pre(cmd|exec))'
 zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters
 
 # Directories
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle -e ':completion:*:default' list-colors 'reply=("${PREFIX:+=(#bi)($PREFIX:t)(?)*==2;9=1}:${(s.:.)LS_COLORS}")'
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
 zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'users' 'expand'


### PR DESCRIPTION
When using zsh completion menu, the already-typed prefix is made faint (decreased intensity) and striked-through, and the next character is made bold (increased intensity).

This makes it easy to quickly see which is the next character that distinguishes available completion options.

Reddit thread: http://redd.it/msps0
Solution thanks to: @nicoulaj

To preview, set this and then complete on something in `/usr/bin/` (or somewhere with lots of files with common prefixes).
