### PR TITLE
Added conda virtualenv support to python module.

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -3,6 +3,19 @@ Python
 
 Enables local Python and local Python package installation.
 
+Settings
+--------
+
+This module supports virtual environments from conda and virtualenvwrapper. By default, only virtualenvwrapper is enabled. To disable virtualenvwrapper, add the following to *zpreztorc*.
+
+    zstyle ':prezto:module:python' skip-virtualenvwrapper-init 'on'
+
+Conda support is enabled by adding the following to *zpreztorc*.
+
+    zstyle ':prezto:module:python' conda-init 'on'
+
+Caution: using conda and virtualenvwrapper at the same time may cause conflicts.
+
 Local Python Installation
 -------------------------
 

--- a/modules/python/functions/python-info
+++ b/modules/python/functions/python-info
@@ -4,6 +4,7 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Patrick Bos <egpbos@gmail.com>
 #
 
 local virtualenv_format
@@ -17,5 +18,12 @@ typeset -gA python_info
 if [[ -n "$VIRTUAL_ENV" ]]; then
   zstyle -s ':prezto:module:python:info:virtualenv' format 'virtualenv_format'
   zformat -f virtualenv_formatted "$virtualenv_format" "v:${VIRTUAL_ENV:t}"
+  python_info[virtualenv]="$virtualenv_formatted"
+fi
+
+# Do the same for Conda virtual environments
+if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
+  zstyle -s ':prezto:module:python:info:virtualenv' format 'virtualenv_format'
+  zformat -f virtualenv_formatted "$virtualenv_format" "v:${CONDA_DEFAULT_ENV:t}"
   python_info[virtualenv]="$virtualenv_formatted"
 fi

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -4,6 +4,7 @@
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #   Sebastian Wiesner <lunaryorn@googlemail.com>
+#   Patrick Bos <egpbos@gmail.com>
 #
 
 # Load manually installed pyenv into the shell session.
@@ -44,6 +45,14 @@ if (( $? && $+commands[virtualenvwrapper.sh] )); then
   VIRTUAL_ENV_DISABLE_PROMPT=1
 
   source "$commands[virtualenvwrapper.sh]"
+fi
+
+# Load conda into the shell session, if requested
+zstyle -T ':prezto:module:python' conda-init
+if (( $? && $+commands[conda] )); then
+  if (( $(conda ..changeps1) )); then
+    echo "To make sure Conda doesn't change your prompt (should do that in the prompt module) run:\n  conda config --set changeps1 false"
+  fi
 fi
 
 #

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -52,6 +52,11 @@ zstyle -T ':prezto:module:python' conda-init
 if (( $? && $+commands[conda] )); then
   if (( $(conda ..changeps1) )); then
     echo "To make sure Conda doesn't change your prompt (should do that in the prompt module) run:\n  conda config --set changeps1 false"
+    # TODO:
+    # We could just run this ourselves. In an exit hook
+    # (add zsh-hook zshexit [(anonymous) function]) we could then set it back
+    # to the way it was before we changed it. However, I'm not sure if this is
+    # exception safe, so left it like this for now.
   fi
 fi
 


### PR DESCRIPTION
Conda is both a package manager like pip (but without the tedious compilation, because binary) and an environment manager like virtualenv (inside conda environments one can still use pip, if necessary). I like it a lot better than pip+venv. This PR slightly modifies the python module to be compatible with Conda as well as virtualenv. Virtualenv support works as before, the only real changes are:
- when using conda, virtualenv things are not loaded, since the two cannot be used together (maybe they can, but I can't think of a reason why one would want this)
- when inside a conda venv, python_info[virtualenv] is set to the right conda environment name.
