### PR TITLE
Add io.js support to the node module so iojs/node can be output

### DIFF
--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -21,13 +21,15 @@ Functions
 Theming
 -------
 
-To display the version number of the current Node.js version, define the
+To display the version number or fork of the current Node.js or io.js version, define the
 following style inside the `prompt_name_setup` function.
 
     # %v - Node.js version.
+    # %f - Node.js fork (either node or iojs).
     zstyle ':prezto:module:node:info:version' format 'version:%v'
+    zstyle ':prezto:module:node:info:version' format 'fork:%f'
 
-Then add `$node_info[version]` to either `$PROMPT` or `$RPROMPT` and call
+Then add `$node_info[version]` and/or `$node_info[fork]` to either `$PROMPT` or `$RPROMPT` and call
 `node-info` in `prompt_name_preexec` hook function.
 
 Authors
@@ -37,6 +39,7 @@ Authors
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
   - [Zeh Rizzatti](https://github.com/zehrizzatti)
+  - [Robbie Trencheny](https://github.com/robbiet480)
 
 [1]: http://nodejs.org
 [2]: http://npmjs.org

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -27,7 +27,7 @@ following style inside the `prompt_name_setup` function.
     # %v - Node.js version.
     # %f - Node.js fork (either node or iojs).
     zstyle ':prezto:module:node:info:version' format 'version:%v'
-    zstyle ':prezto:module:node:info:version' format 'fork:%f'
+    zstyle ':prezto:module:node:info:fork' format 'fork:%f'
 
 Then add `$node_info[version]` and/or `$node_info[fork]` to either `$PROMPT` or `$RPROMPT` and call
 `node-info` in `prompt_name_preexec` hook function.

--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -4,6 +4,7 @@
 #
 # Authors:
 #   Zeh Rizzatti <zehrizzatti@gmail.com>
+#   Robbie Trencheny <me@robbiet.us>
 #
 
 local version
@@ -14,11 +15,19 @@ unset node_info
 typeset -gA node_info
 
 if (( $+functions[nvm_version] )); then
-  version="${$(nvm_version)#v}"
+  version="${$(nvm_version)#iojs-#v}"
+  if nvm_is_iojs_version "$(nvm_version)"; then
+    fork="$(nvm_iojs_prefix)"
+  else
+    fork="$(nvm_node_prefix)"
+  fi
 fi
 
 if [[ "$version" != (none|) ]]; then
   zstyle -s ':prezto:module:node:info:version' format 'version_format'
   zformat -f version_formatted "$version_format" "v:$version"
+  zstyle -s ':prezto:module:node:info:fork' format 'fork_format'
+  zformat -f fork_formatted "$fork_format" "f:$fork"
   node_info[version]="$version_formatted"
+  node_info[fork]="$fork_formatted"
 fi


### PR DESCRIPTION
This adds `$node_info[fork]` which will contain either `node` or `iojs`, depending on what is currently active according to nvm.