### PR TITLE
Allow directories customizations

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -6,6 +6,15 @@
 #
 
 #
+# Configuration
+#
+
+# Set PREZTO_DIR to the default value if not already set
+if [ -z "${PREZTO_DIR}" ]; then
+  PREZTO_DIR=${ZDOTDIR:-$HOME}/.zprezto
+fi
+
+#
 # Version Check
 #
 
@@ -31,7 +40,7 @@ function pmodload {
   pmodules=("$argv[@]")
 
   # Add functions to $fpath.
-  fpath=(${pmodules:+${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions(/FN)} $fpath)
+  fpath=(${pmodules:+${PREZTO_DIR}/modules/${^pmodules}/functions(/FN)} $fpath)
 
   function {
     local pfunction
@@ -40,7 +49,7 @@ function pmodload {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
     # Load Prezto functions.
-    for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions/$~pfunction_glob; do
+    for pfunction in ${PREZTO_DIR}/modules/${^pmodules}/functions/$~pfunction_glob; do
       autoload -Uz "$pfunction"
     done
   }

--- a/init.zsh
+++ b/init.zsh
@@ -11,7 +11,12 @@
 
 # Set PREZTO_DIR to the default value if not already set
 if [ -z "${PREZTO_DIR}" ]; then
-  PREZTO_DIR=${ZDOTDIR:-$HOME}/.zprezto
+  PREZTO_DIR="${ZDOTDIR:-$HOME}/.zprezto"
+fi
+
+# Set PREZTORC to the default value if not already set
+if [ -z "${PREZTORC}" ]; then
+  PREZTORC="${ZDOTDIR:-$HOME}/.zpreztorc"
 fi
 
 #
@@ -58,19 +63,19 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    elif [[ ! -d "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule" ]]; then
+    elif [[ ! -d "${PREZTO_DIR}/modules/$pmodule" ]]; then
       print "$0: no such module: $pmodule" >&2
       continue
     else
-      if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh" ]]; then
-        source "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh"
+      if [[ -s "${PREZTO_DIR}/modules/$pmodule/init.zsh" ]]; then
+        source "${PREZTO_DIR}/modules/$pmodule/init.zsh"
       fi
 
       if (( $? == 0 )); then
         zstyle ":prezto:module:$pmodule" loaded 'yes'
       else
         # Remove the $fpath entry.
-        fpath[(r)${ZDOTDIR:-$HOME}/.zprezto/modules/${pmodule}/functions]=()
+        fpath[(r)${PREZTO_DIR}/modules/${pmodule}/functions]=()
 
         function {
           local pfunction
@@ -80,7 +85,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in ${PREZTO_DIR}/modules/$pmodule/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }
@@ -96,8 +101,8 @@ function pmodload {
 #
 
 # Source the Prezto configuration file.
-if [[ -s "${ZDOTDIR:-$HOME}/.zpreztorc" ]]; then
-  source "${ZDOTDIR:-$HOME}/.zpreztorc"
+if [[ -s "${PREZTORC}" ]]; then
+  source ${PREZTORC}
 fi
 
 # Disable color and theme in dumb terminals.


### PR DESCRIPTION
This is a simple change.
I've just added the possibility to specify the following paths:
- `PREZTO_DIR`: The prezto directory
- `PREZTORC`: The path for the prezto configuration file

**This allows the user to use custom locations, which is really useful sometimes...**

I've tested the changes, it will work without breaking compatibility. By default, the paths are the current values, so users can just ignore the change if they aren't pro-users and don't want custom locations.

Thanks
