### PR TITLE
Add note in README about how to workaround installation with existing .zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ version is 4.3.17.
         for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
           ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
         done
+      
+      NB: The above will not overwrite or update any existing `.zshrc`. Therefore, if you
+      have an existing `.zshrc` you must manually add the line `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"`.
 
   4. Set Zsh as your default shell:
 


### PR DESCRIPTION
This is a long-standing issue, first brought up in #231.

As many people have reported, the current installation instructions **silently** fail if the user has an existing `.zshrc`.

This PR simple makes the situation clearer in the README.
