### PR TITLE
makes prezto and its init script location agnostic

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -17,6 +17,8 @@ if ! autoload -Uz is-at-least || ! is-at-least "$min_zsh_version"; then
 fi
 unset min_zsh_version
 
+prezto_home=${0:a:h}
+
 #
 # Module Loader
 #
@@ -31,7 +33,7 @@ function pmodload {
   pmodules=("$argv[@]")
 
   # Add functions to $fpath.
-  fpath=(${pmodules:+${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions(/FN)} $fpath)
+  fpath=(${pmodules:+${prezto_home}/modules/${^pmodules}/functions(/FN)} $fpath)
 
   function {
     local pfunction
@@ -40,7 +42,7 @@ function pmodload {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
     # Load Prezto functions.
-    for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions/$~pfunction_glob; do
+    for pfunction in "${prezto_home}"/modules/${^pmodules}/functions/$~pfunction_glob; do
       autoload -Uz "$pfunction"
     done
   }
@@ -49,19 +51,19 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    elif [[ ! -d "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule" ]]; then
+    elif [[ ! -d "${prezto_home}/modules/$pmodule" ]]; then
       print "$0: no such module: $pmodule" >&2
       continue
     else
-      if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh" ]]; then
-        source "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh"
+      if [[ -s "${prezto_home}/modules/$pmodule/init.zsh" ]]; then
+        source "${prezto_home}/modules/$pmodule/init.zsh"
       fi
 
       if (( $? == 0 )); then
         zstyle ":prezto:module:$pmodule" loaded 'yes'
       else
         # Remove the $fpath entry.
-        fpath[(r)${ZDOTDIR:-$HOME}/.zprezto/modules/${pmodule}/functions]=()
+        fpath[(r)${prezto_home}/modules/${pmodule}/functions]=()
 
         function {
           local pfunction
@@ -71,7 +73,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in ${prezto_home}/modules/$pmodule/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }

--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -6,8 +6,9 @@
 #
 
 # Source Prezto.
-if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
-  source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
-fi
+mypath=$(readlink -f "${ZDOTDIR:-$HOME}/.zshrc")
+prezto_home=${mypath:h:h}
+
+source "${prezto_home}/init.zsh"
 
 # Customize to your needs...


### PR DESCRIPTION
This PR makes prezto location agnostic, so it can be installed anywhere, not just in .zprezto in $HOME or $ZDOTDIR
This is done be retrieveing the full path to init.zsh, and using the fact that the script is in the top level directory of the install, and by getting the full path to zshrc.