### PR TITLE
Only print fortunes in terminals

### DIFF
--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -16,7 +16,9 @@
 
 # Print a random, hopefully interesting, adage.
 if (( $+commands[fortune] )); then
-  fortune -a
-  print
+  if [[ -t 0 || -t 1 ]]; then
+    fortune -a
+    print
+  fi
 fi
 


### PR DESCRIPTION
This modification prevents conflicts with programs that try to read stdout from a login shell.

For example, see https://github.com/brunophilipe/Cakebrew/issues/59
