### PR TITLE
Fix grc alias to anything but grc so Generic Colourizer won't fail

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -127,7 +127,7 @@ alias gpp='git pull origin "$(git-branch-current 2> /dev/null)" && git push orig
 # Rebase (r)
 alias gr='git rebase'
 alias gra='git rebase --abort'
-alias grc='git rebase --continue'
+alias grr='git rebase --continue'
 alias gri='git rebase --interactive'
 alias grs='git rebase --skip'
 


### PR DESCRIPTION
The git module's aliases cause an issue when also using the Generic Colourizer tool, causing commands like make to instantly fail, since grc is called to colorize make's output. Other commands are also affected from this; the one I noticed first was make.

The grr alias was something I came up with just as a quickfix; If there's a better alias to give it, please feel free to change it. 

Unless you want git to growl :smiley: 