### PR TITLE
Add homebrew-cask aliases to homebrew module

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -15,12 +15,21 @@ Aliases
   - `brewu` upgrades Homebrew.
   - `brewx` uninstalls a formula.
 
+  - `cask` is aliased to `brew cask`.
+  - `caskc` cleans up old cached downloads.
+  - `caskC` cleans up all cached downloads.
+  - `caski` installs a cask.
+  - `caskl` lists installed casks.
+  - `casks` searches for a cask.
+  - `caskx` uninstalls a cask.
+
 Authors
 -------
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
+  - [Griffin Yourick](https://github.com/tough-griff)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues
 

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -14,6 +14,7 @@ fi
 # Aliases
 #
 
+# Homebrew
 alias brewc='brew cleanup'
 alias brewC='brew cleanup --force'
 alias brewi='brew install'
@@ -23,3 +24,11 @@ alias brewu='brew upgrade'
 alias brewU='brew update && brew upgrade'
 alias brewx='brew remove'
 
+# homebrew-cask
+alias cask='brew cask'
+alias caskc='brew cask cleanup --outdated'
+alias caskC='brew cask cleanup'
+alias caski='brew cask install'
+alias caskl='brew cask list'
+alias casks='brew cask search'
+alias caskx='brew cask uninstall'


### PR DESCRIPTION
I've started using [homebrew-cask](https://github.com/phinze/homebrew-cask) extensively to install native Mac apps, and these changes make the new `brew cask` commands mirror the existing homebrew aliases.
