### PR TITLE
Add a hook to set the gpg-agent tty

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -35,6 +35,13 @@ if grep 'enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then
 
   # Load the SSH module for additional processing.
   pmodload 'ssh'
+
+  # ssh doesn't set the gpg-agent tty when asking for the key.
+  # This updates the tty before every command as a workaround
+  function _gpg-agent-update-tty() {
+    gpg-connect-agent updatestartuptty /bye > /dev/null
+  }
+  add-zsh-hook preexec _gpg-agent-update-tty
 fi
 
 # Clean up.


### PR DESCRIPTION
Using the gpg-agent with ssh can be a problem when using multiple tty (like with tmux). According to gpg documentation:

> SSH has no way to tell the gpg-agent what terminal or X display it is running on. So when remotely logging into a box where a gpg-agent with SSH support is running, the pinentry will get popped up on whatever display the gpg-agent has been started. To solve this problem you may issue the command
> 
> ```
> echo UPDATESTARTUPTTY | gpg-connect-agent
> ```
> 
> and the next pinentry will pop up on your display or screen. However, you need to kill the running pinentry first because only one pinentry may be running at once. If you plan to use ssh on a new display you should issue the above command before invoking ssh or any other service making use of ssh.

This proposed solution updates the tty before every command (if you use gpg-agent for ssh). Maybe there's a way to be a bit more selective but I don't know how :confused:.
