### PR TITLE
Add nodenv support to Node.js module

### DIFF
--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -10,6 +10,13 @@ nvm
 [nvm][5] allows for managing multiple, isolated Node.js installations in the
 home directory.
 
+nodenv
+------
+
+[nodenv][6] does one thing well. nodenv is concerned solely with switching
+Node versions. It's simple and predictable, Just Works, and is rock solid in
+production. nodenv is forked from the popular [rbenv][7].
+
 Functions
 ---------
 
@@ -43,3 +50,5 @@ Authors
 [3]: http://nodejs.org/api
 [4]: https://github.com/sorin-ionescu/prezto/issues
 [5]: https://github.com/creationix/nvm
+[6]: https://github.com/nodenv/nodenv
+[7]: https://github.com/sstephenson/rbenv

--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -15,6 +15,8 @@ typeset -gA node_info
 
 if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
+elif (( $+commands[nodenv] )); then
+  version="${${$(nodenv version)#v}[(w)0]}"
 fi
 
 if [[ "$version" != (none|) ]]; then

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -14,6 +14,14 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2>/dev/null)" ]]; then
   source $(brew --prefix nvm)/nvm.sh
 
+# Load manually installed nodenv into the shell session.
+elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$($HOME/.nodenv/bin/nodenv init -)"
+
+# Load package manager installed nodenv into the shell session.
+elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nodenv 2>/dev/null)" ]]; then
+  eval "$($(brew --prefix nodenv)/bin/nodenv init -)"
+
 # Return if requirements are not found.
 elif (( ! $+commands[node] )); then
   return 1


### PR DESCRIPTION
I had originally opened this PR back on the temporary "unofficial-official" fork over at `zsh-users` 😉  – Anyways, here's that a reference to that PR: https://github.com/zsh-users/prezto/pull/59.

I've been using the included changes to support `nodenv` in Prezto from my own fork for quite some time now.

- Implementation from https://github.com/sorin-ionescu/prezto/pull/1001
- Documentation from https://github.com/sorin-ionescu/prezto/pull/1178

Let me know if you have any questions.