### PR TITLE
Use `which` to find correct zsh path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ version is 4.3.17.
 
   4. Set Zsh as your default shell:
 
-        chsh -s /bin/zsh
+        chsh -s $(which zsh)
 
   5. Open a new Zsh terminal window or tab.
 


### PR DESCRIPTION
Some environments (like OS X using Homebrew) don't install applications to /usr/bin, so hardcoding the path to zsh is likely to result in the wrong version of zsh being saved as the default shell.