### PR TITLE
[tmux module] Auto-start Only creates default session if none created in tmux.conf

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -28,7 +28,6 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" ]] && ( \
   # and no session has been created.
   if ! tmux has-session 2> /dev/null; then
     tmux \
-      start-server \; \
       new-session -d -s "$tmux_session" \; \
       set-option -t "$tmux_session" destroy-unattached off &> /dev/null
   fi


### PR DESCRIPTION
(refs #544) As per @nasenatmer remark
