### PR TITLE
Resolves: Warning: We decided to not change the behaviour of `brew up…

### DIFF
--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -20,7 +20,7 @@ alias brewC='brew cleanup --force'
 alias brewi='brew install'
 alias brewl='brew list'
 alias brews='brew search'
-alias brewu='brew update && brew upgrade --all'
+alias brewu='brew update && brew upgrade'
 alias brewx='brew remove'
 
 # Homebrew Cask


### PR DESCRIPTION
Resolves: Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).

as of:
Homebrew 1.0.6
Homebrew/homebrew-core (git revision 5b51; last commit 2016-10-06)