### PR TITLE
New variable: vimode

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -87,16 +87,20 @@ function editor-info {
   if [[ "$KEYMAP" == 'vicmd' ]]; then
     zstyle -s ':prezto:module:editor:info:keymap:alternate' format 'REPLY'
     editor_info[keymap]="$REPLY"
+    editor_info[vimode]="$REPLY"
   else
     zstyle -s ':prezto:module:editor:info:keymap:primary' format 'REPLY'
     editor_info[keymap]="$REPLY"
+    editor_info[vimode]="$REPLY"
 
     if [[ "$ZLE_STATE" == *overwrite* ]]; then
       zstyle -s ':prezto:module:editor:info:keymap:primary:overwrite' format 'REPLY'
       editor_info[overwrite]="$REPLY"
+      editor_info[vimode]="$REPLY"
     else
       zstyle -s ':prezto:module:editor:info:keymap:primary:insert' format 'REPLY'
       editor_info[overwrite]="$REPLY"
+      editor_info[vimode]="$REPLY"
     fi
   fi
 


### PR DESCRIPTION
A separate pull request for the proposed vimode variable, see #616.
It combines the two variables `editor_info[keymap]` and `editor_info[overwrite]` into a single variable `editor_info[vimode]`.
I recognized that this variable would be handy when I developed the budspencer, terencehill and dangerous themes. Without it, many additional if-else statements as in `editor/init.zsh` would be needed.
