### PR TITLE
fix url for node-docs

### DIFF
--- a/modules/node/functions/node-doc
+++ b/modules/node/functions/node-doc
@@ -11,4 +11,4 @@ if [[ -z "$BROWSER" ]]; then
 fi
 
 # TODO: Make the sections easier to use.
-"$BROWSER" "http://nodejs.org/docs/$(node --version | sed 's/-.*//')/api/all.html#${1}"
+"$BROWSER" "http://nodejs.org/docs/$(node --version | sed 's/-.*//')/api/${1}.html"


### PR DESCRIPTION
If you do `node-doc fs` with the current implementation it won't work because `all.html#fs` doesn't exist, there is a page already called `fs.html` so this fixes this issue.
