### PR TITLE
Add module cowbuilder

### DIFF
--- a/modules/cowbuilder/README.md
+++ b/modules/cowbuilder/README.md
@@ -1,0 +1,48 @@
+Cowbuilder
+==========
+
+Start interactive cowbuilder session for debugging purposes.
+It allows for easy entering and saving changes in the chroots.
+
+The shell function `cb-shell` is based on the notes from the
+[Debian packaging symposium][1].
+
+Cowbuilder is started using sudo with the option to preserve the
+environment. This allows one to configure cowbuilder and pbuilder
+using *~/.pbuilderrc*.
+
+Aliases
+-------
+
+- `cb-shell-save` start `cb-shell` and saves changes on exit.
+
+Functions
+---------
+
+- `cb-shell` start shell inside cowbuilder chroot.
+
+Examples
+--------
+
+Start cowbuilder for distribution jessie.
+When environment variable `DIST` is present, the `-d` argument can be
+omitted.
+
+    $ cb-shell -d jessie
+    $ DIST=jessie cb-shell
+
+To make changes persistent start the cowbuilder shell with
+option `-s` or use the alias `cb-shell-save`.
+
+    $ cb-shell -d jessie -s
+    $ cb-shell-save -d jessie
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Olaf Conradi](https://github.com/oohlaf)
+
+[1]: http://jpvanoosten.nl/blog/2012/12/22/notes-from-the-debian-packaging-symposium/
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/cowbuilder/functions/cb-shell
+++ b/modules/cowbuilder/functions/cb-shell
@@ -1,0 +1,53 @@
+local path_pbuilder usage opt_dist opt_safe cb_opt
+
+: ${path_pbuilder:=/var/cache/pbuilder}
+
+usage="$(
+cat <<EOF
+usage: $0 [-d dist] [-s] [command ...]
+
+Start cowbuilder with shell for named distribution.
+
+options:
+  -d dist  Start cowbuilder for distribution dist
+           When environment variable DIST is set this option can be
+           omitted.
+  -s       Safe changes on exit
+EOF
+)"
+
+if [[ -n $DIST ]]; then
+  opt_dist="-$DIST"
+else
+  opt_dist=
+fi
+
+while getopts ':d:s' opt; do
+  case "$opt" in
+    d)  opt_dist="-$OPTARG"
+        ;;
+    s)  opt_safe=--safe-after-login
+        ;;
+    :)
+        print "$0: option requires an argument: $OPTARG" >&2
+        print "$usage" >&2
+        return 1
+        ;;
+    \?) print "$0: unknown option: $OPTARG" >&2
+        print "$usage" >&2
+        return 1
+        ;;
+  esac
+done
+shift $(( $OPTIND - 1 ))
+
+if [[ -n $opt_safe ]]; then
+  cb_opt=$opt_safe "$@"
+else
+  cb_opt="$@"
+fi
+
+sudo -E cowbuilder \
+  --bindmount $HOME \
+  --login \
+  --basepath=${path_pbuilder}/base${opt_dist}.cow $cb_opt

--- a/modules/cowbuilder/init.zsh
+++ b/modules/cowbuilder/init.zsh
@@ -1,0 +1,8 @@
+#
+# Helper to start inter-active shell session within cowbuilder chroots.
+#
+# Author:
+#   Olaf Conradi <olaf@conradi.org>
+#
+
+alias cb-shell-save='cb-shell -s'


### PR DESCRIPTION
Makes entering cowbuilder chroots easy and allows to persist changes for debugging purposes.
