### PR TITLE
Integrate zsh-notify

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "modules/autosuggestions/external"]
 	path = modules/autosuggestions/external
 	url = https://github.com/tarruda/zsh-autosuggestions
+[submodule "modules/zsh-notify/external"]
+	path = modules/zsh-notify/external
+	url = https://github.com/marzocchi/zsh-notify.git

--- a/modules/zsh-notify/README.md
+++ b/modules/zsh-notify/README.md
@@ -1,0 +1,21 @@
+zsh-notify
+====
+
+[zsh-notidy][1] is a plugin for the Z shell that posts desktop notifications when a command terminates with a non-zero exit status or when it took more than 30 seconds to complete, if the terminal application is in the background (or the terminal tab is inactive).
+
+Install
+-------
+
+When using the default notifier notifications are posted using [terminal-notifier.app][2] on Mac OS X and notify-send on other systems.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][3].*
+
+  - [Rui Coelho](https://github.com/rjcoelho)
+  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+
+[1]: https://github.com/marzocchi/zsh-notify
+[2]: https://github.com/alloy/terminal-notifier
+[3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/zsh-notify/init.zsh
+++ b/modules/zsh-notify/init.zsh
@@ -1,0 +1,5 @@
+#
+# Load zsh-notify Module
+#
+source "${0:h}/external/notify.plugin.zsh"
+


### PR DESCRIPTION
zsh-notify is a plugin for the Z shell that posts desktop notifications when a command terminates with a non-zero exit status or when it took more than 30 seconds to complete, if the terminal application is in the background (or the terminal tab is inactive).
