### PR TITLE
Add pattern tweaking to syntax-highlighting

### DIFF
--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -50,6 +50,16 @@ green, add the following to *zpreztorc*:
       'command' 'bg=blue' \
       'function' 'bg=blue'
 
+### Highlighting Patterns
+
+The pattern highlighter enables highlighting user defined patterns.
+
+For example, to highlight commands starting with `rm -rf` in red, add the
+following to *zpreztorc*:
+
+    zstyle ':prezto:module:syntax-highlighting' patterns \
+      'rm -rf *' 'fg=white,bold,bg=red'
+
 Authors
 -------
 

--- a/modules/syntax-highlighting/init.zsh
+++ b/modules/syntax-highlighting/init.zsh
@@ -26,3 +26,11 @@ for syntax_highlighting_style in "${(k)syntax_highlighting_styles[@]}"; do
   ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]="$syntax_highlighting_styles[$syntax_highlighting_style]"
 done
 unset syntax_highlighting_style{s,}
+
+# Set highlighting patterns
+typeset -A syntax_highlighting_patterns
+zstyle -a ':prezto:module:syntax-highlighting' patterns 'syntax_highlighting_patterns'
+for syntax_highlighting_pattern in "${(k)syntax_highlighting_patterns[@]}"; do
+  ZSH_HIGHLIGHT_PATTERNS[$syntax_highlighting_pattern]="$syntax_highlighting_patterns[$syntax_highlighting_pattern]"
+done
+unset syntax_highlighting_pattern{s,}

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -123,12 +123,16 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 #   'pattern' \
 #   'cursor' \
 #   'root'
-#
+
 # Set syntax highlighting styles.
 # zstyle ':prezto:module:syntax-highlighting' styles \
 #   'builtin' 'bg=blue' \
 #   'command' 'bg=blue' \
 #   'function' 'bg=blue'
+
+# Set syntax highlighting patterns
+# zstyle ':prezto:module:syntax-highlighting' patterns \
+#   'rm -rf *' 'fg=white,bold,bg=red'
 
 #
 # Terminal


### PR DESCRIPTION
Enable setting patterns in *zpreztorc* like styles are set, since patterns are set separately.
Accidentally closed the other pull request—sorry! I had to make a small edit.