### PR TITLE
git-info: temporarily set IFS to $'\t' for tamper-proof extraction of ahead and behind

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -254,7 +254,7 @@ function git-info {
 
     # Format ahead.
     if [[ -n "$ahead_format" ]]; then
-      ahead="$ahead_and_behind[(w)1]"
+      ahead="$ahead_and_behind[(pws:\t:)1]"
       if (( ahead > 0 )); then
         zformat -f ahead_formatted "$ahead_format" "A:$ahead"
       fi
@@ -262,7 +262,7 @@ function git-info {
 
     # Format behind.
     if [[ -n "$behind_format" ]]; then
-      behind="$ahead_and_behind[(w)2]"
+      behind="$ahead_and_behind[(pws:\t:)2]"
       if (( behind > 0 )); then
         zformat -f behind_formatted "$behind_format" "B:$behind"
       fi


### PR DESCRIPTION
The problem with the current implementation of `ahead` and `behind` extraction in `git-info` is that it is not tamper-proof against a modified `IFS`. The output format of `git rev-list --count --left-right ...` is `ahead<TAB>behind`, and `ahead` and `behind` are parsed from that output through word splitting; but if `IFS` doesn't contain the TAB character, then splitting will fail, leading to angry bad math expression errors.

To fix this problem, I'm temporarily setting `IFS` to `$'\t'`, then restore it when done.

Another thought is to use parameter expansion flags `(ws:<separator>:)`. The code would be cleaner, but I tried to use `$'\t'` as separator with no luck (unless I hard code the tab, which I'm afraid is not so readable and would easily fall victim to editor commands like `untabify`). It seems that quoting doesn't work inside the flags, for some reason. Thoughts are welcome.

Here's a small test case:

``` zsh
> string=$'1\t2'
> echo $string[(ws: :)1]  # between the two colons is a literal tab
1
> echo $string[(ws:$'\t':)1]
1   2
```
