### PR TITLE
Fix typo in modules/README.md

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -130,7 +130,7 @@ Provides aliases and functions for the Pacman package manager and frontends.
 Perl
 ----
 
-Enables local Perl module installation on Mac OS X and defines alises.
+Enables local Perl module installation on Mac OS X and defines aliases.
 
 Prompt
 ------


### PR DESCRIPTION
Fix typo...

`alises` => `aliases`
