### PR TITLE
Use `whoami` instead of $USER

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -66,7 +66,7 @@ fi
 #
 
 if [[ ! -d "$TMPDIR" ]]; then
-  export TMPDIR="/tmp/$USER"
+  export TMPDIR="/tmp/`whoami`"
   mkdir -p -m 700 "$TMPDIR"
 fi
 


### PR DESCRIPTION
If TMPDIR doesn't exist, USER also may not exist. `mkdir` then throws an error
after this because TMPDIR is /tmp/, which already exists.
