### PR TITLE
Don't load pfunctions from vi backup files

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -25,7 +25,7 @@ unset min_zsh_version
 function pmodload {
   local -a pmodules
   local pmodule
-  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(-.N:t)'
+  local pfunction_glob='^([_.]*|prompt_*_setup|README*|*~)(-.N:t)'
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")


### PR DESCRIPTION
I couldn't figure out how a particular function was possibly getting loaded… turns out this regex will load functions from a vi backup file.
