### PR TITLE
utility module: fix/improve colordiff call in diff

### DIFF
--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -8,7 +8,7 @@
 function diff {
   if zstyle -t ':prezto:module:utility:diff' color; then
     if (( $+commands[colordiff] )); then
-      command diff --unified "$@" | colordiff --difftype diffu
+      command colordiff --unified "$@"
     elif (( $+commands[git] )); then
       git --no-pager diff --color=auto --no-ext-diff --no-index "$@"
     else


### PR DESCRIPTION
Currently the `diff` function pipes output of `command diff --unified` to `colordiff`, which is not really necessary, since `colordiff` is capable of calling `diff` with any option. Worse still, the current call fails under `colordiff` 1.0.14 and 1.0.15 — the call always produces empty output (at least on OS X 10.10.4 with system `diff` and `perl`). To be fair, this is an upstream bug and I've reported it upstream at https://github.com/daveewart/colordiff/issues/22. However, `command colordiff --unified "$@"` is better than the current piping solution anyway (tested to work on all versions of `colordiff` down to 1.0.8, which is the [oldest tag in git](https://github.com/daveewart/colordiff/tags)).
