### PR TITLE
Add support for skipping VIRTUALENVWRAPPER init in modules/python

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -38,7 +38,7 @@ fi
 zstyle -t ':prezto:module:python' skip-virtualenvwrapper-init
 if (( $? && $+commands[virtualenvwrapper.sh] )); then
   # Set the directory where virtual environments are stored.
-  export WORKON_HOME="$HOME/.virtualenvs"
+  export WORKON_HOME="${WORKON_HOME:-$HOME/.virtualenvs}"
 
   # Disable the virtualenv prompt.
   VIRTUAL_ENV_DISABLE_PROMPT=1

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -34,8 +34,9 @@ if (( ! $+commands[python] && ! $+commands[pyenv] )); then
   return 1
 fi
 
-# Load virtualenvwrapper into the shell session.
-if (( $+commands[virtualenvwrapper.sh] )); then
+# Load virtualenvwrapper into the shell session, unless requested not to
+zstyle -t ':prezto:module:python' skip-virtualenvwrapper-init
+if (( $? && $+commands[virtualenvwrapper.sh] )); then
   # Set the directory where virtual environments are stored.
   export WORKON_HOME="$HOME/.virtualenvs"
 


### PR DESCRIPTION
This branch just changes modules/python/init.zsh so that it will recognize if the user defined a PREZTO_PYTHON_NO_VIRTUALENVWRAPPER var and will not do the virtualenvwrapper setup and sourcing of virtualenvwrapper_lazy.sh in that case.
