### PR TITLE
add sorin config variable to allow full PWD to be printed

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -38,8 +38,10 @@ function prompt_sorin_pwd {
   if [[ "$pwd" == (#m)[/~] ]]; then
     _prompt_sorin_pwd="$MATCH"
     unset MATCH
-  else
+  elif [[ "$SORIN_PROMPT_SHORT_PWD" == 'Y' ]]; then
     _prompt_sorin_pwd="${${${${(@j:/:M)${(@s:/:)pwd}##.#?}:h}%/}//\%/%%}/${${pwd:t}//\%/%%}"
+  else
+    _prompt_sorin_pwd="$pwd"
   fi
 }
 
@@ -129,6 +131,12 @@ function prompt_sorin_setup {
   zstyle ':prezto:module:git:info:untracked' format ' %%B%F{7}◼%f%%b'
   zstyle ':prezto:module:git:info:keys' format \
     'status' '$(coalesce "%b" "%p" "%c")%s%A%B%S%a%d%m%r%U%u'
+
+  # See if our user has turned off shortened pwd (default to on)
+  zstyle -s ':prezto:module:prompt:theme:sorin' shortPWD \
+       'SORIN_PROMPT_SHORT_PWD' \
+    || SORIN_PROMPT_SHORT_PWD='Y'
+  SORIN_PROMPT_SHORT_PWD="${(C)SORIN_PROMPT_SHORT_PWD[1,1]}"
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '


### PR DESCRIPTION
I have multiple source code paths for work that I need to be able to see at a glance, otherwise I have to keep typing "pwd" manually to see what directory I'm in. For example, I'll have 6 iTerm tabs open at once with these directories open:

/Volumes/SourceCode/src/git/project1-2014/foo/bar/baz/wibble/
/Volumes/SourceCode/src/git/project1-2014-rel/foo/bar/baz/wibble/
/Volumes/SourceCode/src/git/project1-2015/foo/bar/baz/wibble/
/Volumes/SourceCode/src/git/project1-2015-rel/foo/bar/baz/wibble/

And if all I can see is "/V/S/s/g/p/f/b/b/wibble" in my pwd for sorin, I can't tell what branch I'm in without typing pwd manually.

I've added a config variable to allow the full pwd to be printed instead of the shortened version. Totally new to prezto, so definitely open to comments/suggestions/changes.

Thanks!
