### PR TITLE
[module:ruby:chruby] If a default ruby is set for the user, switch to it

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -28,6 +28,8 @@ elif (( $+commands[chruby-exec] )); then
   source "${commands[chruby-exec]:h:h}/share/chruby/chruby.sh"
   if zstyle -t ':prezto:module:ruby:chruby' auto-switch; then
     source "${commands[chruby-exec]:h:h}/share/chruby/auto.sh"
+    # If a default ruby is configured for the user, switch to it
+    chruby_auto
   fi
 
 # Prepend local gems bin directories to PATH.


### PR DESCRIPTION
If a default ruby is set for the user, switch to it automatically. This
sets the PATH variables and allows gems such as `bundler` to be found,
allowing the `bundler` aliases to be enabled.
This only matters when the default ruby is _not_ the system ruby (and/or
where `bundler` is not installed for the system ruby)

This also fixes an issue where the `ruby-info` function has the wrong
info for the initial prompt when a default ruby is set via `chruby`.

A `.ruby-version` file must exist in the users $HOME directory (as
recommended here for auto-switching:
https://github.com/postmodern/chruby#default-ruby)
