### PR TITLE
Enable 'acls', 'xattrs' support in rsync whenever available.

### DIFF
--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -16,10 +16,14 @@ fi
 
 _rsync_cmd='rsync --verbose --progress --human-readable --compress --archive --hard-links --one-file-system'
 
+if grep -q 'xattrs' <(rsync --help 2>&1); then
+  _rsync_cmd="${_rsync_cmd} --acls --xattrs"
+fi
+
 # Mac OS X and HFS+ Enhancements
 # http://help.bombich.com/kb/overview/credits#opensource
 if [[ "$OSTYPE" == darwin* ]] && grep -q 'file-flags' <(rsync --help 2>&1); then
-  _rsync_cmd="${_rsync_cmd} --crtimes --acls --xattrs --fileflags --protect-decmpfs --force-change"
+  _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --protect-decmpfs --force-change"
 fi
 
 alias rsync-copy="${_rsync_cmd}"


### PR DESCRIPTION
rsync has support for these available in most cases and isn't
specific to Mac OS X any more.
