### PR TITLE
git performance improvement if aliased

### DIFF
--- a/modules/git/functions/_git-hub-browse
+++ b/modules/git/functions/_git-hub-browse
@@ -8,7 +8,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   return 1
 fi
 
@@ -21,7 +21,7 @@ _arguments -C -s -S \
 
 case "$state" in
   (remote)
-    remotes=($(git config --get-regexp 'remote.*.url' | cut -d. -f2))
+    remotes=($(command git config --get-regexp 'remote.*.url' | cut -d. -f2))
 
     _describe -t branch 'remotes' remotes && ret=0
   ;;
@@ -29,7 +29,7 @@ case "$state" in
     remote="$words[(($CURRENT - 1))]"
 
     branches_or_tags=($(
-      git ls-remote --heads --tags "$remote" 2>/dev/null | cut -f2
+      command git ls-remote --heads --tags "$remote" 2>/dev/null | cut -f2
     ))
 
     branches=(HEAD ${${(M)branches_or_tags[@]##refs/heads/?##}##refs/heads/})
@@ -39,7 +39,7 @@ case "$state" in
     _describe -t tag 'tags' tags && ret=0
   ;;
   (file)
-    files=(${(0)"$(_call_program files git ls-files -z --exclude-standard 2>/dev/null)"})
+    files=(${(0)"$(_call_program files command git ls-files -z --exclude-standard 2>/dev/null)"})
     _wanted file expl 'file' _multi_parts - / files && ret=0
   ;;
 esac

--- a/modules/git/functions/_git-info
+++ b/modules/git/functions/_git-info
@@ -8,7 +8,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   return 1
 fi
 

--- a/modules/git/functions/_git-submodule-move
+++ b/modules/git/functions/_git-submodule-move
@@ -8,7 +8,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   return 1
 fi
 
@@ -25,7 +25,7 @@ case "$state" in
     while IFS=$'\n' read submodule; do
       submodules+=("$submodule")
     done < <(
-      git config --file "$(git-root)/.gitmodules" --list \
+      command git config --file "$(git-root)/.gitmodules" --list \
         | grep '.path=' \
         | cut -d= -f2-
     )

--- a/modules/git/functions/_git-submodule-remove
+++ b/modules/git/functions/_git-submodule-remove
@@ -8,7 +8,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   return 1
 fi
 
@@ -18,7 +18,7 @@ local submodule
 while IFS=$'\n' read submodule; do
   submodules+=("$submodule")
 done < <(
-  git config --file "$(git-root)/.gitmodules" --list \
+  command git config --file "$(git-root)/.gitmodules" --list \
     | grep '.path=' \
     | cut -d= -f2-
 )

--- a/modules/git/functions/git-branch-current
+++ b/modules/git/functions/git-branch-current
@@ -5,12 +5,12 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! git rev-parse 2> /dev/null; then
+if ! command git rev-parse 2> /dev/null; then
   print "$0: not a repository: $PWD" >&2
   return 1
 fi
 
-local ref="$(git symbolic-ref HEAD 2> /dev/null)"
+local ref="$(command git symbolic-ref HEAD 2> /dev/null)"
 
 if [[ -n "$ref" ]]; then
   print "${ref#refs/heads/}"

--- a/modules/git/functions/git-commit-lost
+++ b/modules/git/functions/git-commit-lost
@@ -5,15 +5,15 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
 
-git fsck 2> /dev/null \
+command git fsck 2> /dev/null \
   | grep "^dangling commit" \
   | awk '{print $3}' \
-  | git log \
+  | command git log \
       --date-order \
       --no-walk \
       --stdin \

--- a/modules/git/functions/git-dir
+++ b/modules/git/functions/git-dir
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-local git_dir="${$(git rev-parse --git-dir):A}"
+local git_dir="${$(command git rev-parse --git-dir):A}"
 
 if [[ -n "$git_dir" ]]; then
   print "$git_dir"

--- a/modules/git/functions/git-hub-browse
+++ b/modules/git/functions/git-hub-browse
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
@@ -13,7 +13,7 @@ fi
 local remotes remote references reference file url
 
 remote="${1:-origin}"
-remotes=($(git config --get-regexp 'remote.*.url' | cut -d. -f2))
+remotes=($(command git config --get-regexp 'remote.*.url' | cut -d. -f2))
 
 if (( $remotes[(i)$remote] == $#remotes + 1 )); then
   print "$0: remote not found: $remote" >&2
@@ -21,14 +21,14 @@ if (( $remotes[(i)$remote] == $#remotes + 1 )); then
 fi
 
 url=$(
-  git config --get "remote.${remote}.url" \
+  command git config --get "remote.${remote}.url" \
     | sed -En "s/(git|https?)(@|:\/\/)github.com(:|\/)(.+)\/(.+).git/https:\/\/github.com\/\4\/\5/p"
 )
 
 reference="${${2:-$(git-branch-current)}:-HEAD}"
 references=(
   HEAD
-  ${$(git ls-remote --heads --tags "$remote" | awk '{print $2}')##refs/(heads|tags)/}
+  ${$(command git ls-remote --heads --tags "$remote" | awk '{print $2}')##refs/(heads|tags)/}
 )
 
 if (( $references[(i)$reference] == $#references + 1 )); then
@@ -37,7 +37,7 @@ if (( $references[(i)$reference] == $#references + 1 )); then
 fi
 
 if [[ "$reference" == 'HEAD' ]]; then
-  reference="$(git rev-parse HEAD 2>/dev/null)"
+  reference="$(command git rev-parse HEAD 2>/dev/null)"
 fi
 
 file="$3"

--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -164,15 +164,15 @@ function git-info {
   typeset -gA git_info
 
   # Return if not inside a Git repository work tree.
-  if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+  if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
     return 1
   fi
 
   if (( $# > 0 )); then
     if [[ "$1" == [Oo][Nn] ]]; then
-      git config --bool prompt.showinfo true
+      command git config --bool prompt.showinfo true
     elif [[ "$1" == [Oo][Ff][Ff] ]]; then
-      git config --bool prompt.showinfo false
+      command git config --bool prompt.showinfo false
     else
       print "usage: $0 [ on | off ]" >&2
     fi
@@ -180,7 +180,7 @@ function git-info {
   fi
 
   # Return if git-info is disabled.
-  if ! is-true "${$(git config --bool prompt.showinfo):-true}"; then
+  if ! is-true "${$(command git config --bool prompt.showinfo):-true}"; then
     return 1
   fi
 
@@ -190,7 +190,7 @@ function git-info {
   # Format commit.
   zstyle -s ':prezto:module:git:info:commit' format 'commit_format'
   if [[ -n "$commit_format" ]]; then
-    commit="$(git rev-parse HEAD 2> /dev/null)"
+    commit="$(command git rev-parse HEAD 2> /dev/null)"
     if [[ -n "$commit" ]]; then
       zformat -f commit_formatted "$commit_format" "c:$commit"
     fi
@@ -199,7 +199,7 @@ function git-info {
   # Format stashed.
   zstyle -s ':prezto:module:git:info:stashed' format 'stashed_format'
   if [[ -n "$stashed_format" && -f "$(git-dir)/refs/stash" ]]; then
-    stashed="$(git stash list 2> /dev/null | wc -l | awk '{print $1}')"
+    stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
     if [[ -n "$stashed" ]]; then
       zformat -f stashed_formatted "$stashed_format" "S:$stashed"
     fi
@@ -215,7 +215,7 @@ function git-info {
   fi
 
   # Get the branch.
-  branch="${$(git symbolic-ref HEAD 2> /dev/null)#refs/heads/}"
+  branch="${$(command git symbolic-ref HEAD 2> /dev/null)#refs/heads/}"
 
   # Format branch.
   zstyle -s ':prezto:module:git:info:branch' format 'branch_format'
@@ -226,7 +226,7 @@ function git-info {
   # Format position.
   zstyle -s ':prezto:module:git:info:position' format 'position_format'
   if [[ -z "$branch" && -n "$position_format" ]]; then
-    position="$(git describe --contains --all HEAD 2> /dev/null)"
+    position="$(command git describe --contains --all HEAD 2> /dev/null)"
     if [[ -n "$position" ]]; then
       zformat -f position_formatted "$position_format" "p:$position"
     fi
@@ -236,7 +236,7 @@ function git-info {
   zstyle -s ':prezto:module:git:info:remote' format 'remote_format'
   if [[ -n "$branch" && -n "$remote_format" ]]; then
     # Gets the remote name.
-    remote_cmd='git rev-parse --symbolic-full-name --verify HEAD@{upstream}'
+    remote_cmd='command git rev-parse --symbolic-full-name --verify HEAD@{upstream}'
     remote="${$(${(z)remote_cmd} 2> /dev/null)##refs/remotes/}"
     if [[ -n "$remote" ]]; then
       zformat -f remote_formatted "$remote_format" "R:$remote"
@@ -247,7 +247,7 @@ function git-info {
   zstyle -s ':prezto:module:git:info:behind' format 'behind_format'
   if [[ -n "$branch" && ( -n "$ahead_format" || -n "$behind_format" ) ]]; then
     # Gets the commit difference counts between local and remote.
-    ahead_and_behind_cmd='git rev-list --count --left-right HEAD...@{upstream}'
+    ahead_and_behind_cmd='command git rev-list --count --left-right HEAD...@{upstream}'
 
     # Get ahead and behind counts.
     ahead_and_behind="$(${(z)ahead_and_behind_cmd} 2> /dev/null)"
@@ -276,7 +276,7 @@ function git-info {
     if [[ -n "$indexed_format" ]]; then
       ((
         indexed+=$(
-          git diff-index \
+          command git diff-index \
             --no-ext-diff \
             --name-only \
             --cached \
@@ -296,7 +296,7 @@ function git-info {
     if [[ -n "$unindexed_format" ]]; then
       ((
         unindexed+=$(
-          git diff-files \
+          command git diff-files \
             --no-ext-diff \
             --name-only \
             --ignore-submodules=${ignore_submodules:-none} \
@@ -314,7 +314,7 @@ function git-info {
     if [[ -n "$untracked_format" ]]; then
       ((
         untracked+=$(
-          git ls-files \
+          command git ls-files \
             --other \
             --exclude-standard \
             2> /dev/null \
@@ -329,7 +329,7 @@ function git-info {
     (( dirty = indexed + unindexed + untracked ))
   else
     # Use porcelain status for easy parsing.
-    status_cmd="git status --porcelain --ignore-submodules=${ignore_submodules:-none}"
+    status_cmd="command git status --porcelain --ignore-submodules=${ignore_submodules:-none}"
 
     # Get current status.
     while IFS=$'\n' read line; do

--- a/modules/git/functions/git-root
+++ b/modules/git/functions/git-root
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-local root="$(git rev-parse --show-toplevel 2> /dev/null)"
+local root="$(command git rev-parse --show-toplevel 2> /dev/null)"
 
 if [[ -n "$root" ]]; then
   print "$root"

--- a/modules/git/functions/git-stash-clear-interactive
+++ b/modules/git/functions/git-stash-clear-interactive
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
@@ -13,10 +13,10 @@ fi
 local stashed
 
 if [[ -f "$(git-dir)/refs/stash" ]]; then
-  stashed="$(git stash list 2> /dev/null | wc -l | awk '{print $1}')"
+  stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
   if (( $stashed > 0 )); then
     if read -q "?Clear $stashed stashed state(s) [y/N]? "; then
-      git stash clear
+      command git stash clear
     fi
   fi
 fi

--- a/modules/git/functions/git-stash-dropped
+++ b/modules/git/functions/git-stash-dropped
@@ -5,15 +5,15 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
 
-git fsck --unreachable 2> /dev/null \
+command git fsck --unreachable 2> /dev/null \
   | grep 'commit' \
   | awk '{print $3}' \
-  | git log \
+  | command git log \
       --pretty=format:${_git_log_oneline_format} \
       --extended-regexp \
       --grep="${1:-(WIP )?[Oo]n [^:]+:}" \

--- a/modules/git/functions/git-stash-recover
+++ b/modules/git/functions/git-stash-recover
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
@@ -13,7 +13,7 @@ fi
 local commit
 
 for commit in "$@"; do
-  git update-ref \
-    -m "$(git log -1 --pretty="format:%s" "$commit")" refs/stash "$commit"
+  command git update-ref \
+    -m "$(command git log -1 --pretty="format:%s" "$commit")" refs/stash "$commit"
 done
 

--- a/modules/git/functions/git-submodule-move
+++ b/modules/git/functions/git-submodule-move
@@ -5,7 +5,7 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 elif [[ "$PWD" != "$(git-root)" ]]; then
@@ -17,7 +17,7 @@ local src="$1"
 local dst="$2"
 local url
 
-url="$(git config --file "$(git-root)/.gitmodules" --get "submodule.${src}.url")"
+url="$(command git config --file "$(git-root)/.gitmodules" --get "submodule.${src}.url")"
 
 if [[ -z "$url" ]]; then
   print "$0: submodule not found: $src" >&2
@@ -27,7 +27,7 @@ fi
 mkdir -p "${dst:h}"
 
 git-submodule-remove "$src"
-git submodule add "$url" "$dst"
+command git submodule add "$url" "$dst"
 
 return 0
 

--- a/modules/git/functions/git-submodule-remove
+++ b/modules/git/functions/git-submodule-remove
@@ -5,22 +5,22 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 elif [[ "$PWD" != "$(git-root)" ]]; then
   print "$0: must be run from the root of the work tree" >&2
   return 1
-elif ! git config --file .gitmodules --get "submodule.${1}.path" &>/dev/null; then
+elif ! command git config --file .gitmodules --get "submodule.${1}.path" &>/dev/null; then
   print "$0: submodule not found: $1" >&2
   return 1
 fi
 
-git config --file "$(git-dir)/config" --remove-section "submodule.${1}" &>/dev/null
-git config --file "$(git-root)/.gitmodules" --remove-section "submodule.${1}" &>/dev/null
-git add .gitmodules
+command git config --file "$(git-dir)/config" --remove-section "submodule.${1}" &>/dev/null
+command git config --file "$(git-root)/.gitmodules" --remove-section "submodule.${1}" &>/dev/null
+command git add .gitmodules
 
-git rm --cached -rf "${1}"
+command git rm --cached -rf "${1}"
 rm -rf "${1}"
 rm -rf "$(git-dir)/modules/${1}"
 

--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -10,7 +10,7 @@ function diff {
     if (( $+commands[colordiff] )); then
       command diff --unified "$@" | colordiff --difftype diffu
     elif (( $+commands[git] )); then
-      git --no-pager diff --color=auto --no-ext-diff --no-index "$@"
+      command git --no-pager diff --color=auto --no-ext-diff --no-index "$@"
     else
       command diff --unified "$@"
     fi

--- a/modules/utility/functions/wdiff
+++ b/modules/utility/functions/wdiff
@@ -17,7 +17,7 @@ function wdiff {
         "$@" \
       | sed 's/^\(@@\( [+-][[:digit:]]*,[[:digit:]]*\)\{2\} @@\)$/;5;6m\10m/g'
     elif (( $+commands[git] )); then
-      git --no-pager diff --color=auto --no-ext-diff --no-index --color-words "$@"
+      command git --no-pager diff --color=auto --no-ext-diff --no-index --color-words "$@"
     else
       command wdiff "$@"
     fi


### PR DESCRIPTION
If git is aliased to hub the performance of the git module was very poor. The prompt was very laggy. 

I replaced all occurences of `git` with `command git` and used it for a while now. Performance is back to normal and all git infos are displayed nicely.
