### PR TITLE
Added pattern options for syntax-highlighting

### DIFF
--- a/modules/syntax-highlighting/init.zsh
+++ b/modules/syntax-highlighting/init.zsh
@@ -26,3 +26,6 @@ for syntax_highlighting_style in "${(k)syntax_highlighting_styles[@]}"; do
   ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]="$syntax_highlighting_styles[$syntax_highlighting_style]"
 done
 unset syntax_highlighting_style{s,}
+
+# Set highlighting patterns.
+zstyle -a ':prezto:module:syntax-highlighting' patterns 'ZSH_HIGHLIGHT_PATTERNS'


### PR DESCRIPTION
Added highlighting pattern options as zstyle array for the `zsh-syntax-highlighting`. Should I also add an example to `zprestorc`?
```
## Pattern highlighter, that highlights user defined patterns:
zstyle ":prezto:module:syntax-highlighting" styles \
    "rm -rf *" "fg=white,bold,bg=red" \
    "sudo"     "fg=white,bold,bg=red" \
```