### PR TITLE
Load add-zsh-hook in GPG module

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -30,6 +30,9 @@ export GPG_TTY="$(tty)"
 
 # Integrate with the SSH module.
 if grep 'enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then
+  # Load required functions.
+  autoload -Uz add-zsh-hook
+
   # Override the ssh-agent environment file default path.
   _ssh_agent_env="$_gpg_agent_env"
 


### PR DESCRIPTION
Fixes this error:

    ~/.zprezto/modules/gpg/init.zsh:43: command not found: add-zsh-hook

I use Prezto in conjunction with Liquidprompt, and so do not load the prompt module, which otherwise would have loaded `add-zsh-hook`. Regardless, it's required by the GPG module and so should be (re)loaded since it's needed.