### PR TITLE
gpg: check for S.gpg-agent to see if gpg-agent is running

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -15,7 +15,7 @@ _gpg_agent_conf="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.conf"
 _gpg_agent_env="${TMPDIR:-/tmp}/gpg-agent.env"
 
 # Start gpg-agent if not started.
-if [[ -z "$GPG_AGENT_INFO" ]]; then
+if [[ -z "$GPG_AGENT_INFO" && ! -S "${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent" ]]; then
   # Export environment variables.
   source "$_gpg_agent_env" 2> /dev/null
 


### PR DESCRIPTION
from gpg changelog:

>  Removed the GPG_AGENT_INFO related code.  GnuPG does now
>  always use a fixed socket name in its home directory.

This is basically the same fix as PaBLoX-CL posted in https://github.com/sorin-ionescu/prezto/issues/689
