### PR TITLE
Git tag aliases

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -193,6 +193,11 @@ Aliases
   - `gSu` fetches and merges the latest changes for all submodule.
   - `gSx` removes a submodule.
 
+### Tag
+
+  - `gt` lists tags or creates tag.
+  - `gtl` lists tags matching pattern.
+
 ### Working directory
 
   - `gws` displays working-tree status in the short format.

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -168,6 +168,10 @@ alias gSs='git submodule sync'
 alias gSu='git submodule foreach git pull origin master'
 alias gSx='git-submodule-remove'
 
+# Tag (t)
+alias gt='git tag'
+alias gtl='git tag -l'
+
 # Working Copy (w)
 alias gws='git status --ignore-submodules=${_git_status_ignore_submodules} --short'
 alias gwS='git status --ignore-submodules=${_git_status_ignore_submodules}'


### PR DESCRIPTION
There aren't any git tag aliases. If you use git, you probably use tags. If you don't use aliases, you're inefficient.

This PR will make you more efficient.
