### PR TITLE
fixed vivisual key binding

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -240,8 +240,8 @@ fi
 # Vi Key Bindings
 #
 
-# Edit command in an external editor.
-bindkey -M vicmd "v" edit-command-line
+# Edit command in an external editor emacs style (v is used for visual mode)
+bindkey -M vicmd "$key_info[Control]X$key_info[Control]E" edit-command-line
 
 # Undo/Redo
 bindkey -M vicmd "u" undo


### PR DESCRIPTION
v is used as default for character wise visual mode since zsh 5.0.8; using emacs style C-x C-e to edit current command in full editor in editor module instead, which allows to use v as meant to
