### PR TITLE
Detach from tmux if attached, before attach

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -38,7 +38,7 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" ]] && ( \
   fi
 
   # Attach to the 'prezto' session or to the last session used. (detach first)
-  exec tmux $_tmux_iterm_integration -d attach-session
+  exec tmux $_tmux_iterm_integration attach-session -d
 fi
 
 #

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -37,8 +37,8 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" ]] && ( \
       set-option -t "$tmux_session" destroy-unattached off &> /dev/null
   fi
 
-  # Attach to the 'prezto' session or to the last session used.
-  exec tmux $_tmux_iterm_integration attach-session
+  # Attach to the 'prezto' session or to the last session used. (detach first)
+  exec tmux $_tmux_iterm_integration -d attach-session
 fi
 
 #


### PR DESCRIPTION
If you are in a tmux session, and auto-start is enabled
Then you `sudo su` and then `su <username>` it will re-attach, in a loop.
This resolves that problem, by forcing a detach before a (re)attach.
