### PR TITLE
Add statusline theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "modules/prompt/functions/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
+[submodule "modules/prompt/external/statusline"]
+	path = modules/prompt/external/statusline
+	url = https://github.com/el1t/statusline.git

--- a/modules/prompt/functions/prompt_statusline_setup
+++ b/modules/prompt/functions/prompt_statusline_setup
@@ -1,0 +1,1 @@
+../external/statusline/prezto/prompt_statusline_setup


### PR DESCRIPTION
If I may submit (yet another) custom prompt for consideration:

![Screenshot](https://raw.githubusercontent.com/el1t/statusline/master/images/preview.png)

I made [statusline](https://github.com/el1t/statusline) originally as a clone of agnoster from oh-my-zsh, so it looks somewhat similar to the powerline prompt. However, I also added a host of features, such as task runtime, a single-line prompt mode, and dynamic directory abbreviation. Of course, I included the async loading of git info from sorin :wink:. In addition, I made it extremely easy to edit the segments displayed; the following two arrays can be changed on the fly:
```zsh
_prompt_statusline_left_segments=(status user git-branch directory)
_prompt_statusline_right_segments=(git-status clock history machine)
```
This theme uses a custom patched font, but I can add support for typical powerline-patched fonts if desired. Also, I will edit the coding style to match if this ends up getting voted on :sweat_smile: 