### PR TITLE
Add autosuggestions module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "modules/prompt/functions/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
+[submodule "modules/autosuggestions/external/zsh-autosuggestions"]
+	path = modules/autosuggestions/external/zsh-autosuggestions
+	url = https://github.com/tarruda/zsh-autosuggestions

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -1,0 +1,10 @@
+# ZSH Autosuggestions
+
+This plugin enables [zsh-autosuggestions](https://github.com/tarruda/zsh-autosuggestions) and adds
+vi-mode compatible keybindings.
+
+## Keybindings
+
+* `CTRL-F` is bound to `vi-forward-word`, it is equivalent to hitting `w` in vim and accepts the
+  suggestion word by word
+* `CTRL-K` is bound to `vi-end-of-line` which effectively accepts the suggestion

--- a/modules/autosuggestions/init.zsh
+++ b/modules/autosuggestions/init.zsh
@@ -1,0 +1,13 @@
+source "${0:h}/external/zsh-autosuggestions/autosuggestions.zsh" || return 1
+
+zle-line-init() {
+  zle autosuggest-start
+}
+
+zle -N zle-line-init
+
+zstyle -s ':prezto:module:editor' key-bindings 'key_bindings'
+if [[ "$key_bindings" == vi ]]; then
+  bindkey '' vi-forward-word
+  bindkey '' vi-end-of-line
+fi


### PR DESCRIPTION
The modules uses zsh-autosuggestions as an external submodule and defines
useful keybindings for vi-mode.