### PR TITLE
Add interactivity toggle to utility module

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -28,6 +28,14 @@ To disable `make` highlighting, add the following line to *zpreztorc*:
 
     zstyle ':prezto:module:utility:make' color 'no'
 
+### Interactive aliases
+
+By default `rm`, `cp`, `mv` and `ln` are aliased with the `-i` flag, which
+makes the commands interactive. To disable this behavior you can set the
+following in *zpreztorc*:
+
+    zstyle ':prezto:module:utility:aliases' interactive 'no'
+
 Aliases
 -------
 

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -48,16 +48,19 @@ alias sftp='noglob sftp'
 # Define general aliases.
 alias _='sudo'
 alias b='${(z)BROWSER}'
-alias cp="${aliases[cp]:-cp} -i"
 alias e='${(z)VISUAL:-${(z)EDITOR}}'
-alias ln="${aliases[ln]:-ln} -i"
 alias mkdir="${aliases[mkdir]:-mkdir} -p"
-alias mv="${aliases[mv]:-mv} -i"
 alias p='${(z)PAGER}'
 alias po='popd'
 alias pu='pushd'
-alias rm="${aliases[rm]:-rm} -i"
 alias type='type -a'
+
+if zstyle -T ':prezto:module:utility:aliases' interactive; then
+  alias cp="${aliases[cp]:-cp} -i"
+  alias ln="${aliases[ln]:-ln} -i"
+  alias mv="${aliases[mv]:-mv} -i"
+  alias rm="${aliases[rm]:-rm} -i"
+fi
 
 # ls
 if is-callable 'dircolors'; then


### PR DESCRIPTION
Make it possible to remove interactive options from aliases. Disabling these come down to a matter of opinion, so I left them on by default and because it could be argued that it's not always in the best interest of the user to disable these, I left the feature undocumented.

This was briefly discussed in issue #851 as well.
