### PR TITLE
Add alias for log with filename to git module

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -107,6 +107,7 @@ alias glo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
 alias glg='git log --topo-order --all --graph --pretty=format:"${_git_log_oneline_format}"'
 alias glb='git log --topo-order --pretty=format:"${_git_log_brief_format}"'
 alias glc='git shortlog --summary --numbered'
+alias gln='git log --topo-order --name-only --pretty=format:"${_git_log_brief_format}"'
 
 # Merge (m)
 alias gm='git merge'


### PR DESCRIPTION
Fix for enhancement request issue #1045.

It adds a new alias `gln` to git module, which expands to:
```
$ git log --name-only [prezto formatting]
```