### PR TITLE
Add gdI to show all assume-unchanged (Ignored) files

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -73,6 +73,7 @@ alias gdm='git ls-files --modified'
 alias gdu='git ls-files --other --exclude-standard'
 alias gdk='git ls-files --killed'
 alias gdi='git status --porcelain --short --ignored | sed -n "s/^!! //p"'
+alias gdI='git ls-files -v `git rev-parse --show-toplevel` | grep "^[a-z]"'
 
 # Fetch (f)
 alias gf='git fetch'


### PR DESCRIPTION
I have a few files marked with 

```
git update-index --assume-unchanged 
```

gdI shows the list of these files.  Found it useful, it seemed to fit in the alias naming scheme.