### PR TITLE
Use the `x` command for unrar and rar to preserve paths

### DIFF
--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -54,8 +54,8 @@ while (( $# > 0 )); do
     (*.Z) uncompress "$1" ;;
     (*.zip) unzip "$1" -d $extract_dir ;;
     (*.rar) unrar &> /dev/null \
-      && unrar e -ad "$1" \
-      || rar e -ad "$1" ;;
+      && unrar x -ad "$1" \
+      || rar x -ad "$1" ;;
     (*.7z) 7za x "$1" ;;
     (*.deb)
       mkdir -p "$extract_dir/control"


### PR DESCRIPTION
unrar and rar will discard everything up to the file name when extracting with `e`. This breaks extraction of archives that have files with duplicate file names and ones where the paths are important. The `x` command extracts with the full path instead.
