### PR TITLE
omit warning of brew upgrade

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -13,8 +13,7 @@ Aliases
   - `brewi` installs a formula.
   - `brewl` lists installed formulae.
   - `brews` searches for a formula.
-  - `brewU` upgrades Homebrew and outdated brews.
-  - `brewu` upgrades Homebrew.
+  - `brewu [formulae]` upgrades Homebrew and all/specified formulae.
   - `brewx` uninstalls a formula.
 
 ### Homebrew Cask

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -20,8 +20,10 @@ alias brewC='brew cleanup --force'
 alias brewi='brew install'
 alias brewl='brew list'
 alias brews='brew search'
-alias brewu='brew upgrade'
-alias brewU='brew update && brew upgrade'
+brewu() {
+    brew update
+    [[ -z $1 ]] && brew upgrade --all || brew upgrade "$@"
+}
 alias brewx='brew remove'
 
 # Homebrew Cask


### PR DESCRIPTION
In newly version of homebrew when you execute `brew upgrade` you will
get the following:


> Warning: brew upgrade with no arguments will change behaviour soon!
> It currently upgrades all formula but this will soon change to require '--all'.
> Please update any workflows, documentation and scripts!