### PR TITLE
Restart Zsh without opening new window or tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ version is 4.3.17.
 
   5. Restart Zsh:
   
-        exec $SHELL -li
+        exec $commands[zsh]
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ version is 4.3.17.
 
         chsh -s /bin/zsh
 
-  5. Open a new Zsh terminal window or tab.
+  5. Restart Zsh:
+  
+        exec $SHELL
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ version is 4.3.17.
 
   5. Restart Zsh:
   
-        exec $SHELL -l
+        exec $SHELL -li
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ version is 4.3.17.
 
   5. Restart Zsh:
   
-        exec $SHELL
+        exec $SHELL -l
 
 ### Troubleshooting
 


### PR DESCRIPTION
It seems that you could just use `exec $SHELL` instead of manually opening a new system or tab. Is there any reason not to do this?
