### PR TITLE
Remove extra git-dir call in git-info and use git_dir variable instead

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -198,7 +198,7 @@ function git-info {
 
   # Format stashed.
   zstyle -s ':prezto:module:git:info:stashed' format 'stashed_format'
-  if [[ -n "$stashed_format" && -f "$(git-dir)/refs/stash" ]]; then
+  if [[ -n "$stashed_format" && -f "${git_dir}/refs/stash" ]]; then
     stashed="$(git stash list 2> /dev/null | wc -l | awk '{print $1}')"
     if [[ -n "$stashed" ]]; then
       zformat -f stashed_formatted "$stashed_format" "S:$stashed"


### PR DESCRIPTION
This avoids an extra `git rev-parse --git-dir` shellout when displaying git info in prompt.

Before:

```
~/.dotfiles master $ export GIT_TRACE=1
15:43:40.670779 git.c:349               trace: built-in: git 'config' '--bool' 'prompt.showinfo'    
15:43:40.682923 git.c:349               trace: built-in: git 'rev-parse' '--git-dir'
15:43:40.690074 git.c:349               trace: built-in: git 'rev-parse' '--git-dir'
~/.dotfiles master $
```

After:

```
~/.dotfiles master $ export GIT_TRACE=1
15:43:58.904774 git.c:349               trace: built-in: git 'config' '--bool' 'prompt.showinfo'    
15:43:58.915877 git.c:349               trace: built-in: git 'rev-parse' '--git-dir'
~/.dotfiles master $
```
