### PR TITLE
Avoids errors when running prezto in Emacs terminals

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$TERM" == 'dumb' ]]; then
+if [[ "$TERM" == 'dumb' ]] || [[ "$TERM" == 'eterm-color' ]]; then
   return 1
 fi
 


### PR DESCRIPTION
Without this, running `zsh` in Emacs' `ansi-terminal` caused errors. This prevents that.
