### PR TITLE
adds rudimentary install script

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -1,0 +1,31 @@
+#
+# Install Prezto by creating a bunch of symlinks.
+#
+# Authors:
+#   Adrien Bak <adrien.bak@gmail.com>
+#
+
+#get the folder containing this script
+install_folder=${0:a:h}
+
+setopt EXTENDED_GLOB
+
+if [[ $1 == "--dry-run" ]]; then
+	dryrun=true
+	echo 'Dry-Run'
+else
+	dryrun=false
+fi
+
+for rcfile in "${install_folder}"/runcoms/^README.md(.N); do
+	target="$rcfile"
+	symlink="${ZDOTDIR:-$HOME}/.${rcfile:t}"
+
+	if $dryrun ; then
+		echo "${symlink} --> ${target}"
+	else
+		ln -s ${target} ${symlink}
+	fi
+
+done
+


### PR DESCRIPTION
this PR creates and add an install script in the root folder.
This script then creates symlinks between runcoms/^README.md and the target folder (${ZDOTDIR:-$HOME}).

The main advantage is that prezto can be cloned anywhere, and not necessarily in ${ZDOTDIR:-$HOME}.