### PR TITLE
Make "o" to be able to open multiple files

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -111,15 +111,11 @@ if zstyle -t ':prezto:module:utility:grep' color; then
 fi
 
 # Mac OS X Everywhere
-if [[ "$OSTYPE" == darwin* ]]; then
-  alias o='open'
-elif [[ "$OSTYPE" == cygwin* ]]; then
+if [[ "$OSTYPE" == cygwin* ]]; then
   alias o='cygstart'
   alias pbcopy='tee > /dev/clipboard'
   alias pbpaste='cat /dev/clipboard'
 else
-  alias o='xdg-open'
-
   if (( $+commands[xclip] )); then
     alias pbcopy='xclip -selection clipboard -in'
     alias pbpaste='xclip -selection clipboard -out'
@@ -128,6 +124,20 @@ else
     alias pbpaste='xsel --clipboard --output'
   fi
 fi
+
+function o() {
+  open_cmd='xdg-open'
+  if [[ "$OSTYPE" == darwin* ]]; then
+    open_cmd='open'
+  elif [[ "$OSTYPE" == cygwin* ]]; then
+    open_cmd='cygstart'
+  fi
+
+  for f in "$@"
+  do
+    $open_cmd $f
+  done
+}
 
 alias pbc='pbcopy'
 alias pbp='pbpaste'


### PR DESCRIPTION
Current "o" is simply an alias of the default open command on a specific platform. This commit replaces this alias with a function, which accepts arbitrary number of arguments to open multiple files with default
applications at one command.