### PR TITLE
For VI folks: Remap ESC to something else

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -247,6 +247,13 @@ bindkey -M vicmd "v" edit-command-line
 bindkey -M vicmd "u" undo
 bindkey -M vicmd "$key_info[Control]R" redo
 
+
+# Allow remapping of command-mode key
+zstyle -s ':prezto:module:editor' escape-remap 'escape_remap'
+if [[ ! -z "$escape_remap" ]]; then
+  bindkey -M viins "$escape_remap" vi-cmd-mode
+fi
+
 if (( $+widgets[history-incremental-pattern-search-backward] )); then
   bindkey -M vicmd "?" history-incremental-pattern-search-backward
   bindkey -M vicmd "/" history-incremental-pattern-search-forward

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -41,6 +41,9 @@ zstyle ':prezto:load' pmodule \
 # Set the key mapping style to 'emacs' or 'vi'.
 zstyle ':prezto:module:editor' key-bindings 'emacs'
 
+# If you prefer to have a different Escape key in 'vi' mode
+# zstyle ':prezto:module:editor' escape-remap 'jk'
+
 # Auto convert .... to ../..
 # zstyle ':prezto:module:editor' dot-expansion 'yes'
 


### PR DESCRIPTION
Added the option to remap ESC to something else. Having `fd` on all my editors to enter command mode, this felt a little out of place :smile: 
