### PR TITLE
new theme 'squiggs'

### DIFF
--- a/modules/prompt/functions/prompt_squiggs_setup
+++ b/modules/prompt/functions/prompt_squiggs_setup
@@ -1,0 +1,206 @@
+#
+# A simple theme that displays relevant, contextual information with
+# baked in support for git, ruby-info, and python-info.
+#
+# Based on the 'sorin' prompt by Sorin Ionescu <sorin.ionescu@gmail.com>
+#
+# Authors:
+#   Matthew Crenshaw <sgt@squig.gs>
+#
+# Screenshots:
+#   http://i.imgur.com/w2ein8H.png
+#
+
+#
+# 16 Terminal Colors
+# -- ---------------
+#  0 black
+#  1 red
+#  2 green
+#  3 yellow
+#  4 blue
+#  5 magenta
+#  6 cyan
+#  7 white
+#  8 bright black
+#  9 bright red
+# 10 bright green
+# 11 bright yellow
+# 12 bright blue
+# 13 bright magenta
+# 14 bright cyan
+# 15 bright white
+#
+
+# Load dependencies.
+pmodload 'helper'
+
+function prompt_squiggs_pwd {
+  local pwd="${PWD/#$HOME/~}"
+
+  if [[ "$pwd" == (#m)[/~] ]]; then
+    _prompt_squiggs_pwd="$MATCH"
+    unset MATCH
+  else
+    _prompt_squiggs_pwd="${${${${(@j:/:M)${(@s:/:)pwd}##.#?}:h}%/}//\%/%%}/${${pwd:t}//\%/%%}"
+  fi
+}
+
+function prompt_squiggs_async_trap {
+  if (( _prompt_squiggs_precmd_async_pid > 0 )); then
+    # Append ruby info to RPROMPT
+    prompt_squiggs_ruby_info
+
+    # Append python info to RPROMPT
+    prompt_squiggs_python_info
+
+    # Append git info to RPROMPT
+    prompt_squiggs_git_info
+
+    # Reset PID.
+    _prompt_squiggs_precmd_async_pid=0
+
+    # Remove async data
+    rm -f "$_prompt_squiggs_precmd_async_data"
+
+    # Redisplay prompt.
+    zle && zle reset-prompt
+  fi
+}
+
+function prompt_squiggs_git_info {
+  # Append Git status.
+  if [[ -s "$_prompt_squiggs_precmd_async_data" ]]; then
+    alias typeset='typeset -g'
+    source "$_prompt_squiggs_precmd_async_data"
+    RPROMPT+='${git_info:+${(e)git_info[status]}}'
+    unalias typeset
+  fi
+}
+
+function prompt_squiggs_ruby_info {
+  # Append Ruby status.
+  if [[ -s "$_prompt_squiggs_precmd_async_data" ]]; then
+    alias typeset='typeset -g'
+    source "$_prompt_squiggs_precmd_async_data"
+    RPROMPT+='${ruby_info:+${(e)ruby_info[version]}}'
+    unalias typeset
+  fi
+}
+
+function prompt_squiggs_python_info {
+  # Append Python status.
+  if [[ -s "$_prompt_squiggs_precmd_async_data" ]]; then
+    alias typeset='typeset -g'
+    source "$_prompt_squiggs_precmd_async_data"
+    RPROMPT+='${python_info:+${(e)python_info[virtualenv]}}'
+    unalias typeset
+  fi
+}
+
+function prompt_squiggs_precmd_async {
+  # Get Git repository information.
+  if (( $+functions[git-info] )); then
+    git-info
+    typeset -p git_info >>! "$_prompt_squiggs_precmd_async_data"
+  fi
+
+  # Get ruby version information.
+  if (( $+functions[ruby-info] )); then
+    ruby-info
+    if [[ "$ruby_info[version]" != *@* ]]; then
+      ruby_info[version]=""
+    fi
+    typeset -p ruby_info >>! "$_prompt_squiggs_precmd_async_data"
+  fi
+
+  # Get Python virtualenv information.
+  if (( $+functions[python-info] )); then
+    python-info
+    typeset -p python_info >>! "$_prompt_squiggs_precmd_async_data"
+  fi
+
+  # Signal completion to parent process.
+  kill -WINCH $$
+}
+
+function prompt_squiggs_precmd {
+  setopt LOCAL_OPTIONS
+  unsetopt XTRACE KSH_ARRAYS
+
+  # Format PWD.
+  prompt_squiggs_pwd
+
+  # Define prompts.
+  RPROMPT='${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}'
+
+  # Kill the old process of slow commands if it is still running.
+  if (( _prompt_squiggs_precmd_async_pid > 0 )); then
+    kill -KILL "$_prompt_squiggs_precmd_async_pid" &>/dev/null
+  fi
+
+  # Compute slow commands in the background.
+  trap prompt_squiggs_async_trap WINCH
+  prompt_squiggs_precmd_async &!
+  _prompt_squiggs_precmd_async_pid=$!
+}
+
+function prompt_squiggs_setup {
+  setopt LOCAL_OPTIONS
+  unsetopt XTRACE KSH_ARRAYS
+  prompt_opts=(cr percent subst)
+  _prompt_squiggs_precmd_async_pid=0
+  _prompt_squiggs_precmd_async_data="${TMPPREFIX}-prompt_squiggs_data"
+
+  # Load required functions.
+  autoload -Uz add-zsh-hook
+
+  # Add hook for calling git-info before each command.
+  add-zsh-hook precmd prompt_squiggs_precmd
+
+  # Set editor-info parameters.
+  zstyle ':prezto:module:editor:info:completing' format '%B%F{7}...%f%b'
+  zstyle ':prezto:module:editor:info:keymap:primary' format ' %B%F{1}❯%F{3}❯%F{2}❯%f%b'
+  zstyle ':prezto:module:editor:info:keymap:primary:overwrite' format ' %F{3}♺%f'
+  zstyle ':prezto:module:editor:info:keymap:alternate' format ' %B%F{2}❮%F{3}❮%F{1}❮%f%b'
+
+  # Set git-info parameters.
+  zstyle ':prezto:module:git:info' verbose 'yes'
+  zstyle ':prezto:module:git:info:action' format '%F{7}:%f%%B%F{9}%s%f%%b'
+  zstyle ':prezto:module:git:info:added' format ' %%B%F{2}✚%f%%b'
+  zstyle ':prezto:module:git:info:ahead' format ' %%B%F{13}⬆%f%%b'
+  zstyle ':prezto:module:git:info:behind' format ' %%B%F{13}⬇%f%%b'
+  zstyle ':prezto:module:git:info:branch' format ' %%B%F{4}[%F{2}%b%F{4}]%f%%b'
+  zstyle ':prezto:module:git:info:commit' format ' %%B%F{3}%.7c%f%%b'
+  zstyle ':prezto:module:git:info:deleted' format ' %%B%F{1}✖%f%%b'
+  zstyle ':prezto:module:git:info:modified' format ' %%B%F{4}✱%f%%b'
+  zstyle ':prezto:module:git:info:position' format ' %%B%F{13}%p%f%%b'
+  zstyle ':prezto:module:git:info:renamed' format ' %%B%F{5}➜%f%%b'
+  zstyle ':prezto:module:git:info:stashed' format ' %%B%F{6}✭%f%%b'
+  zstyle ':prezto:module:git:info:unmerged' format ' %%B%F{3}═%f%%b'
+  zstyle ':prezto:module:git:info:untracked' format ' %%B%F{7}◼%f%%b'
+  zstyle ':prezto:module:git:info:keys' format \
+    'status' '$(coalesce "%b" "%p" "%c")%s%A%B%S%a%d%m%r%U%u'
+  
+  # Set ruby-info parameters.
+  zstyle ':prezto:module:ruby:info:version' format ' %F{4}rbenv%f:%F{2}%v%f'
+  
+  # Set python-info parameters.
+  zstyle ':prezto:module:python:info:virtualenv' format ' %F{4}pyenv%f:%F{2}%v%f'
+
+  # Define prompts.
+  PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_squiggs_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '
+  RPROMPT=''
+  SPROMPT='zsh: correct %F{1}%R%f to %F{2}%r%f [nyae]? '
+}
+
+function prompt_squiggs_preview {
+  local +h PROMPT=''
+  local +h RPROMPT=''
+  local +h SPROMPT=''
+
+  editor-info 2>/dev/null
+  prompt_preview_theme 'squiggs'
+}
+
+prompt_squiggs_setup "$@"


### PR DESCRIPTION
basically `sorin` w/ support for ruby-info and python-info. Uses the async methods to grab rvm gemset and virtualenv name, and is displayed on the right with git info.

![squiggs screenshot](http://i.imgur.com/w2ein8H.png)

I can't for the life of me get `prompt -p squiggs` to display anything and I've pretty much duplicated the method in `sorin`.