### PR TITLE
Allow syntax highlighting pattern styles

### DIFF
--- a/modules/syntax-highlighting/init.zsh
+++ b/modules/syntax-highlighting/init.zsh
@@ -26,3 +26,11 @@ for syntax_highlighting_style in "${(k)syntax_highlighting_styles[@]}"; do
   ZSH_HIGHLIGHT_STYLES[$syntax_highlighting_style]="$syntax_highlighting_styles[$syntax_highlighting_style]"
 done
 unset syntax_highlighting_style{s,}
+
+# Set pattern highlighting styles.
+typeset -A syntax_pattern_styles
+zstyle -a ':prezto:module:syntax-highlighting' pattern 'syntax_pattern_styles'
+for syntax_pattern_style in "${(k)syntax_pattern_styles[@]}"; do
+  ZSH_HIGHLIGHT_PATTERNS[$syntax_pattern_style]="$syntax_pattern_styles[$syntax_pattern_style]"
+done
+unset syntax_pattern_style{s,}

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -137,6 +137,10 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 #   'builtin' 'bg=blue' \
 #   'command' 'bg=blue' \
 #   'function' 'bg=blue'
+#
+# Set syntax pattern styles.
+# zstyle ':prezto:module:syntax-highlighting' pattern \
+#   'rm*-rf*' 'fg=white,bold,bg=red'
 
 #
 # Terminal


### PR DESCRIPTION
The syntax-highlighting module also allows to define some patterns to be highlighted. I have this already in my fork, maybe other also would like to use it (;
