### PR TITLE
Fixed 'topc' and 'topm' aliases

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -146,8 +146,8 @@ alias du='du -kh'
 if (( $+commands[htop] )); then
   alias top=htop
 else
-  alias topc='top -o cpu'
-  alias topm='top -o vsize'
+  alias topc='top -o %CPU'
+  alias topm='top -o %MEM'
 fi
 
 # Miscellaneous

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -146,8 +146,15 @@ alias du='du -kh'
 if (( $+commands[htop] )); then
   alias top=htop
 else
-  alias topc='top -o %CPU'
-  alias topm='top -o %MEM'
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OS X
+    alias topc='top -o cpu'
+    alias topm='top -o vsize'
+  else
+  # Linux or Cygwin
+    alias topc='top -o %CPU'
+    alias topm='top -o %MEM'
+  fi
 fi
 
 # Miscellaneous


### PR DESCRIPTION
The 'topc' an 'topm' aliases are working even when 'htop' is not installed