### PR TITLE
remove double escape sequence

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -29,8 +29,8 @@ zmodload zsh/terminfo
 typeset -gA key_info
 key_info=(
   'Control'      '\C-'
-  'ControlLeft'  '\e[1;5D \e[5D \e\e[D \eOd'
-  'ControlRight' '\e[1;5C \e[5C \e\e[C \eOc'
+  'ControlLeft'  '\e[1;5D \e[5D \e[D \eOd'
+  'ControlRight' '\e[1;5C \e[5C \e[C \eOc'
   'Escape'       '\e'
   'Meta'         '\M-'
   'Backspace'    "^?"


### PR DESCRIPTION
Hi in my setup:
- fedora 21 
- byobu (TERM=screen) inside gnome-terminal (TERM=xterm-256color)

ControlLeft and ControlRight are: \e[D and \e[C
I might be wrong but I guess the \e\e escape sequence  should be replaced by a single \e escape sequence.

Cheers,
 Ayman
