### PR TITLE
Add notice about potential shadowing of the gb command

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -214,6 +214,7 @@ The following aliases may shadow system commands:
 
   - `gpt` shadows the [GUID partition table maintenance utility][4].
   - `gs` shadows the [Ghostscript][5].
+  - `gb` shadows the [GB][9].
 
 If you frequently use the above commands, you may wish to remove said aliases
 from this module or to disable them at the bottom of the zshrc with `unalias`.
@@ -332,3 +333,4 @@ Authors
 [6]: https://github.com/sorin-ionescu/prezto/issues
 [7]: https://github.com/sorin-ionescu/prezto/issues/219
 [8]: http://www.kernel.org/pub/software/scm/git/docs/git-log.html
+[9]: https://getgb.io/


### PR DESCRIPTION
When you're using the git module, it will override your `gb` command from the [Go build tool](https://getgb.io/about/).
I added just a note about it.
