### PR TITLE
Terminal titling improvements

### DIFF
--- a/modules/terminal/README.md
+++ b/modules/terminal/README.md
@@ -13,14 +13,19 @@ directory, add the following to *zpreztorc*:
 
     zstyle ':prezto:module:terminal' auto-title 'yes'
 
-Auto titling is disabled inside terminal multiplexers, except inside dvtm, since
-it interferes with window names defined in configuration files and profile
-managers.
+Auto titling is disabled inside terminal multiplexers (except inside dvtm)
+since it interferes with window names defined in configuration files and
+profile managers. This can be overridden by setting it to `always`.
+
+    zstyle ':prezto:module:terminal' auto-title 'always'
+
+### Title formats
 
 To format terminal window and tab titles, add the following to *zpreztorc*:
 
     zstyle ':prezto:module:terminal:window-title' format '%n@%m: %s'
     zstyle ':prezto:module:terminal:tab-title' format '%m: %s'
+    zstyle ':prezto:module:terminal:multiplexer-title' format '%s'
 
 `%s` will be replaced with the current working directory path or the currently
 executing program name.
@@ -31,7 +36,8 @@ Functions
 ---------
 
 - `set-tab-title` sets the terminal tab title.
-- `set-window-title` sets the terminal or terminal multiplexer window title.
+- `set-window-title` sets the terminal window title.
+- `set-multiplexer-title` sets the terminal multiplexer title.
 
 Authors
 -------
@@ -39,6 +45,7 @@ Authors
 *The authors of this module should be contacted via the [issue tracker][2].*
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
+  - [Olaf Conradi](https://github.com/oohlaf)
 
 [1]: http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Expansion-of-Prompt-Sequences
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/terminal/init.zsh
+++ b/modules/terminal/init.zsh
@@ -3,6 +3,7 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Olaf Conradi <olaf@conradi.org>
 #
 
 # Return if requirements are not found.
@@ -10,19 +11,12 @@ if [[ "$TERM" == (dumb|linux|*bsd*|eterm*) ]]; then
   return 1
 fi
 
-# Sets the terminal or terminal multiplexer window title.
+# Sets the terminal window title.
 function set-window-title {
   local title_format{,ted}
   zstyle -s ':prezto:module:terminal:window-title' format 'title_format' || title_format="%s"
   zformat -f title_formatted "$title_format" "s:$argv"
-
-  if [[ "$TERM" == screen* ]]; then
-    title_format="\ek%s\e\\"
-  else
-    title_format="\e]2;%s\a"
-  fi
-
-  printf "$title_format" "${(V%)title_formatted}"
+  printf '\e]2;%s\a' "${(V%)title_formatted}"
 }
 
 # Sets the terminal tab title.
@@ -30,8 +24,15 @@ function set-tab-title {
   local title_format{,ted}
   zstyle -s ':prezto:module:terminal:tab-title' format 'title_format' || title_format="%s"
   zformat -f title_formatted "$title_format" "s:$argv"
+  printf '\e]1;%s\a' "${(V%)title_formatted}"
+}
 
-  printf "\e]1;%s\a" ${(V%)title_formatted}
+# Sets the terminal multiplexer tab title.
+function set-multiplexer-title {
+  local title_format{,ted}
+  zstyle -s ':prezto:module:terminal:multiplexer-title' format 'title_format' || title_format="%s"
+  zformat -f title_formatted "$title_format" "s:$argv"
+  printf '\ek%s\e\\' "${(V%)title_formatted}"
 }
 
 # Sets the tab and window titles with a given command.
@@ -59,8 +60,11 @@ function _terminal-set-titles-with-command {
     local truncated_cmd="${cmd/(#m)?(#c15,)/${MATCH[1,12]}...}"
     unset MATCH
 
-    set-window-title "$cmd"
+    if [[ "$TERM" == screen* ]]; then
+      set-multiplexer-title "$truncated_cmd"
+    fi
     set-tab-title "$truncated_cmd"
+    set-window-title "$cmd"
   fi
 }
 
@@ -74,8 +78,11 @@ function _terminal-set-titles-with-path {
   local truncated_path="${abbreviated_path/(#m)?(#c15,)/...${MATCH[-12,-1]}}"
   unset MATCH
 
-  set-window-title "$abbreviated_path"
+  if [[ "$TERM" == screen* ]]; then
+    set-multiplexer-title "$truncated_path"
+  fi
   set-tab-title "$truncated_path"
+  set-window-title "$abbreviated_path"
 }
 
 # Do not override precmd/preexec; append to the hook array.
@@ -110,12 +117,13 @@ then
 fi
 
 # Set up non-Apple terminals.
-if zstyle -t ':prezto:module:terminal' auto-title \
-  && ( ! [[ -n "$STY" || -n "$TMUX" ]] )
+if zstyle -t ':prezto:module:terminal' auto-title 'always' \
+  || (zstyle -t ':prezto:module:terminal' auto-title \
+    && ( ! [[ -n "$STY" || -n "$TMUX" ]] ))
 then
-  # Sets the tab and window titles before the prompt is displayed.
+  # Sets titles before the prompt is displayed.
   add-zsh-hook precmd _terminal-set-titles-with-path
 
-  # Sets the tab and window titles before command execution.
+  # Sets titles before command execution.
   add-zsh-hook preexec _terminal-set-titles-with-command
 fi

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -143,6 +143,9 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 # Set the tab title format.
 # zstyle ':prezto:module:terminal:tab-title' format '%m: %s'
 
+# Set the terminal multiplexer title format.
+# zstyle ':prezto:module:terminal:multiplexer-title' format '%s'
+
 #
 # Tmux
 #


### PR DESCRIPTION
Simplifies titling functions.

Multiplexer titles can be set independent of window and tab titles.
Adds auto-title always option to have dynamic titling inside terminal multiplexers.
Setting auto-title to yes continues to ignore dynamic titling inside terminal multiplexers.
This patch should not alter behavior under Apple terminals.
