### PR TITLE
Show rev info when in detached HEAD

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -215,7 +215,8 @@ function git-info {
   fi
 
   # Get the branch.
-  branch="${$(git symbolic-ref HEAD 2> /dev/null)#refs/heads/}"
+  branch="${$(git symbolic-ref HEAD 2> /dev/null)#refs/heads/}" \
+      || branch="$(git rev-parse --short HEAD 2> /dev/null)"
 
   # Format branch.
   zstyle -s ':prezto:module:git:info:branch' format 'branch_format'


### PR DESCRIPTION
If you're in a detached HEAD state, it's not a symbolic ref, and so
`$branch` was left empty.