### PR TITLE
added vim text objects for vim mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "modules/prompt/functions/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
+[submodule "modules/opp/external"]
+	path = modules/opp/external
+	url = https://github.com/hchbaw/opp.zsh.git

--- a/modules/opp/README.md
+++ b/modules/opp/README.md
@@ -1,0 +1,19 @@
+VIM text objects
+========================
+
+Integrates [opp][1] into Prezto, which implements [vim text objects][2] right into vim mode of prezto.
+
+Due to some conflicts with prezto loading, opp will get compiled during initial run.
+
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][3].*
+
+  - [Takeshi Banse](https://github.com/hchbaw)
+
+[1]: https://github.com/hchbaw/opp.zsh
+[2]: http://blog.carbonfive.com/2011/10/17/vim-text-objects-the-definitive-guide/
+[3]: https://github.com/hchbaw/opp.zsh/issues?state=open
+

--- a/modules/opp/init.zsh
+++ b/modules/opp/init.zsh
@@ -1,0 +1,20 @@
+# Vim's text-objects-ish for zsh.
+
+# Author: Takeshi Banse <takebi@laafc.net>
+# License: Public Domain
+
+# Thank you very much, Bram Moolenaar!
+# I want to use the Vim's text-objects in zsh.
+if [[ ! -f ${0:h}/functions/opp.zwc ]] ||
+   [[ ! -f ${0:h}/functions/opp-install.zwc ]]; then
+  (
+    . "${0:h}/external/opp.zsh"
+    . "${0:h}/external/opp/surround.zsh"
+    . "${0:h}/external/opp/textobj-between.zsh"
+    opp-zcompile "${0:h}/external/opp.zsh" ${0:h}/functions > /dev/null
+  )
+  fpath+=${0:h}/functions > /dev/null
+  . ${0:h}/functions/opp-install
+  autoload opp
+fi
+opp-install


### PR DESCRIPTION
This pull request adds vim text objects to prezto's vim mode by adding the external 'opp' module from https://github.com/hchbaw/opp.zsh. 

As a vim guy, missing my text objects felt like a big issue. opp brings all that stuff back thanks to the awesome hchbaw. 