### PR TITLE
Add aliases to osx module

### DIFF
--- a/modules/osx/init.zsh
+++ b/modules/osx/init.zsh
@@ -19,3 +19,13 @@ alias cdf='cd "$(pfd)"'
 
 # Pushes directory to the current Finder directory.
 alias pushdf='pushd "$(pfd)"'
+
+# Locks screen.
+alias lock='/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend'
+
+# Saves a screen shot to the current directory with 1s delay for app switching.
+alias snap="screencapture -T 1 "Screen Shot $(date +'%Y-%m-%d') at $(date +"%I.%M.%S %p").png";"
+
+# Mutes/Unmutes the system volume.
+alias mute="osascript -e 'set volume output muted true'"
+alias unmute="osascript -e 'set volume output muted false'"


### PR DESCRIPTION
Include aliases for lock screen, screencapture, and system volume.

`lock` brings up the login screen without a full logout.
`snap` saves a screen shot to current dir following default OS X screen shot naming convention
`mute` and `unmute` are essentially identical to pressing the physical mute key, can be changed via any other volume altering function in OS X. I find it useful for (1) not straying too far from the home row and (2) when function keys and fn are remapped to oblivion.

PS - thanks so much for prezto. OMZ performance was killing me.