### PR TITLE
Added explainshell module

### DIFF
--- a/modules/explainshell/README.md
+++ b/modules/explainshell/README.md
@@ -1,0 +1,10 @@
+#Explainshell
+
+Adds a keybinding to open (explainshell.com)[http://www.explainshell.com] with the content of the command line.
+
+##Settings
+
+###Key-Binding
+The keybinding to open (explainshell.com)[http://www.explainshell.com]
+
+`zstyle ':prezto:module:explainshell' key-binding '^K'`

--- a/modules/explainshell/README.md
+++ b/modules/explainshell/README.md
@@ -1,10 +1,11 @@
 #Explainshell
 
-Adds a keybinding to open (explainshell.com)[http://www.explainshell.com] with the content of the command line.
+Adds a keybinding and a function to open 
+[explainshell.com](http://www.explainshell.com) with the content of the command
+line.
 
 ##Settings
-
 ###Key-Binding
-The keybinding to open (explainshell.com)[http://www.explainshell.com]
+The keybinding to open [explainshell.com](http://www.explainshell.com)
 
 `zstyle ':prezto:module:explainshell' key-binding '^K'`

--- a/modules/explainshell/init.zsh
+++ b/modules/explainshell/init.zsh
@@ -1,0 +1,38 @@
+#
+# Adds a explain function and explainshell widget
+# 
+# Authors
+#   C Lentfort
+#
+
+
+function explain {
+  # base url with first command already injected
+  # $ explain tar
+  #   => http://explainshel.com/explain/tar?args=
+  url="http://explainshell.com/explain/$1?args="
+  
+  # removes $1 (tar) from arguments ($@)
+  shift;
+  
+  # iterates over remaining args and adds builds the rest of the url
+  for i in "$@"; do
+    url=$url"$i""+"
+  done
+  
+  # opens url in browser
+  $BROWSER -t $url &> /dev/null
+}
+
+function explainshell {
+    explain $BUFFER
+}
+
+zle -N explainshell
+
+zstyle -s ':prezto:module:explainshell' key-binding 'key_binding'
+if [[ -n "$key_binding" ]]; then
+  bindkey "$key_binding" explainshell
+fi
+
+unset key_binding

--- a/modules/explainshell/init.zsh
+++ b/modules/explainshell/init.zsh
@@ -5,27 +5,52 @@
 #   C Lentfort
 #
 
+function _expand_alias_recursive {
+  local _alias
+  for word in "$@"; do
+    # Check if word is aliased
+    _alias=$aliases[$word]
+    if [ -n "$_alias" ]; then
+      # Check if found alias and given command are identical
+      if [[ "$_alias" != "${(j: :)@}" ]]; then
+        _expand_alias_recursive "${(z)_alias}"
+      else
+        _explainshell_expanded_buffer+=$1
+      fi
+    else
+      _explainshell_expanded_buffer+=$word
+    fi
+  done
+}
 
 function explain {
+  local url
+  # We don't explain empty buffers
+  if (( $# == 0 )); then
+    return 1;
+  fi
+
+  # Replace aliases with their actual expansions
+  _explainshell_expanded_buffer=()
+  _expand_alias_recursive $@
+  _explainshell_expanded_buffer=(${(u)_explainshell_expanded_buffer})
   # base url with first command already injected
   # $ explain tar
   #   => http://explainshel.com/explain/tar?args=
-  url="http://explainshell.com/explain/$1?args="
-  
-  # removes $1 (tar) from arguments ($@)
-  shift;
-  
+  url="http://explainshell.com/explain?cmd="
+
   # iterates over remaining args and adds builds the rest of the url
-  for i in "$@"; do
+  for i in "$_explainshell_expanded_buffer"; do
     url=$url"$i""+"
   done
-  
+
+  unset _explainshell_expanded_buffer
   # opens url in browser
   $BROWSER -t $url &> /dev/null
 }
 
 function explainshell {
-    explain $BUFFER
+  explain ${(z)BUFFER}
 }
 
 zle -N explainshell


### PR DESCRIPTION
A simple module which adds the `explain` and a keybinding to open explainshell with the contents of the current command line.