### PR TITLE
Suppress node-info when nvm points system-wide node

### DIFF
--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -17,7 +17,7 @@ if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
 fi
 
-if [[ "$version" != (none|) ]]; then
+if [[ "$version" != (none|system) ]]; then
   zstyle -s ':prezto:module:node:info:version' format 'version_format'
   zformat -f version_formatted "$version_format" "v:$version"
   node_info[version]="$version_formatted"


### PR DESCRIPTION
On modern versions of nvm, when virtual environment is not activated
(i.e. node comes from system-wide and `nvm version` == 'system'),
redundant node-info could be suppressed from showing.

Example screenshot :

![](http://i.imgur.com/4SEUM8C.png)
