### PR TITLE
Improve node module performance

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -16,11 +16,12 @@ elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2>/dev/null)" ]]; then
 
 # Load manually installed nodenv into the shell session.
 elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then
-  eval "$($HOME/.nodenv/bin/nodenv init -)"
+  path=("$HOME/.rbenv/bin $path")
+  eval "$(nodenv init - --no-rehash zsh)"
 
 # Load package manager installed nodenv into the shell session.
-elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nodenv 2>/dev/null)" ]]; then
-  eval "$($(brew --prefix nodenv)/bin/nodenv init -)"
+elif (( $+commands[nodenv] )); then
+  eval "$(nodenv init - --no-rehash zsh)"
 
 # Return if requirements are not found.
 elif (( ! $+commands[node] )); then


### PR DESCRIPTION
`brew --prefix` can be an expensive operation, and if `nodenv` is installed it should live in the user's $PATH anyway. These changes improve performance and parity with the `ruby` module.