### PR TITLE
add support for nodenv

### DIFF
--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -16,7 +16,7 @@ typeset -gA node_info
 if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
 elif (( $+commands[nodenv] )); then
-  version="${$(nodenv version)#v}"
+  version="${${$(nodenv version)#v}[(w)0]}"
 fi
 
 if [[ "$version" != (none|) ]]; then

--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -15,6 +15,8 @@ typeset -gA node_info
 
 if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
+elif (( $+commands[nodenv] )); then
+  version="${$(nodenv version)#v}"
 fi
 
 if [[ "$version" != (none|) ]]; then

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -14,6 +14,14 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2>/dev/null)" ]]; then
   source $(brew --prefix nvm)/nvm.sh
 
+# Load manually installed nodenv into the shell session.
+elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$($HOME/.nodenv/bin/nodenv init -)"
+
+# Load package manager installed nodenv into the shell session.
+elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nodenv 2>/dev/null)" ]]; then
+  eval "$($(brew --prefix nodenv)/bin/nodenv init -)"
+
 # Return if requirements are not found.
 elif (( ! $+commands[node] )); then
   return 1


### PR DESCRIPTION
nodenv is a node version manager. 
This PR is used to initialize nodenv and to get node version for prompt. 

nodenv: https://github.com/wfarr/nodenv
