### PR TITLE
Correct vim-style autosuggest-accept binding.

### DIFF
--- a/modules/autosuggestions/init.zsh
+++ b/modules/autosuggestions/init.zsh
@@ -31,5 +31,5 @@ fi
 if [[ -n "$key_info" ]]; then
   # vi
   bindkey -M viins "$key_info[Control]F" vi-forward-word
-  bindkey -M viins "$key_info[Control]E" vi-add-eol
+  bindkey -M viins "$key_info[Control]E" vi-end-of-line
 fi


### PR DESCRIPTION
Update the vim-style command line binding for Ctrl-E such that it
properly accepts autosuggestions (instead of doing nothing).