### PR TITLE
prompt: added clover theme

### DIFF
--- a/modules/prompt/functions/prompt_clover_setup
+++ b/modules/prompt/functions/prompt_clover_setup
@@ -78,7 +78,6 @@ function prompt_clover_setup {
 	esac
 
 	# Need this so the prompt will work
-	setopt LOCAL_OPTIONS
 	setopt PROMPT_SUBST
 	setopt EXTENDED_GLOB
 	unsetopt BRACE_CCL


### PR DESCRIPTION
Please pull this branch into sorin-ionescu/master.

This branch add a prompt theme with configurable colors (either 4 or 8 colors). The does works as expected minus the first loding with prompt... it requires sourcing it in ~/.zshrc first. It works as expected afterwards. Even with numerous theme switching.

I cannot found the origin of this issue. BRACE_CCL is problematic with this theme. Maybe a LOCAL_OPTIONS should be added first to avoid a conflict with environment module.

![](https://imgur.com/10w3Tzu.png)
