### PR TITLE
substitute command name when alias is not defined (for ls and grep in the utility module)

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -71,9 +71,9 @@ if is-callable 'dircolors'; then
       eval "$(dircolors --sh)"
     fi
 
-    alias ls="$aliases[ls] --color=auto"
+    alias ls="${aliases[ls]:-ls} --color=auto"
   else
-    alias ls="$aliases[ls] -F"
+    alias ls="${aliases[ls]:-ls} -F"
   fi
 else
   # BSD Core Utilities
@@ -107,7 +107,7 @@ if zstyle -t ':prezto:module:utility:grep' color; then
   export GREP_COLOR='37;45'           # BSD.
   export GREP_COLORS="mt=$GREP_COLOR" # GNU.
 
-  alias grep="$aliases[grep] --color=auto"
+  alias grep="${aliases[grep]:-grep} --color=auto"
 fi
 
 # Mac OS X Everywhere


### PR DESCRIPTION
`$aliases[grep]` works with the assumption that an alias is already defined for `grep`. If one comments out the correction-related code, including `alias grep='nocorrect grep'`, then `alias grep="$aliases[grep] --color=auto"` would break. `${aliases[grep]:-grep}` fixes the problem. Same goes for `ls`.

In fact, the `${aliases[command]:-command}` idiom is already seen in the file, just not used throughout.