### PR TITLE
Python virtualenvwrapper workon crashing when tabbing.

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -35,14 +35,14 @@ if (( ! $+commands[python] && ! $+commands[pyenv] )); then
 fi
 
 # Load virtualenvwrapper into the shell session.
-if (( $+commands[virtualenvwrapper_lazy.sh] )); then
+if (( $+commands[virtualenvwrapper.sh] )); then
   # Set the directory where virtual environments are stored.
   export WORKON_HOME="$HOME/.virtualenvs"
 
   # Disable the virtualenv prompt.
   VIRTUAL_ENV_DISABLE_PROMPT=1
 
-  source "$commands[virtualenvwrapper_lazy.sh]"
+  source "$commands[virtualenvwrapper.sh]"
 fi
 
 #


### PR DESCRIPTION
Mac 10.9.4 using iTerm2 

When in a new terminal session tabbing to list virtualevn's using workon crashes the session. Using the same fix found on the oh-my-zsh thread below fixed the issue for me.

https://github.com/robbyrussell/oh-my-zsh/issues/2355
