### PR TITLE
Fix stashed count

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -95,8 +95,6 @@ function git-info {
   setopt LOCAL_OPTIONS
   setopt EXTENDED_GLOB
 
-  local git_dir="$(git-dir)"
-
   local action
   local action_format
   local action_formatted
@@ -169,6 +167,8 @@ function git-info {
   if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
     return 1
   fi
+
+  local git_dir="$(git-dir)"
 
   if (( $# > 0 )); then
     if [[ "$1" == [Oo][Nn] ]]; then


### PR DESCRIPTION
The variable `git_dir` was not available in the context of the
function `git-info`. It was only defined in the function `_git-action`.

It is only used to determine if there is a stash and then set the stashed count: [git-info#L203](https://github.com/eugenk/prezto/blob/fix_stashed_count/modules/git/functions/git-info#L203)
