### PR TITLE
Fix git log pretty format argument

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -100,12 +100,12 @@ alias gix='git rm -r --cached'
 alias giX='git rm -rf --cached'
 
 # Log (l)
-alias gl='git log --topo-order --pretty=format:${_git_log_medium_format}'
-alias gls='git log --topo-order --stat --pretty=format:${_git_log_medium_format}'
-alias gld='git log --topo-order --stat --patch --full-diff --pretty=format:${_git_log_medium_format}'
-alias glo='git log --topo-order --pretty=format:${_git_log_oneline_format}'
-alias glg='git log --topo-order --all --graph --pretty=format:${_git_log_oneline_format}'
-alias glb='git log --topo-order --pretty=format:${_git_log_brief_format}'
+alias gl='git log --topo-order --pretty=format:"${_git_log_medium_format}"'
+alias gls='git log --topo-order --stat --pretty=format:"${_git_log_medium_format}"'
+alias gld='git log --topo-order --stat --patch --full-diff --pretty=format:"${_git_log_medium_format}"'
+alias glo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
+alias glg='git log --topo-order --all --graph --pretty=format:"${_git_log_oneline_format}"'
+alias glb='git log --topo-order --pretty=format:"${_git_log_brief_format}"'
 alias glc='git shortlog --summary --numbered'
 
 # Merge (m)


### PR DESCRIPTION
Hello,

after updating Git to version 2.1.1 (on Elementary OS Luna) all the git log related aliases stopped working showing "Invalid object name". After some digging I found that its because of the way the format arguments are passed to the git command. This PR issues that.
