### PR TITLE
remove TERM_PROGRAM condition

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -17,9 +17,7 @@ fi
 # Auto Start
 #
 
-if ([[ "$TERM_PROGRAM" = 'iTerm.app' ]] && \
-  zstyle -t ':prezto:module:tmux:iterm' integrate \
-); then
+if (zstyle -t ':prezto:module:tmux:iterm' integrate); then
   _tmux_iterm_integration='-CC'
 fi
 


### PR DESCRIPTION
The variable `TERM_PROGRAM` isn't being taken to the root when you change to superuser via `su - root`, even if it is set on the client:
```
SendEnv TERM_*
```
And on the server:
```
AcceptEnv TERM_*
```
As this only works for the user the session is initiated with and not for root, I suggest to remove the `$TERM_PROGRAM` condition (as oh-my-zsh does).

see
https://github.com/sorin-ionescu/prezto/issues/1071