### PR TITLE
gpg: fix enable-ssh-support detection

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -29,7 +29,7 @@ fi
 export GPG_TTY="$(tty)"
 
 # Integrate with the SSH module.
-if grep 'enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then
+if grep '^enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then
   # Load required functions.
   autoload -Uz add-zsh-hook
 


### PR DESCRIPTION
That line may be commented in the config file, and `#enable-ssh-support` was being detected as the feature being enabled.
