### PR TITLE
Try alternative NVM location if installed via Homebrew on OS X.

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -9,6 +9,11 @@
 # Load NVM into the shell session.
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   source "$HOME/.nvm/nvm.sh"
+elif [[ "$OSTYPE" == darwin* ]]; then
+  # Try alternative NVM location if installed via Homebrew (See: `brew info nvm`)
+  if (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2> /dev/null)" ]]; then
+    source $(brew --prefix nvm)/nvm.sh
+  fi
 fi
 
 # Return if requirements are not found.


### PR DESCRIPTION
On Mac OS X, `nvm` is usually installed via Homebrew with full path `$(brew --prefix nvm)/nvm.sh`.
We try looking up the location in case `nvm.sh` isn't available in `~/.nvm/nvm.sh`.
