### PR TITLE
Command to activate virtualenvs when changing directory

### DIFF
--- a/modules/python/functions/workon-cwd
+++ b/modules/python/functions/workon-cwd
@@ -1,0 +1,60 @@
+#
+# Enables automatic activation of a virtualenv when jumping into a directory
+# This is done by looking in the current directory for a file or directory
+# named `.venv`. If it's not found in the current directory its parents will
+# also be examined. `.venv` can be either:
+#
+#     1. A file containing the name of a virtualenv found in $WORKON_HOME
+#     2. A directory containing bin/activate (meaning that the directory is
+#        assumed to be a virtualenv.)
+#
+# If $WORKON_HOME is set it is assumed that virtualenvwrapper is installed and
+# the `workon` command will be issued.
+#
+
+function workon_cwd {
+  if [ ! $WORKON_CWD ]; then
+    WORKON_CWD=1
+    # Look for a proper PROJECT_ROOT path
+    PROJECT_ROOT=$(pwd)
+    while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
+      PROJECT_ROOT=${PROJECT_ROOT:A:h}
+    done
+
+    if [[ "$PROJECT_ROOT" == "/" ]]; then
+      PROJECT_ROOT="."
+    fi
+    # Check for virtualenv name override
+    if [[ -f "$PROJECT_ROOT/.venv" ]]; then
+      ENV_NAME=$(cat "$PROJECT_ROOT/.venv")
+    elif [[ -f "$PROJECT_ROOT/.venv/bin/activate" ]];then
+      ENV_NAME="$PROJECT_ROOT/.venv"
+    else
+      ENV_NAME=""
+    fi
+    if [[ "$ENV_NAME" != "" ]]; then
+      # Activate the environment only if it is not already active
+      if [[ "$VIRTUAL_ENV" != "$WORKON_HOME/$ENV_NAME" ]]; then
+        if [[ -e "$WORKON_HOME/$ENV_NAME/bin/activate" ]]; then
+          workon "$ENV_NAME" && export CD_VIRTUAL_ENV="$ENV_NAME"
+        elif [[ -e "$ENV_NAME/bin/activate" ]]; then
+          source $ENV_NAME/bin/activate && export CD_VIRTUAL_ENV="$ENV_NAME"
+        fi
+      fi
+    elif [[ -n $CD_VIRTUAL_ENV && -n $VIRTUAL_ENV ]]; then
+      # We've just left the repo, deactivate the environment
+      # Note: this only happens if the virtualenv was activated automatically
+      deactivate && unset CD_VIRTUAL_ENV
+    fi
+    unset PROJECT_ROOT
+    unset WORKON_CWD
+  fi
+}
+
+if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
+  # Append workon_cwd to the chpwd_functions array, so it will be called on cd
+  # http://zsh.sourceforge.net/Doc/Release/Functions.html
+  if ! (( $chpwd_functions[(I)workon_cwd] )); then
+    chpwd_functions+=(workon_cwd)
+  fi
+fi

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -43,6 +43,10 @@ if (( $+commands[virtualenvwrapper.sh] )); then
   VIRTUAL_ENV_DISABLE_PROMPT=1
 
   source "$commands[virtualenvwrapper.sh]"
+
+  if (( $+functions[workon-cwd] )); then
+    workon-cwd
+  fi
 fi
 
 #


### PR DESCRIPTION
Enables automatic activation of a virtualenv when jumping into a directory. This is done by looking in the current directory for a file or directory named `.venv`. If it's not found in the current directory its parents will also be examined. `.venv` can be either:
1. A file containing the name of a virtualenv found in $WORKON_HOME
2. A directory containing bin/activate (meaning that the directory is assumed to be a virtualenv.)

If $WORKON_HOME is set it is assumed that virtualenvwrapper is installed and the `workon` command will be issued.
