### PR TITLE
ssh: Set default SSH_AGENT_PID for grep

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -25,7 +25,7 @@ if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
   source "$_ssh_agent_env" 2> /dev/null
 
   # Start ssh-agent if not started.
-  if ! ps -U "$USER" -o pid,ucomm | grep -q "${SSH_AGENT_PID} ssh-agent"; then
+  if ! ps -U "$USER" -o pid,ucomm | grep -q -- "${SSH_AGENT_PID:--1} ssh-agent"; then
     eval "$(ssh-agent | sed '/^echo /d' | tee "$_ssh_agent_env")"
   fi
 fi


### PR DESCRIPTION
- If `SSH_AGENT_PID` is unset, grep will succeed if another ssh-agent is
  running as it will match the string `ssh-agent` where the PID was an
  empty string.
- Set a default value for the grep to a value that will never match if
  unset, i.e. -1.
