### PR TITLE
Updated Command to change the default shell in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ version is 4.3.17.
 
   4. Set Zsh as your default shell:
 
-        chsh -s /bin/zsh
+        chsh -s `which zsh` [username here]
 
   5. Open a new Zsh terminal window or tab.
 


### PR DESCRIPTION
This change only updates the command to change the default shell after installing prezto.

Currently it is 

`chsh -s /bin/zsh`

Issues with this are: 
1. On Ubuntu 14.04 and 16.04, This command will not change the default shell, Instead it'll give an error as shown in image.
2. The path where zsh is installed isn't always `/bin/zsh`, So i also changed that and made it a little bit better. 

What does this Improves: 

The suggested edit correctly changes the shell with very little input from user and also allow the user to change the default shell for a user account they are not logged in at that moment.