### PR TITLE
fix utility module dircolors bug when launching zsh if SHELL is csh

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -66,9 +66,9 @@ if is-callable 'dircolors'; then
 
   if zstyle -t ':prezto:module:utility:ls' color; then
     if [[ -s "$HOME/.dir_colors" ]]; then
-      eval "$(dircolors "$HOME/.dir_colors")"
+      eval "$(dircolors -b "$HOME/.dir_colors")"
     else
-      eval "$(dircolors)"
+      eval "$(dircolors -b)"
     fi
 
     alias ls="$aliases[ls] --color=auto"


### PR DESCRIPTION
If the user's SHELL is a csh derivative, then the call to 'dircolors' in modules/utility/init.zsh when starting 'zsh' from csh returns a csh-style result with 'setenv', which of course causes a prezto init error. This tweak to include the '-b' option when calling dircolors ensures that code for Bourne shell and friends is returned instead.
