### PR TITLE
Provide a simple installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
-Prezto — Instantly Awesome Zsh
-==============================
+# Prezto — Instantly Awesome Zsh
+
 
 Prezto is the configuration framework for [Zsh][1]; it enriches the command line
 interface environment with sane defaults, aliases, functions, auto completion,
 and prompt themes.
 
-Installation
-------------
+## Prerequisites
 
-Prezto will work with any recent release of Zsh, but the minimum required
-version is 4.3.17.
+Obviously you need to install [Zsh][1]. Prezto will work with any recent release of Zsh, but the minimum required version is 4.3.17.
 
-  1. Launch Zsh:
+## Installation
 
-        zsh
+### Automated installation
 
-  2. Clone the repository:
+`curl -sL https://github.com/sorin-ionescu/prezto/raw/install.zsh | zsh -`
 
-        git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
+### Manual installation:
 
-  3. Create a new Zsh configuration by copying the Zsh configuration files
-     provided:
+```bash
+# 1. Launch Zsh:
+zsh
 
-        setopt EXTENDED_GLOB
-        for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
-          ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
-        done
+# 2. Clone the repository:
+git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
 
-  4. Set Zsh as your default shell:
+# 3. Create a new Zsh configuration by copying the Zsh configuration files provided:
+setopt EXTENDED_GLOB
+for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
+  ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+done
 
-        chsh -s /bin/zsh
+# 4. Set Zsh as your default shell:
+chsh -s /bin/zsh
 
-  5. Open a new Zsh terminal window or tab.
+# 5. Open a new Zsh terminal window or tab.
+```
 
 ### Troubleshooting
 
@@ -67,21 +70,21 @@ accompanying README files to learn of what is available.
 
      ![sorin theme][2]
 
-Customization
--------------
+## Customization
+
 
 The project is managed via [Git][3]. It is highly recommended that you fork this
 project; so, that you can commit your changes and push them to [GitHub][4] to
 not lose them. If you do not know how to use Git, follow this [tutorial][5] and
 bookmark this [reference][6].
 
-Resources
----------
+## Resources
+
 
 The [Zsh Reference Card][7] and the [zsh-lovers][8] man page are indispensable.
 
-License
--------
+## License
+
 
 (The MIT License)
 

--- a/install.zsh
+++ b/install.zsh
@@ -1,29 +1,12 @@
 #!/usr/bin/env zsh
 setopt PIPEFAIL
 setopt EXTENDED_GLOB
-# setopt XTRACE prompt_subst
 
 ## Ensure colors are available.
 autoload -U colors && colors
 
 PREZTO_DIRECTORY="${ZDOTDIR:-$HOME}/.zprezto"
 PREZTO_GIT_REMOTE="https://github.com/ezintz/prezto.git"
-
-function is_osx {
-  if [[ "$OSTYPE" != darwin* ]]; then
-    return 1
-  fi
-
-  return 0
-}
-
-function is_linux {
-  if [[ "$OSTYPE" != linux* ]]; then
-    return 1
-  fi
-
-  return 0
-}
 
 function print_header {
   printf "\n${fg[blue]}%s${reset_color}\n" "$@"
@@ -63,14 +46,9 @@ function is_confirmed {
   return 1
 }
 
-function cleanup {
-  print_header "Cleanup"
-}
-
 TRAPINT() {
   print ""
   print_error "Caught SIGINT, aborting."
-  cleanup
   return $(( 128 + $1 ))
 }
 

--- a/install.zsh
+++ b/install.zsh
@@ -6,7 +6,7 @@ setopt EXTENDED_GLOB
 autoload -U colors && colors
 
 PREZTO_DIRECTORY="${ZDOTDIR:-$HOME}/.zprezto"
-PREZTO_GIT_REMOTE="https://github.com/ezintz/prezto.git"
+PREZTO_GIT_REMOTE="https://github.com/sorin-ionescu/prezto.git"
 
 function print_header {
   printf "\n${fg[blue]}%s${reset_color}\n" "$@"

--- a/install.zsh
+++ b/install.zsh
@@ -1,0 +1,98 @@
+#!/usr/bin/env zsh
+setopt PIPEFAIL
+setopt EXTENDED_GLOB
+# setopt XTRACE prompt_subst
+
+## Ensure colors are available.
+autoload -U colors && colors
+
+PREZTO_DIRECTORY="${ZDOTDIR:-$HOME}/.zprezto"
+PREZTO_GIT_REMOTE="https://github.com/ezintz/prezto.git"
+
+function is_osx {
+  if [[ "$OSTYPE" != darwin* ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+function is_linux {
+  if [[ "$OSTYPE" != linux* ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+function print_header {
+  printf "\n${fg[blue]}%s${reset_color}\n" "$@"
+}
+
+function print_success {
+  printf "${fg[green]}✓ %s${reset_color}\n" "$@"
+}
+
+function print_notice {
+  printf "${fg[yellow]}i %s${reset_color}\n" "$@"
+}
+
+function print_warning {
+  printf "${fg[magenta]}! %s${reset_color}\n" "$@"
+}
+
+function print_error {
+  printf "${fg[red]}x %s${reset_color}\n" "$@"
+}
+
+function print_question {
+  printf "${fg[cyan]}? %s${reset_color}\n" "$@"
+}
+
+function seek_confirmation {
+  print_warning "$@"
+  read -q "REPLY?${fg[cyan]}? Continue? (y/n)${reset_color} " -n 1
+  printf "\n"
+}
+
+function is_confirmed {
+  if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+function cleanup {
+  print_header "Cleanup"
+}
+
+TRAPINT() {
+  print ""
+  print_error "Caught SIGINT, aborting."
+  cleanup
+  return $(( 128 + $1 ))
+}
+
+print_header "Prezto — Instantly Awesome Zsh"
+seek_confirmation "Do you want to proceed with the installation"
+if is_confirmed; then
+  print_notice "Cloning prezto to $PREZTO_DIRECTORY ..."
+  if [[ ! -d $PREZTO_DIRECTORY ]]; then
+     git clone --recursive "$PREZTO_GIT_REMOTE" "$PREZTO_DIRECTORY"
+  fi
+  print_success "... done!"
+
+  print_notice "Creating sym links for prezto rcfiles ..."
+  for rcfile in "$PREZTO_DIRECTORY"/runcoms/^README.md(.N); do
+    tarfile="${ZDOTDIR:-$HOME}/.${rcfile:t}"
+    if [[ -f "$tarfile" ]]; then
+      print_warning "$tarfile already exists, creating a backup as ${tarfile}.backup"
+      mv "$tarfile" "${tarfile}.backup"
+    fi
+    ln -s "$rcfile" "$tarfile"
+  done
+  print_success "... done!"
+else
+  print_error "Installation aborted."
+fi


### PR DESCRIPTION
Hello,

from time to time, I am updating my prezto. Today was one of those days and somehow I found on the issues and pull requests a lot of installers that did not made it into master. This was kind of a motivation for me to try it as well, since I have a similar installer for my `dotfiles`.

#### _Which steps is the installer performing?_
- Asking the user if he wants to proceed with the installation
- Clone the repository to `PREZTO_DIRECTORY="${ZDOTDIR:-$HOME}/.zprezto"`
- Sym linking the runcoms and creating backups of the existing files 

#### _Why did you change the headings in the README.md?_

Somehow I wanted to have the headings in a consistent way to be identified when updating the file.

#### _Why does the installer does not change the shell for the user?_

Users that are switching from any other shell may have it already customized and might want to migrate later. Besides that there are many Terminals which provide the user to run a customized command which means: chsh -s may have no effect at all.

I guess that somehow the TRAPINIT needs somehow to do a cleanup, but for a first version it should be okay. If you see any issues with this pull request please let me know.