### PR TITLE
node module: Don't set node-info if version is 'none'

### DIFF
--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -17,7 +17,7 @@ if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
 fi
 
-if [[ -n "$version" ]]; then
+if [[ -n "$version" && $version != 'none' ]]; then
   zstyle -s ':prezto:module:node:info:version' format 'version_format'
   zformat -f version_formatted "$version_format" "v:$version"
   node_info[version]="$version_formatted"


### PR DESCRIPTION
Not sure if this is a recent change, but running `nvm_version` without a node version currently active echoes "none" instead of an empty string; it also returns 0, so we can't check the return value to determine if there is a currently active node version. So, this PR explicitly checks if `'none'` was echoed, and if so, doesn't set the version in `node_info`.

The main benefit of this is to make it easier to not show node-info in themes when no node version is currently in use. In addition, this change makes the node module consistent with the Python module's python-info, which also does not set `python_info` is no virtual environment is currently active.
