### PR TITLE
python_info[version] will show python version number in the format "py-3.4.1"

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -74,6 +74,8 @@ Functions
 
 Theming
 -------
+  - `python_info[virtualenv]` exposes virtualenv name
+  - `python_info[version]` exposes virtualenv python version (eg. py-3.4.1, py-2.7.6)
 
 To display the name of the current virtual enviroment in a prompt, define the
 following style in the `prompt_name_setup` function.
@@ -82,7 +84,7 @@ following style in the `prompt_name_setup` function.
     zstyle ':prezto:module:python:info:virtualenv' format 'virtualenv:%v'
 
 Then add `$python_info[virtualenv]` to `$PROMPT` or `$RPROMPT` and call
-`python-info` in the `prompt_name_preexec` hook function.
+`python-info` in the `prompt_name_precmd` hook function.
 
 Authors
 -------

--- a/modules/python/functions/python-info
+++ b/modules/python/functions/python-info
@@ -18,4 +18,6 @@ if [[ -n "$VIRTUAL_ENV" ]]; then
   zstyle -s ':prezto:module:python:info:virtualenv' format 'virtualenv_format'
   zformat -f virtualenv_formatted "$virtualenv_format" "v:${VIRTUAL_ENV:t}"
   python_info[virtualenv]="$virtualenv_formatted"
+  PY_VERSION=`python -V 2>&1`
+  python_info[version]="py-"$PY_VERSION[(w)2]
 fi


### PR DESCRIPTION
python_info[version] will show python version number in the format "py-3.4.1" (without the quotes.)

Also changed prompt_name_preexec to prompt_name_precmd. 
prompt_name_precmd is executed before the prompt is loaded.
This makes loading the prompt with python info sort of "proactive".
