### PR TITLE
Change $TMPDIR for non-interactive shells

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -67,8 +67,7 @@ fi
 #
 
 if [[ ! -d "$TMPDIR" ]]; then
-  export TMPDIR="/tmp/$LOGNAME"
-  mkdir -p -m 700 "$TMPDIR"
+  export TMPDIR="$(mktemp -d)"
 fi
 
 TMPPREFIX="${TMPDIR%/}/zsh"


### PR DESCRIPTION
This commit changes the way $TMPDIR is set by using `mktemp` rather
than a fixed string.
