### PR TITLE
allow sourcing zshrc.local config

### DIFF
--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -11,3 +11,7 @@ if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
 fi
 
 # Customize to your needs...
+# Source custom configuration
+if [[ -s "${ZDOTDIR:-$HOME}/zshrc.local" ]]; then
+  source "${ZDOTDIR:-$HOME}/zshrc.local"
+fi

--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -10,8 +10,9 @@ if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
 fi
 
-# Customize to your needs...
-# Source custom configuration
+# Source custom configuration if present
 if [[ -s "${ZDOTDIR:-$HOME}/zshrc.local" ]]; then
   source "${ZDOTDIR:-$HOME}/zshrc.local"
 fi
+
+# Customize to your needs...


### PR DESCRIPTION
Allowing .local files to be sourced will allow users to customize prezto without needing to maintain a fork and making sure they are current with upstream. This way prezto can be cloned and custom aliases can remain in users own dotfiles repos if desired.

Of course, they can still fork and update zshrc as before, but this will allow a default option for users who do not want to.