### PR TITLE
Allow to load prezto modules from an alternate path

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -23,15 +23,22 @@ unset min_zsh_version
 
 # Loads Prezto modules.
 function pmodload {
+  pmodload_path "${ZDOTDIR:-$HOME}/.zprezto/modules" "$argv[@]"
+}
+
+function pmodload_path {
   local -a pmodules
+  local modules_path
   local pmodule
   local pfunction_glob='^([_.]*|prompt_*_setup|README*)(-.N:t)'
 
+  modules_path="${argv[1]}"
+  shift
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")
 
   # Add functions to $fpath.
-  fpath=(${pmodules:+${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions(/FN)} $fpath)
+  fpath=(${pmodules:+${modules_path}/${^pmodules}/functions(/FN)} $fpath)
 
   function {
     local pfunction
@@ -40,7 +47,7 @@ function pmodload {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
     # Load Prezto functions.
-    for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions/$~pfunction_glob; do
+    for pfunction in ${modules_path}/${^pmodules}/functions/$~pfunction_glob; do
       autoload -Uz "$pfunction"
     done
   }
@@ -49,19 +56,19 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    elif [[ ! -d "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule" ]]; then
+    elif [[ ! -d "${modules_path}/$pmodule" ]]; then
       print "$0: no such module: $pmodule" >&2
       continue
     else
-      if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh" ]]; then
-        source "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh"
+      if [[ -s "${modules_path}/$pmodule/init.zsh" ]]; then
+        source "${modules_path}/$pmodule/init.zsh"
       fi
 
       if (( $? == 0 )); then
         zstyle ":prezto:module:$pmodule" loaded 'yes'
       else
         # Remove the $fpath entry.
-        fpath[(r)${ZDOTDIR:-$HOME}/.zprezto/modules/${pmodule}/functions]=()
+        fpath[(r)${modules_path}/${pmodule}/functions]=()
 
         function {
           local pfunction
@@ -71,7 +78,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in ${modules_path}/$pmodule/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }


### PR DESCRIPTION
Hello guys, this change allows you to load prezto modules from a user-specified directory.
It is useful to me when I create modules that I don't want to commit to the prezto repository because they are too specific to be useful to anyone or because they contain confidential data.
It can be used like that

```
zstyle ':prezto:load' user_pmodules_path "$HOME/.zsh/modules"
zstyle ':prezto:load' user_pmodule \
  'mymodule'
```

I have considered making `pmodload` use a search path variable (like $path or $fpath) but it makes things a bit more complicated. What do you think?
Cheers
