### PR TITLE
Ignore case in filenames.

### DIFF
--- a/modules/archive/functions/lsarchive
+++ b/modules/archive/functions/lsarchive
@@ -30,7 +30,7 @@ while (( $# > 0 )); do
     continue
   fi
 
-  case "$1" in
+  case "$1:l" in
     (*.tar.gz|*.tgz) tar t${verbose:+v}vzf "$1" ;;
     (*.tar.bz2|*.tbz|*.tbz2) tar t${verbose:+v}jf "$1" ;;
     (*.tar.xz|*.txz) tar --xz --help &> /dev/null \

--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -37,7 +37,7 @@ while (( $# > 0 )); do
   success=0
   file_name="${1:t}"
   extract_dir="${file_name:r}"
-  case "$1" in
+  case "$1:l" in
     (*.tar.gz|*.tgz) tar xvzf "$1" ;;
     (*.tar.bz2|*.tbz|*.tbz2) tar xvjf "$1" ;;
     (*.tar.xz|*.txz) tar --xz --help &> /dev/null \


### PR DESCRIPTION
This allows, for instance, to use `lsarchive something.ZIP`.
Odd, but can happen accessing an old filesystem that does not support filename case distinction.
