### PR TITLE
Allow tmux session name to be passed as env var

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -29,16 +29,16 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" && -z "$INSIDE_EMACS" && -z "$VSCOD
 ); then
   tmux start-server
 
-  # Create a 'prezto' session if no session has been defined in tmux.conf.
-  if ! tmux has-session 2> /dev/null; then
+  # Create a session named 'prezto' (or value of environment variable) if it does not exist
+  if ! tmux has-session ${tmux_session:+-t $tmux_session} 2> /dev/null; then
     zstyle -s ':prezto:module:tmux:session' name tmux_session || tmux_session='prezto'
     tmux \
       new-session -d -s "$tmux_session" \; \
       set-option -t "$tmux_session" destroy-unattached off &> /dev/null
   fi
 
-  # Attach to the 'prezto' session or to the last session used. (detach first)
-  exec tmux $_tmux_iterm_integration attach-session -d
+  # Attach to the default session, the requested session, or to the last session used and detach others
+  exec tmux $_tmux_iterm_integration attach-session ${tmux_session:+-t $tmux_session} -d
 fi
 
 #


### PR DESCRIPTION
For normal usage this change should be a NOOP. However it enables the
use case where the user might want to predefine what session gets
connected to when the shell is launched. Running `zsh` will still net
you a connection to the last used tmux session or a new one named
"zprezto" if none exists. However `env tmux_session=myname zsh` will
connect you specifically to a session called 'myname' including creating
it if it doesn't exist.

This is particularly useful in window managers where a key binding might
open a terminal with a predefined session or even show a list of current
sessions and open a new terminal connected to that session.
