### PR TITLE
Add new functions (wherefrom and settings) to OS X module

### DIFF
--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -23,6 +23,8 @@ Functions
   - `osx-rm-dir-metadata` deletes .DS\_Store, \_\_MACOSX cruft.
   - `osx-ls-download-history` displays the Mac OS X download history.
   - `osx-rm-download-history` deletes the Mac OS X download history.
+  - `wherefrom` sets the Mac OS X download location for a file.
+  - `settings` changes the terminal settings for the current window.
 
 Authors
 -------

--- a/modules/osx/functions/_settings
+++ b/modules/osx/functions/_settings
@@ -1,0 +1,10 @@
+#compdef settings
+
+_known_settings=$(osascript 2>/dev/null <<EOF
+    tell application "Terminal" to get name of every settings set
+EOF
+)
+
+_arguments \
+  "1:Terminal Settings:( \${(s:, :)_known_settings} )"
+

--- a/modules/osx/functions/_wherefrom
+++ b/modules/osx/functions/_wherefrom
@@ -1,0 +1,5 @@
+#compdef wherefrom
+
+_arguments \
+  "1:Download URL" \
+  "*:Downloaded File:_files"

--- a/modules/osx/functions/settings
+++ b/modules/osx/functions/settings
@@ -1,0 +1,36 @@
+#
+# Opens a new Terminal window using the specified settings
+#
+# Authors:
+#   josho
+#
+
+if (( $# < 1 )); then
+  local known_settings
+  known_settings=$(osascript 2>/dev/null <<EOF
+    tell application "Terminal" to get name of every settings set
+EOF
+)
+  cat >&2 <<EOF
+Usage: $0 [${known_settings}]
+EOF
+  return 1
+fi
+
+local settings=$1
+local the_app=$(
+  osascript 2>/dev/null <<EOF
+    tell application "System Events"
+      name of first item of (every process whose frontmost is true)
+    end tell
+EOF
+)
+
+if [[ "$the_app" == 'Terminal' ]]; then
+  osascript 2>/dev/null <<EOF
+    tell application "Terminal" to set current settings of first window to settings set "$settings"
+EOF
+else
+  echo Unsupported terminal
+  return 1
+fi

--- a/modules/osx/functions/tab
+++ b/modules/osx/functions/tab
@@ -8,7 +8,7 @@
 local command="cd \\\"$PWD\\\""
 (( $# > 0 )) && command="${command}; $*"
 
-the_app=$(
+local the_app=$(
   osascript 2>/dev/null <<EOF
     tell application "System Events"
       name of first item of (every process whose frontmost is true)

--- a/modules/osx/functions/wherefrom
+++ b/modules/osx/functions/wherefrom
@@ -1,0 +1,39 @@
+#
+# Tells Finder where a file was downloaded from
+#
+# List of spotlight metadata keys https://developer.apple.com/library/mac/#docum
+#
+# Authors:
+#   josho
+#
+
+local url
+local success
+
+if (( $# < 2 )); then
+  cat >&2 <<EOF
+Usage: $0 <url> [file ...]
+EOF
+return 1
+fi
+
+url=$1
+shift
+
+while (( $# > 0 )); do
+  if [[ -f "$1" ]]; then
+    # A json plist containing the Downloaded from URL
+    local plist='["'"$url"'"]'
+
+    # Convert to a hexdump representation of a binary plist
+    # In xxd set the max column count to avoid line breaks
+    local binplist=`echo -n "$plist" | plutil -convert binary1 -o - - | xxd -p -c 256`
+
+    xattr -wx 'com.apple.metadata:kMDItemWhereFroms' "$binplist" "$1"
+
+  else
+    print "$0: cannot read: $1" >&2
+    success=1
+  fi
+  shift
+done


### PR DESCRIPTION
These functions have been handy in my environment, so I thought I'd share with a larger audience.
- New function 'wherefrom' sets the OSX metadata in file(s) for Finder to
  show where the file was downloaded from
- New function 'settings' updates the Terminal window with a different settings
  configuration, e.g. to quickly change the window theme.
- Fix a missing local variable in the 'tab' function