### PR TITLE
Change VIRTUALENVWRAPPER_VIRTUALENV_ARGS example

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -55,11 +55,10 @@ is used. Replace *Developer* with your projects directory.
     export PROJECT_HOME="$HOME/Developer"
 
 The variable `$VIRTUALENVWRAPPER_VIRTUALENV_ARGS` tells virtualenvwrapper what
-arguments to pass to `virtualenv`. For example, set the value to
-*--no-site-packages* to ensure that all new environments are isolated from the
-system site-packages directory.
+arguments to pass to `virtualenv`. For example, set *--download* to force
+pre-installed packages to be re-downloaded from PyPI.
 
-    export VIRTUALENVWRAPPER_VIRTUALENV_ARGS='--no-site-packages'
+    export VIRTUALENVWRAPPER_VIRTUALENV_ARGS='--download'
 
 Aliases
 -------


### PR DESCRIPTION
`--no-site-packages` option is deprecated, so we should use something else
as an example so we don't mislead folks: 
https://virtualenv.pypa.io/en/latest/reference.html#cmdoption--no-site-packages

I wasn't sure what might be best as the new example, this looked reasonable.
