### PR TITLE
Fix themes which cause errors if the git module is not loaded.

### DIFF
--- a/modules/prompt/functions/prompt_cloud_setup
+++ b/modules/prompt/functions/prompt_cloud_setup
@@ -114,7 +114,7 @@ function prompt_cloud_setup {
     'rprompt' ''
 
   # Define prompts.
-  PROMPT='%B%F{$primary_color}${prefix}%f%b  %B%F{$secondary_color}%c%f%b $git_info[prompt] '
+  PROMPT='%B%F{$primary_color}${prefix}%f%b  %B%F{$secondary_color}%c%f%b ${git_info:+${(e)git_info[prompt]}} '
   RPROMPT=''
 }
 

--- a/modules/prompt/functions/prompt_kylewest_setup
+++ b/modules/prompt/functions/prompt_kylewest_setup
@@ -58,7 +58,7 @@ function prompt_kylewest_setup {
   zstyle ':prezto:module:ruby:info:version' format '%F{blue}[%v]%f'
 
   # Define prompts.
-  PROMPT='%F{cyan}%c%f ${git_info[prompt]}${editor_info[keymap]} '
+  PROMPT='%F{cyan}%c%f ${git_info:+${(e)git_info[prompt]}}${editor_info[keymap]} '
   RPROMPT='${ruby_info[version]}'
 }
 

--- a/modules/prompt/functions/prompt_skwp_setup
+++ b/modules/prompt/functions/prompt_skwp_setup
@@ -68,7 +68,7 @@ function prompt_skwp_setup {
   zstyle ':prezto:module:ruby:info:version' format '[%v]'
 
   # Define prompts.
-  PROMPT="${_prompt_skwp_colors[3]}%n%f@${_prompt_skwp_colors[2]}%m%f ${_prompt_skwp_colors[5]}%~%f "'$git_info[prompt]'"$ "
+  PROMPT="${_prompt_skwp_colors[3]}%n%f@${_prompt_skwp_colors[2]}%m%f ${_prompt_skwp_colors[5]}%~%f "'${git_info:+${(e)git_info[prompt]}}'"$ "
   RPROMPT='%F{blue}${ruby_info[version]}'
 }
 

--- a/modules/prompt/functions/prompt_smiley_setup
+++ b/modules/prompt/functions/prompt_smiley_setup
@@ -57,7 +57,7 @@ function prompt_smiley_setup {
   zstyle ':prezto:module:git:info:keys' format 'prompt' '(%b%D)'
 
   # Define prompts.
-  PROMPT='$python_info[virtualenv]$ruby_info[version]${git_info[prompt]} %B%c%b %(?:%F{green}ツ%f:%F{red}✖%f) '
+  PROMPT='$python_info[virtualenv]$ruby_info[version]${git_info:+${(e)git_info[prompt]}} %B%c%b %(?:%F{green}ツ%f:%F{red}✖%f) '
   RPROMPT='${editor_info[overwrite]}${VIM:+" %B%F{green}V%f%b"}'
   SPROMPT='zsh: correct %F{red}%R%f to %F{green}%r%f [nyae]? '
 }


### PR DESCRIPTION
This change wraps the git_info call in several themes, preventing errors that occur if the themes are used without the git module being enabled. Should fix https://github.com/sorin-ionescu/prezto/issues/743.
