### PR TITLE
Fix node-info to show right node version

### DIFF
--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -17,7 +17,7 @@ if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
 fi
 
-if [[ "$version" == (none|) ]]; then
+if [[ "$version" != (none|) ]]; then
   zstyle -s ':prezto:module:node:info:version' format 'version_format'
   zformat -f version_formatted "$version_format" "v:$version"
   node_info[version]="$version_formatted"


### PR DESCRIPTION
Currently, node-info shows nothing if $version is different than 'none'.
