### PR TITLE
Remove useless use of grep

### DIFF
--- a/modules/git/functions/git-hub-shorten-url
+++ b/modules/git/functions/git-hub-shorten-url
@@ -16,7 +16,7 @@ if [[ -z "$url" ]]; then
 fi
 
 if (( $+commands[curl] )); then
-  curl -s -i 'http://git.io' -F "url=$url" | grep 'Location:' | sed 's/Location: //'
+  curl -s -i 'http://git.io' -F "url=$url" | sed -n 's/^Location: //p'
 else
   print "$0: command not found: curl" >&2
 fi


### PR DESCRIPTION
Shrink `grep 'Location:' | sed 's/Location: //'` to `sed -n 's/^Location: //p'` in `git-hub-shorten-url` (added `^` since `Location:` should appear at the beginning of a line in `curl`'s output).
