### PR TITLE
Update zsh required version info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ and prompt themes.
 Installation
 ------------
 
-Prezto will work with any recent release of Zsh, but the minimum recommended
-version is 4.3.11.
+Prezto requires zsh version 4.3.11 or later.
 
   1. Launch Zsh:
 


### PR DESCRIPTION
4.3.11 is not "recommended," it's required. zsh gives an error message and refuses to start with 4.3.10.
