### PR TITLE
Add CMake module

### DIFF
--- a/modules/cmake/README.md
+++ b/modules/cmake/README.md
@@ -1,0 +1,44 @@
+CMake
+=====
+
+Initializes build directories for [CMake][1].
+
+### Usage
+
+```sh
+# In the root directory of a CMake project:
+$ mb
+# Or with additional flags:
+$ mb -DSOME_EXTRA_FLAGS="foo"
+```
+
+### Options
+
+```sh
+# Set the install prefix.
+zstyle ':prezto:module:cmake' install-prefix '/usr'
+
+# Set the build prefix.
+zstyle ':prezto:module:cmake' build-prefix '_build'
+
+# Set the build profiles.
+zstyle ':prezto:module:cmake' profiles 'Debug' 'Release'
+
+# Whether to support clang as well.
+zstyle ':prezto:module:cmake' support-clang 'yes'
+```
+
+### Aliases
+
+* `mb` initialize build directories.
+
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Benjamin Chrétien](https://github.com/bchretien)
+
+[1]: https://cmake.org
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/cmake/README.md
+++ b/modules/cmake/README.md
@@ -15,16 +15,19 @@ $ mb -DSOME_EXTRA_FLAGS="foo"
 ### Options
 
 ```sh
-# Set the install prefix.
+# Set the install prefix (else CMake's default prefix will be used)
 zstyle ':prezto:module:cmake' install-prefix '/usr'
 
-# Set the build prefix.
+# Set the build prefix (else '_build' will be used)
 zstyle ':prezto:module:cmake' build-prefix '_build'
 
-# Set the build profiles.
+# Set the build profiles (else Debug and Release will be used)
 zstyle ':prezto:module:cmake' profiles 'Debug' 'Release'
 
-# Whether to support clang as well.
+# Set the generator (else CMake's default generator will be used)
+zstyle ':prezto:module:cmake' generator 'Unix Makefiles'
+
+# Whether to support clang as well (default is 'yes')
 zstyle ':prezto:module:cmake' support-clang 'yes'
 ```
 

--- a/modules/cmake/init.zsh
+++ b/modules/cmake/init.zsh
@@ -6,9 +6,9 @@
 #   Thomas Moulard <thomas dot moulard at gmail dot com>
 #
 
-# Get the install prefix or use the default.
+# Get the install prefix.
 zstyle -s ':prezto:module:cmake' install-prefix '_cmake_install_prefix' \
-  || _cmake_install_prefix='/usr'
+  || _cmake_install_prefix=
 
 # Get the build prefix.
 zstyle -s ':prezto:module:cmake' build-prefix '_cmake_build_prefix' \
@@ -18,11 +18,15 @@ zstyle -s ':prezto:module:cmake' build-prefix '_cmake_build_prefix' \
 zstyle -a ':prezto:module:cmake' profiles '_cmake_profiles' \
   || _cmake_profiles=(Debug Release)
 
+# Get the generator to use.
+zstyle -s ':prezto:module:cmake' generator '_cmake_generator' \
+  || _cmake_generator=
+
 # Whether to look for clang as well.
 zstyle -b ':prezto:module:cmake' support-clang '_cmake_support_clang' \
   || _cmake_support_clang=true
 
-# Check for clang
+# Check for clang.
 _cmake_has_clang=false
 if (( ${_cmake_support_clang} && $+commands[clang] )); then
   _cmake_has_clang=true
@@ -38,16 +42,25 @@ function makeBuildDirectory
     return 1
   fi
 
-  local common_flags="-DCMAKE_INSTALL_PREFIX=${_cmake_install_prefix}"
+  local common_flags=""
+
+  # If an install prefix was provided.
+  if [[ ! -z "${_cmake_install_prefix}" ]]; then
+    common_flags+=" -DCMAKE_INSTALL_PREFIX=\"${_cmake_install_prefix}\""
+  fi
+
+  # If a generator was provided.
+  if [[ ! -z "${_cmake_generator}" ]]; then
+    common_flags+=" -G\"${_cmake_generator}\""
+  fi
 
   # Create default GCC profiles.
   for p in "${_cmake_profiles[@]}"; do
     echo "*** Creating ${p:l} profile..."
     local build_dir="${d}/${_cmake_build_prefix}/${p:l}"
+    local cmake_cmd="cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \"${d}\""
     mkdir -p "${build_dir}"
-    (cd "${build_dir}" && \
-      cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \
-      "${d}")
+    (cd "${build_dir}" && eval ${cmake_cmd})
     echo "*** ...done!"
   done
 
@@ -56,11 +69,9 @@ function makeBuildDirectory
     for p in "${_cmake_profiles[@]}"; do
       echo "*** Creating ${p:l} profile (clang)..."
       local build_dir="${d}/${_cmake_build_prefix}/clang+${p:l}"
+      local cmake_cmd="cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \"${d}\""
       mkdir -p "${build_dir}"
-      (cd "${build_dir}" && \
-        CC=clang CXX=clang++ \
-        cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \
-        "${d}")
+      (cd "${build_dir}" && CC=clang CXX=clang++ eval ${cmake_cmd})
       echo "*** ...done!"
     done
   fi

--- a/modules/cmake/init.zsh
+++ b/modules/cmake/init.zsh
@@ -1,0 +1,74 @@
+#
+# Initialize build directories for CMake.
+#
+# Authors:
+#   Benjamin Chrétien <chretien dot b at gmail dot com>
+#   Thomas Moulard <thomas dot moulard at gmail dot com>
+#
+
+# Get the install prefix or use the default.
+zstyle -s ':prezto:module:cmake' install-prefix '_cmake_install_prefix' \
+  || _cmake_install_prefix='/usr'
+
+# Get the build prefix.
+zstyle -s ':prezto:module:cmake' build-prefix '_cmake_build_prefix' \
+  || _cmake_build_prefix='_build'
+
+# Get the profiles to consider or use the default.
+zstyle -a ':prezto:module:cmake' profiles '_cmake_profiles' \
+  || _cmake_profiles=(Debug Release)
+
+# Whether to look for clang as well.
+zstyle -b ':prezto:module:cmake' support-clang '_cmake_support_clang' \
+  || _cmake_support_clang=true
+
+# Check for clang
+_cmake_has_clang=false
+if (( ${_cmake_support_clang} && $+commands[clang] )); then
+  _cmake_has_clang=true
+fi
+
+function makeBuildDirectory
+{
+  local extra_flags="$@"
+
+  local d=`pwd`
+  if `test x$(find . -maxdepth 1 -name CMakeLists.txt) = x`; then
+    echo "Run this in your project's root directory"
+    return 1
+  fi
+
+  local common_flags="-DCMAKE_INSTALL_PREFIX=${_cmake_install_prefix}"
+
+  # Create default GCC profiles.
+  for p in "${_cmake_profiles[@]}"; do
+    echo "*** Creating ${p:l} profile..."
+    local build_dir="${d}/${_cmake_build_prefix}/${p:l}"
+    mkdir -p "${build_dir}"
+    (cd "${build_dir}" && \
+      cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \
+      "${d}")
+    echo "*** ...done!"
+  done
+
+  # If clang is available, create clang profiles.
+  if ${_cmake_has_clang}; then
+    for p in "${_cmake_profiles[@]}"; do
+      echo "*** Creating ${p:l} profile (clang)..."
+      local build_dir="${d}/${_cmake_build_prefix}/clang+${p:l}"
+      mkdir -p "${build_dir}"
+      (cd "${build_dir}" && \
+        CC=clang CXX=clang++ \
+        cmake ${common_flags} ${extra_flags} -DCMAKE_BUILD_TYPE=${p} \
+        "${d}")
+      echo "*** ...done!"
+    done
+  fi
+}
+
+alias mb=makeBuildDirectory
+
+# Enable CMake completion
+(( $+functions[compdef] )) && {
+  compdef _cmake makeBuildDirectory
+}


### PR DESCRIPTION
This module simplifies the creation of build directories with CMake. The install prefix, build prefix and build profiles can be specified in the prezto configuration file. Clang is supported, and CMake completion is enabled for the alias.
