### PR TITLE
Use short apothegms only in fortune

### DIFF
--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -17,7 +17,7 @@
 # Print a random, hopefully interesting, adage.
 if (( $+commands[fortune] )); then
   if [[ -t 0 || -t 1 ]]; then
-    fortune -a
+    fortune -s
     print
   fi
 fi


### PR DESCRIPTION
This avoids situation where large fortune message eats up most of the screen real estate (at which point it isn't funny anymore).
