### PR TITLE
Prefer 'minimal' prompt in console (monitor)

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -85,7 +85,12 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # Set the prompt theme to load.
 # Setting it to 'random' loads a random theme.
 # Auto set to 'off' on dumb terminals.
-zstyle ':prezto:module:prompt' theme 'sorin'
+# Prefer 'minimal' prompt in console (monitor)
+if [[ "$TERM" == (linux|*bsd*) ]]; then
+  zstyle ':prezto:module:prompt' theme 'minimal'
+else
+  zstyle ':prezto:module:prompt' theme 'sorin'
+fi
 
 #
 # Ruby


### PR DESCRIPTION
Most linux terminal consoles would have difficulty rendering unicode charset OOTB.
In such cases, fallback to minimal prompt by default (instead of switching of completely).
