### PR TITLE
Option added to name the autocreated tmux session

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -23,6 +23,10 @@ following line to *zpreztorc*:
 In both cases, it will create a background session named _prezto_ if the tmux
 server is not started.
 
+You can rename the default session name with:
+
+    zstyle ':prezto:module:tmux:session' name 'your-session-name'
+
 With `auto-start` enabled, you may want to control how multiple sessions are
 managed. The `destroy-unattached` option of tmux controls if the unattached
 sessions must be kept alive, making sessions available for later use, configured
@@ -67,6 +71,7 @@ Authors
   - [Colin Hebert](https://github.com/ColinHebert)
   - [Georges Discry](https://github.com/gdiscry)
   - [Xavier Cambar](https://github.com/xcambar)
+  - [Jörg Kütemeier](https://github.com/jkuetemeier)
 
 [1]: http://tmux.sourceforge.net
 [2]: https://github.com/sorin-ionescu/prezto/issues/62

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -6,6 +6,7 @@
 #   Colin Hebert <hebert.colin@gmail.com>
 #   Georges Discry <georges@discry.be>
 #   Xavier Cambar <xcambar@gmail.com>
+#   Jörg Kütemeier <jk@kuetemeier.net>
 #
 
 # Return if requirements are not found.
@@ -31,7 +32,9 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" ]] && ( \
 
   # Create a 'prezto' session if no session has been defined in tmux.conf.
   if ! tmux has-session 2> /dev/null; then
-    tmux_session='prezto'
+    zstyle -s ':prezto:module:tmux:session' name tmux_session \
+      || tmux_session='prezto'
+
     tmux \
       new-session -d -s "$tmux_session" \; \
       set-option -t "$tmux_session" destroy-unattached off &> /dev/null


### PR DESCRIPTION
Now you can use 

```
zstyle ':prezto:module:tmux:session' name 'your-session-name'
```

in `.zpreztorc` to name your default session. If this config option is not present, the name still defaults to 'prezto'. So default behavior is preserved. 
