### PR TITLE
Export $TMPPREFIX in non-login interactive shells

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -71,4 +71,4 @@ if [[ ! -d "$TMPDIR" ]]; then
   mkdir -p -m 700 "$TMPDIR"
 fi
 
-TMPPREFIX="${TMPDIR%/}/zsh"
+export TMPPREFIX="${TMPDIR%/}/zsh"


### PR DESCRIPTION
The current implementation causes arguably confusing behavior; at least it tripped me up:

[![asciicast](https://asciinema.org/a/dfigewhqtq3238i4l1uaasdou.png)](https://asciinema.org/a/dfigewhqtq3238i4l1uaasdou)

Unless there is a reason `$TMPPREFIX` should differ when saying `zsh` vs `zsh -l`, lack of `export` for this profile variable was probably an oversight.
