### PR TITLE
Use less destructive git push --force-with-lease.

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -117,7 +117,8 @@ alias gmt='git mergetool'
 
 # Push (p)
 alias gp='git push'
-alias gpf='git push --force'
+alias gpf='git push --force-with-lease'
+alias gpF='git push --force'
 alias gpa='git push --all'
 alias gpA='git push --all && git push --tags'
 alias gpt='git push --tags'


### PR DESCRIPTION
`alias gpf='git push --force'` is destructive. Using the `--force-with-lease` option is much safer and prevents accidentally destroying another's work in the same branch.

Also added a `gpF` alias to allow using `--force` if really desired.

See this post about the flag: http://movingfast.io/articles/git-force-pushing/
