### PR TITLE
Fix the sorin prompt theme

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -57,7 +57,7 @@ function prompt_sorin_git_info {
     _prompt_sorin_precmd_async_pid=0
 
     # Redisplay prompt.
-    zle && zle reset-prompt
+    zle && zle .reset-prompt
   fi
 }
 


### PR DESCRIPTION
This fixes https://github.com/sorin-ionescu/prezto/issues/1026 by changing `zle reset-prompt` to `zle .reset-prompt`. This matches the behavior of the `pure` theme.