### PR TITLE
Add --get-dir flag to target .zprezto git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Updating
 
 Pull the latest changes and update submodules.
 
-    git --git-dir "${ZDOTDIR:-$HOME}/.zprezto/.git" pull
-    git --git-dir "${ZDOTDIR:-$HOME}/.zprezto/.git" submodule update --init --recursive
+    git --git-dir "${ZDOTDIR:-$HOME}/.zprezto/.git" --work-tree="${ZDOTDIR:-$HOME}/.zprezto" pull
+    git --git-dir "${ZDOTDIR:-$HOME}/.zprezto/.git" --work-tree="${ZDOTDIR:-$HOME}/.zprezto" submodule update --init --recursive
 
 Usage
 -----


### PR DESCRIPTION
This specifically targets the repository in the `.zprezto` directory so that Prezto can be updated from anywhere just by copy and pasting, rather than expecting the user to know that they need to do:

``` sh
cd "${ZDOTDIR:-$HOME}/.zprezto/"
git pull && git submodule update --init --recursive
cd -
```
