### PR TITLE
add deer support - a ranger like tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "modules/autosuggestions/external"]
 	path = modules/autosuggestions/external
 	url = https://github.com/tarruda/zsh-autosuggestions
+[submodule "modules/deer/external"]
+	path = modules/deer/external
+	url = https://github.com/Vifon/deer.git

--- a/modules/deer/init.zsh
+++ b/modules/deer/init.zsh
@@ -1,0 +1,8 @@
+#
+# Load Deer Module
+#
+fpath=("${0:h}/external" $fpath)
+
+autoload -U deer
+zle -N deer
+bindkey '\ek' deer


### PR DESCRIPTION
[deer](https://github.com/Vifon/deer) is a ranger-like file navigator for zsh.

This PR adds the `deer` module with `alt-k` completion functionality.
