### PR TITLE
osx module: add iTerm2 support to the tab function, and create a similar window function

### DIFF
--- a/modules/osx/functions/tab
+++ b/modules/osx/functions/tab
@@ -1,5 +1,5 @@
 #
-# Opens a new Terminal.app/iTerm.app tab in the current directory.
+# Opens a new Terminal.app/iTerm.app/iTerm2.app tab in the current directory.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
@@ -33,6 +33,19 @@ EOF
         launch session "Default Session"
         set current_session to current session
         tell current_session
+          write text "${command}"
+        end tell
+      end tell
+    end tell
+EOF
+}
+
+[[ "$the_app" == 'iTerm2' ]] && {
+  osascript 2>/dev/null <<EOF
+    tell application "iTerm2"
+      tell current window
+        create tab with default profile
+        tell current session of current tab
           write text "${command}"
         end tell
       end tell

--- a/modules/osx/functions/window
+++ b/modules/osx/functions/window
@@ -1,0 +1,37 @@
+#
+# Opens a new Terminal.app/iTerm2.app window in the current directory.
+#
+# Authors:
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#
+
+local command="cd \\\"$PWD\\\""
+(( $# > 0 )) && command="${command}; $*"
+
+the_app=$(
+  osascript 2>/dev/null <<EOF
+    tell application "System Events"
+      name of first item of (every process whose frontmost is true)
+    end tell
+EOF
+)
+
+[[ "$the_app" == 'Terminal' ]] && {
+  osascript 2>/dev/null <<EOF
+    tell application "System Events"
+      tell process "Terminal" to keystroke "n" using command down
+      tell application "Terminal" to do script "${command}" in front window
+    end tell
+EOF
+}
+
+[[ "$the_app" == 'iTerm2' ]] && {
+  osascript 2>/dev/null <<EOF
+    tell application "iTerm2"
+      create window with default profile
+      tell current session of current window
+        write text "${command}"
+      end tell
+    end tell
+EOF
+}


### PR DESCRIPTION
The `tab` function of the `osx` module currently supports opening a new tab in pwd in Terminal or iTerm. I've added support for iTerm2.

I also adapted the `tab` function a little bit to make a `window` function, which opens a new window rather than a new tab (I personally like windows better than tabs, which I can separately hide and show and drag around to different screens). I didn't include iTerm in the `window` function; it should be trivial to write but since I don't have iTerm installed, I didn't want to risk making a mistake.

The two things are kept in two separate commits so that if you find `window` not worth including, you can easily cherry pick the iTerm2 support in `tab`. Thanks.
