### PR TITLE
make tmux module have optional attach behavior

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -20,15 +20,25 @@ following line to *zpreztorc*:
 
     zstyle ':prezto:module:tmux:auto-start' remote 'yes'
 
-In both cases, it will create a background session named _prezto_ if the tmux
-server is not started.
+In both cases the tmux server will be started and a background session
+named _prezto_ will be created if a session doesn't already exist.
 
-With `auto-start` enabled, you may want to control how multiple sessions are
-managed. The `destroy-unattached` option of tmux controls if the unattached
-sessions must be kept alive, making sessions available for later use, configured
-in *tmux.conf*:
+By default every shell shares a set of windows but has an independent
+view. Detaching from one of these sessions removes the view but the
+open windows persist. This is accomplished by setting the
+`destroy-unattached` option to `on` for each session.
 
-    set-option -g destroy-unattached [on | off]
+Some users prefer that all new shells share the same session so that
+the view for each shell is in sync. This useful for advanced users
+that create multiple sessions and want to manually navigate between
+them. To accomplish this behavior set the `mode` option to `shared` in
+*zpreztorc*,
+
+    zstyle ':prezto:module:tmux:auto-start' mode shared
+
+You can customize the background session by creating a new session in
+your `.tmux.conf` file.
+
 
 Aliases
 -------

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -25,14 +25,21 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" ]] && ( \
 
   # Create a 'prezto' session if no session has been defined in tmux.conf.
   if ! tmux has-session 2> /dev/null; then
-    tmux_session='prezto'
     tmux \
-      new-session -d -s "$tmux_session" \; \
-      set-option -t "$tmux_session" destroy-unattached off &> /dev/null
+      new-session -d -s prezto \; \
+      set-option -t prezto destroy-unattached off &> /dev/null
+  else
+    tmux_session
   fi
 
-  # Attach to the 'prezto' session or to the last session used.
-  exec tmux attach-session
+  if zstyle -t ':prezto:module:tmux:auto-start' mode shared; then
+      # Attach to the 'prezto' session or to the last session used.
+      exec tmux attach
+  else
+      # Find a session to share windows with.
+      tmux_session=`tmux list-sessions -F '#S' | head -n 1`
+      exec tmux new-session -t "$tmux_session"\; set-option destroy-unattached on
+  fi
 fi
 
 #


### PR DESCRIPTION
This commit reverts the tmux module back to the original behavior but
doesn't set `destroy-unattached` to on `on` globally and provides an
option for attaching to the background or last-used session.
