### PR TITLE
Display full command line on suggestion for the kill command

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -116,7 +116,7 @@ zstyle ':completion:*:(rm|kill|diff):*' ignore-line other
 zstyle ':completion:*:rm:*' file-patterns '*:all-files'
 
 # Kill
-zstyle ':completion:*:*:*:*:processes' command 'ps -u $USER -o pid,user,comm -w'
+zstyle ':completion:*:*:*:*:processes' command 'ps -u $USER -o pid,user,command -w'
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#) ([0-9a-z-]#)*=01;36=0=01'
 zstyle ':completion:*:*:kill:*' menu yes select
 zstyle ':completion:*:*:kill:*' force-list always


### PR DESCRIPTION
How about showing full command line (command: usually with arguments)
instead of only the executable name (comm), in the 'kill' command suggestions?

Previously:

![](http://i.imgur.com/8iY0mOf.png)

After fixed:

![](http://i.imgur.com/sa7X8rg.png)

which is very useful when choosing a CPU-consuming process,
with multiple instances of the same executable.
