### PR TITLE
modules: git-info: diverged subcontext for prompt formatting

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -254,6 +254,7 @@ setting a style is as follows.
 | action    |     %s      | Special action name
 | ahead     |     %A      | Commits ahead of remote count
 | behind    |     %B      | Commits behind of remote count
+| diverged  |     %V      | Diverged from remote state
 | branch    |     %b      | Branch name
 | commit    |     %c      | Commit hash
 | position  |     %p      | Commits from the nearest tag count

--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -125,6 +125,8 @@ function git-info {
   local dirty=0
   local dirty_format
   local dirty_formatted
+  local diverged
+  local diverged_formatted
   local ignore_submodules
   local indexed=0
   local indexed_format
@@ -252,9 +254,14 @@ function git-info {
     # Get ahead and behind counts.
     ahead_and_behind="$(${(z)ahead_and_behind_cmd} 2> /dev/null)"
 
+    ahead="$ahead_and_behind[(w)1]"
+    behind="$ahead_and_behind[(w)2]"
+    if (( ahead > 0 )) && (( behind > 0 )); then
+      zstyle -s ':prezto:module:git:info:diverged' format 'diverged_formatted'
+    fi
+
     # Format ahead.
     if [[ -n "$ahead_format" ]]; then
-      ahead="$ahead_and_behind[(w)1]"
       if (( ahead > 0 )); then
         zformat -f ahead_formatted "$ahead_format" "A:$ahead"
       fi
@@ -262,7 +269,6 @@ function git-info {
 
     # Format behind.
     if [[ -n "$behind_format" ]]; then
-      behind="$ahead_and_behind[(w)2]"
       if (( behind > 0 )); then
         zformat -f behind_formatted "$behind_format" "B:$behind"
       fi
@@ -411,7 +417,8 @@ function git-info {
       "s:$action_formatted" \
       "S:$stashed_formatted" \
       "U:$unmerged_formatted" \
-      "u:$untracked_formatted"
+      "u:$untracked_formatted" \
+      "V:$diverged_formatted"
     git_info[$info_format]="$REPLY"
   done
 


### PR DESCRIPTION
The diff should be obvious enough - I prefer to see the fact that remote and local have diverged, rather than the numbers of commits ahead or behind.

Let me know if there's anything else that needs to doing to have this accepted.
