### PR TITLE
added paradox prompt with ruby_info in rprompt

### DIFF
--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -1,0 +1,50 @@
+#
+# A two-line, Powerline-inspired theme that displays contextual information.
+#
+# This theme requires a patched Powerline font, get them from
+# https://github.com/Lokaltog/powerline-fonts.
+#
+# Authors:
+#   Isaac Wolkerstorfer <i@agnoster.net>
+#   Jeff Sandberg <paradox460@gmail.com>
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   rocknrollmarc <rocknrollmarc@gmail.com>
+#
+# Screenshots:
+#   http://i.imgur.com/0XIWX.png
+#
+
+# Load dependencies.
+pmodload 'helper'
+
+# Define variables.
+_prompt_paradox_current_bg='NONE'
+_prompt_paradox_segment_separator=''
+_prompt_paradox_start_time=$SECONDS
+
+function prompt_paradox_start_segment {
+  local bg fg
+  [[ -n "$1" ]] && bg="%K{$1}" || bg="%k"
+  [[ -n "$2" ]] && fg="%F{$2}" || fg="%f"
+  if [[ "$_prompt_paradox_current_bg" != 'NONE' && "$1" != "$_prompt_paradox_current_bg" ]]; then
+    print -n " $bg%F{$_prompt_paradox_current_bg}$_prompt_paradox_segment_separator$fg "
+  else
+    print -n "$bg$fg "
+  fi
+  _prompt_paradox_current_bg="$1"
+  [[ -n "$3" ]] && print -n "$3"
+}
+
+function prompt_paradox_end_segment {
+  if [[ -n "$_prompt_paradox_current_bg" ]]; then
+    print -n " %k%F{$_prompt_paradox_current_bg}$_prompt_paradox_segment_separator"
+  else
+    print -n "%k"
+  fi
+  print -n "%f"
+  _prompt_paradox_current_bg=''
+}
+
+function prompt_paradox_build_prompt {
+  prompt_paradox_start_segment black default '%(?::%F{red}✘ )%(!:%F{yellow}⚡ :)%(1j:%F{cyan}⚙ :)%F{blue}%n%F{red}@%F{green}%m%f'
+  prompt_paradox_start_segment blue black '$_prompt_paradox_pwd'


### PR DESCRIPTION
I added a new version of the new paradox Prompt as I need a ruby-info on the right, I added it so we have the time and ruby-info now.