### PR TITLE
ADDED: tab-title function in osx module

### DIFF
--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -23,6 +23,7 @@ Functions
   - `osx-rm-dir-metadata` deletes .DS\_Store, \_\_MACOSX cruft.
   - `osx-ls-download-history` displays the Mac OS X download history.
   - `osx-rm-download-history` deletes the Mac OS X download history.
+  - `tab-title` sets the tab title (works in both _Terminal_ and [_iTerm_][3]).
 
 Authors
 -------

--- a/modules/osx/functions/tab-title
+++ b/modules/osx/functions/tab-title
@@ -1,0 +1,14 @@
+#
+# Changes the current tab title
+#
+# Authors:
+#   nstCactus <snstCactus@gmail.com>
+#
+
+
+
+function tab-title {
+  echo -ne "\033]0;"$*"\007"
+}
+
+tab-title "$@"


### PR DESCRIPTION
Added a tab-title function in the osx module that changes the current tab title (works in iTerm and Terminal).