### PR TITLE
Skip setting terminal title inside Emacs

### DIFF
--- a/modules/terminal/init.zsh
+++ b/modules/terminal/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$TERM" == (dumb|linux|*bsd*) ]]; then
+if [[ "$TERM" == (dumb|linux|*bsd*|eterm*) ]]; then
   return 1
 fi
 


### PR DESCRIPTION
Hi Sorin,

Might have a quick fix for an Emacs + Prezto + auto-title hiccup I've encountered.

Setting Terminal title in Emacs results in beeping and garbled `2;<cmd>1;<cmd><result>` output, as you can see in the screenshot below.

![multi-term-auto-title](https://cloud.githubusercontent.com/assets/18374/6431084/137f553c-c01c-11e4-8e1d-f7902f47d00c.png)

I've fixed this in my fork of Prezto by preventing the `_terminal-set-titles-with-path` precmd from being used when `EMACS` is set.

Thanks for Prezto BTW. :smile: