### PR TITLE
git: add gbf alias to list all branches

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -42,6 +42,7 @@ Aliases
   - `gbs` lists branches and their commits with ancestry graphs.
   - `gbS` lists local and remote branches and their commits with ancestry
     graphs.
+  - `gbf` list all branches in order of last modification and who the last committer was
   - `gbx` deletes a branch.
   - `gbX` deletes a branch irrespective of its merged status.
   - `gbm` renames a branch.

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -40,6 +40,7 @@ alias gbm='git branch -m'
 alias gbM='git branch -M'
 alias gbs='git show-branch'
 alias gbS='git show-branch -a'
+alias gbf='git-branch-list'
 
 # Commit (c)
 alias gc='git commit --verbose'

--- a/modules/git/functions/git-branch-list
+++ b/modules/git/functions/git-branch-list
@@ -1,0 +1,19 @@
+#
+# Lists the heads of branches and last modification time and user
+# Stolen from someone's git alias file, unfortunately do not remember original source.
+# My work was limited to reformatting this to work as a zsh alias
+#
+# Authors:
+#   Unknown
+#   Anton Stroganov <stroganov.a@gmail.com>
+#
+
+if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+  print "$0: not a repository work tree: $PWD" >&2
+  return 1
+fi
+
+for ref in $(git for-each-ref --sort=-committerdate --format="%(refname)" refs/heads/); do 
+  git log -n1 $ref --pretty=format:"%Cgreen%cr%Creset %C(yellow)%d%Creset %C(bold blue)<%an>%Creset%n"
+done \
+  | awk '! a[$0]++'


### PR DESCRIPTION
This new alias allows us to see the branches and their current status looking like this:

```
~/.zprezto ❯❯❯ gbf       

2 minutes ago  (HEAD -> anton) <Anton Stroganov>
4 minutes ago  (origin/git-gbf, master, git-gbf) <Anton Stroganov>
```
