### PR TITLE
Add completion support for Homebrew

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -26,6 +26,13 @@ Aliases
   - `casks` searches for a cask.
   - `caskx` uninstalls a cask.
 
+Completion
+----------
+
+### Homebrew
+
+Sourced from [Homebrew official repository](2)
+
 Authors
 -------
 
@@ -33,5 +40,7 @@ Authors
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
   - [Griffin Yourick](https://github.com/tough-griff)
+  - [Nevin Valsaraj](http://github.com/nevinvalsaraj)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues
+[2]: https://github.com/Homebrew/homebrew/blob/master/Library/Contributions/brew_zsh_completion.zsh

--- a/modules/homebrew/functions/_brew
+++ b/modules/homebrew/functions/_brew
@@ -1,0 +1,147 @@
+#compdef brew
+#autoload
+
+# Brew ZSH completion function
+# Sourced from Homebrew official repository
+# https://github.com/Homebrew/homebrew/blob/master/Library/Contributions/brew_zsh_completion.zsh
+
+_brew_all_formulae() {
+  formulae=(`brew search`)
+}
+
+_brew_installed_formulae() {
+  installed_formulae=(`brew list`)
+}
+
+_brew_installed_taps() {
+  installed_taps=(`brew tap`)
+}
+
+_brew_official_taps() {
+  official_taps=(`brew tap --list-official`)
+}
+
+_brew_pinned_taps() {
+  pinned_taps=(`brew tap --list-pinned`)
+}
+
+_brew_outdated_formulae() {
+  outdated_formulae=(`brew outdated`)
+}
+
+local -a _1st_arguments
+_1st_arguments=(
+  'audit:check formulae for Homebrew coding style'
+  'cat:display formula file for a formula'
+  'cleanup:uninstall unused and old versions of packages'
+  'commands:show a list of commands'
+  'config:show homebrew and system configuration'
+  'create:create a new formula'
+  'deps:list dependencies and dependants of a formula'
+  'desc:display a description of a formula'
+  'doctor:audits your installation for common issues'
+  'edit:edit a formula'
+  'fetch:download formula resources to the cache'
+  'gist-logs:generate a gist of the full build logs'
+  'home:visit the homepage of a formula or the brew project'
+  'info:information about a formula'
+  'install:install a formula'
+  'reinstall:install a formula anew; re-using its current options'
+  'leaves:show installed formulae that are not dependencies of another installed formula'
+  'link:link a formula'
+  'linkapps:symlink .app bundles provided by formulae into /Applications'
+  'list:list files in a formula or not-installed formulae'
+  'log:git commit log for a formula'
+  'missing:check all installed formuale for missing dependencies.'
+  'migrate:migrate renamed formula to new name'
+  'outdated:list formulae for which a newer version is available'
+  'pin:pin specified formulae'
+  'postinstall:perform post_install for a given formula'
+  'prune:remove dead links'
+  'remove:remove a formula'
+  'search:search for a formula (/regex/ or string)'
+  'switch:switch between different versions of a formula'
+  'tap:tap a new formula repository from GitHub, or list existing taps'
+  'tap-info:information about a tap'
+  'tap-pin:pin a tap'
+  'tap-unpin:unpin a tap'
+  'test-bot:test a formula and build a bottle'
+  'uninstall:uninstall a formula'
+  'unlink:unlink a formula'
+  'unlinkapps:remove symlinked .app bundles provided by formulae from /Applications'
+  'unpin:unpin specified formulae'
+  'untap:remove a tapped repository'
+  'update:fetch latest version of Homebrew and all formulae'
+  'upgrade:upgrade outdated formulae'
+  'uses:show formulae which depend on a formula'
+  `brew commands --quiet --include-aliases`
+)
+
+local expl
+local -a formulae installed_formulae installed_taps official_taps outdated_formulae
+
+_arguments \
+  '(-v)-v[verbose]' \
+  '(--cellar)--cellar[brew cellar]' \
+  '(--env)--env[brew environment]' \
+  '(--repository)--repository[brew repository]' \
+  '(--version)--version[version information]' \
+  '(--prefix)--prefix[where brew lives on this system]' \
+  '(--cache)--cache[brew cache]' \
+  '*:: :->subcmds' && return 0
+
+if (( CURRENT == 1 )); then
+  _describe -t commands "brew subcommand" _1st_arguments
+  return
+fi
+
+case "$words[1]" in
+  install|reinstall|audit|home|homepage|log|info|abv|uses|cat|deps|desc|edit|options|switch)
+    _brew_all_formulae
+    _wanted formulae expl 'all formulae' compadd -a formulae ;;
+  linkapps|unlinkapps)
+    _arguments \
+      '(--local)--local[operate on ~/Applications instead of /Applications]' \
+      '1: :->forms' && return 0
+
+    if [[ "$state" == forms ]]; then
+      _brew_installed_formulae
+      _wanted installed_formulae expl 'installed formulae' compadd -a installed_formulae
+    fi ;;
+  list|ls)
+    _arguments \
+      '(--unbrewed)--unbrewed[files in brew --prefix not controlled by brew]' \
+      '(--pinned)--pinned[list all versions of pinned formulae]' \
+      '(--versions)--versions[list all installed versions of a formula]' \
+      '1: :->forms' && return 0
+
+      if [[ "$state" == forms ]]; then
+        _brew_installed_formulae
+        _wanted installed_formulae expl 'installed formulae' compadd -a installed_formulae
+      fi ;;
+  remove|rm|uninstall|unlink|cleanup|link|ln|pin|unpin)
+    _brew_installed_formulae
+    _wanted installed_formulae expl 'installed formulae' compadd -a installed_formulae ;;
+  search|-S)
+    _arguments \
+      '(--macports)--macports[search the macports repository]' \
+      '(--fink)--fink[search the fink repository]' ;;
+  untap|tap-info|tap-pin)
+    _brew_installed_taps
+    _wanted installed_taps expl 'installed taps' compadd -a installed_taps ;;
+  tap)
+    _brew_official_taps
+    _wanted official_taps expl 'official taps' compadd -a official_taps ;;
+  tap-unpin)
+    _brew_pinned_taps
+    _wanted pinned_taps expl 'pinned taps' compadd -a pinned_taps ;;
+  upgrade)
+    _arguments \
+      '(--cleanup)--cleanup[remove previously installed formula version(s)]' \
+      '1: :->forms' && return 0
+
+    if [[ "$state" == forms ]]; then
+      _brew_outdated_formulae
+      _wanted outdated_formulae expl 'outdated formulae' compadd -a outdated_formulae
+    fi ;;
+esac


### PR DESCRIPTION
- Add completion function for Homebrew under the `homebrew` module.
- Partially adds feature requested in #1115
- Update Readme of `homebrew` module to add reference to original source and
update authors list.

Completion sourced from [Homebrew official repository](https://github.com/Homebrew/homebrew/blob/master/Library/Contributions/brew_zsh_completion.zsh)
