### PR TITLE
Fix node-module

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -7,7 +7,7 @@
 #
 
 # Return if requirements are not found.
-if (( ! $+commands[nvm] || ! $+commands[node] )); then
+if (( ! $+commands[nvm] && ! $+commands[node] )); then
   return 1
 fi
 


### PR DESCRIPTION
The change recently introduced for #777 was actually breaking the module
completely, as it was only loaded if neither `node` nor `nvm`
were available.