### PR TITLE
Port the oh-my-zsh cloud theme to prezto.

### DIFF
--- a/modules/prompt/functions/prompt_cloud_setup
+++ b/modules/prompt/functions/prompt_cloud_setup
@@ -80,20 +80,20 @@ function prompt_cloud_setup {
 
   # Set the theme prefix to a cloud or to the user's given characters.
   if [[ -n "$1" ]]; then
-    prefix=$1
+    prefix="$1"
   else
     prefix='☁'
   fi
 
   # Assign colors.
   if [[ -n "$2" ]]; then
-    primary_color=$2
+    primary_color="$2"
   else
     primary_color='cyan'
   fi
 
   if [[ -n "$3" ]]; then
-    secondary_color=$3
+    secondary_color="$3"
   else
     secondary_color='green'
   fi


### PR DESCRIPTION
I recently switched from oh-my-zsh to prezto. I love it, but I missed my old theme, so I ported it over. Maybe y'all will have a use for it too. 

This is a port of oh-my-zsh's [cloud theme](https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/cloud.zsh-theme) to prezto. The prompts are the same as the omz version, but instead of defining the prompt's prefix in the `ZSH_THEME_CLOUD_PREFIX` environment variable it's done via the config. That seemed like a more prezto-ish way to do it. Hope y'all like it.

The original oh-my-zsh version:
![Original Screenshot](https://camo.githubusercontent.com/97f24b7ff6670393f4414d81532e1431ef4fbe7c/687474703a2f2f662e636c2e6c792f6974656d732f31346635383037653838373131323264396665302f636c6f75642e706e67)

The ported prezto version:
![Ported Screenshot](http://i.imgur.com/mJCZ8rE.png)
