### PR TITLE
Added transfer module. Allows command line file sharing.

### DIFF
--- a/modules/transfer/README.md
+++ b/modules/transfer/README.md
@@ -1,0 +1,14 @@
+Transfer.sh
+==========
+
+Defines [transfer][https://transfer.sh/] aliases for easy file sharing from the commandline.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Remco Verhoef](https://github.com/dutchcoders)
+
+[1]: https://transfer.sh/
+[2]: https://github.com/dutchcoders/transfer.sh/

--- a/modules/transfer/README.md
+++ b/modules/transfer/README.md
@@ -1,7 +1,7 @@
 Transfer.sh
 ==========
 
-Defines [transfer][https://transfer.sh/] aliases for easy file sharing from the commandline.
+Defines [transfer][https://transfer.sh/] alias for easy file sharing from the commandline.
 
 Authors
 -------

--- a/modules/transfer/init.zsh
+++ b/modules/transfer/init.zsh
@@ -55,6 +55,3 @@ transfer() {
     # cleanup
     rm -f $tmpfile
 }
-
-alias transfer=transfer
-

--- a/modules/transfer/init.zsh
+++ b/modules/transfer/init.zsh
@@ -1,0 +1,60 @@
+#
+# Defines transfer alias and provides easy command line file and folder sharing.
+#
+# Authors:
+#   Remco Verhoef <remco@dutchcoders.io>
+#
+
+if (( ! $+commands[curl] )); then
+  return 1
+fi
+
+transfer() { 
+    # check arguments
+    if [ $# -eq 0 ]; 
+    then 
+        echo "No arguments specified. Usage:\necho transfer /tmp/test.md\ncat /tmp/test.md | transfer test.md"
+        return 1
+    fi
+
+    # get temporarily filename, output is written to this file show progress can be showed
+    tmpfile=$( mktemp -t transferXXX )
+    
+    # upload stdin or file
+    file=$1
+
+    if tty -s; 
+    then 
+        basefile=$(basename "$file" | sed -e 's/[^a-zA-Z0-9._-]/-/g') 
+
+        if [ ! -e $file ];
+        then
+            echo "File $file doesn't exists."
+            return 1
+        fi
+        
+        if [ -d $file ];
+        then
+            # zip directory and transfer
+            zipfile=$( mktemp -t transferXXX.zip )
+            cd $(dirname $file) && zip -r -q - $(basename $file) > $zipfile
+            curl --progress-bar --upload-file "$zipfile" "https://transfer.sh/$basefile.zip" >> $tmpfile
+            rm -f $zipfile
+        else
+            # transfer file
+            curl --progress-bar --upload-file "$file" "https://transfer.sh/$basefile" >> $tmpfile
+        fi
+    else 
+        # transfer pipe
+        curl --progress-bar --upload-file "-" "https://transfer.sh/$file" >> $tmpfile
+    fi
+   
+    # cat output link
+    cat $tmpfile
+
+    # cleanup
+    rm -f $tmpfile
+}
+
+alias transfer=transfer
+


### PR DESCRIPTION
Usage:
- `transfer file.txt` will transfer a file and return a link
- `transfer directory` will zip the directory, transfer the zip and return a link
- `cat file.log | transfer file.log` will transfer the piped output and return a link
