### PR TITLE
Add some new git aliases, modify a few more.

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -40,17 +40,17 @@ Aliases are enabled by default. You can disable them with:
 ### Branch
 
   - `gb` lists, creates, renames, and deletes branches.
-  - `gba` lists all local and remote branches and their commits.
   - `gbc` creates a new branch.
-  - `gbd` deletes a branch.
-  - `gbD` deletes a branch irrespective of its merged status.
+  - `gbl` lists branches and their commits. (also `gbv`)
+  - `gbL` lists all local and remote branches and their commits.
   - `gbm` renames a branch.
   - `gbM` renames a branch even if the new branch name already exists.
   - `gbs` lists branches and their commits with ancestry graphs.
   - `gbS` lists local and remote branches and their commits with ancestry
     graphs.
-  - `gbv` lists branches with verbose information about their commits.
   - `gbV` lists branches with more verbose information about their commits.
+  - `gbx` deletes a branch. (also `gbd`)
+  - `gbX` deletes a branch irrespective of its merged status. (also `gbD`)
 
 
 ### Commit

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -44,13 +44,13 @@ Aliases are enabled by default. You can disable them with:
   - `gbc` creates a new branch.
   - `gbd` deletes a branch.
   - `gbD` deletes a branch irrespective of its merged status.
+  - `gbm` renames a branch.
+  - `gbM` renames a branch even if the new branch name already exists.
   - `gbs` lists branches and their commits with ancestry graphs.
   - `gbS` lists local and remote branches and their commits with ancestry
     graphs.
   - `gbv` lists branches with verbose information about their commits.
   - `gbV` lists branches with more verbose information about their commits.
-  - `gbm` renames a branch.
-  - `gbM` renames a branch even if the new branch name already exists.
 
 
 ### Commit

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -40,14 +40,15 @@ Aliases are enabled by default. You can disable them with:
 ### Branch
 
   - `gb` lists, creates, renames, and deletes branches.
+  - `gba` lists all local and remote branches and their commits.
   - `gbc` creates a new branch.
-  - `gbl` lists branches and their commits.
-  - `gbL` lists local and remote branches and their commits.
+  - `gbd` deletes a branch.
+  - `gbD` deletes a branch irrespective of its merged status.
   - `gbs` lists branches and their commits with ancestry graphs.
   - `gbS` lists local and remote branches and their commits with ancestry
     graphs.
-  - `gbx` deletes a branch.
-  - `gbX` deletes a branch irrespective of its merged status.
+  - `gbv` lists branches with verbose information about their commits.
+  - `gbV` lists branches with more verbose information about their commits.
   - `gbm` renames a branch.
   - `gbM` renames a branch even if the new branch name already exists.
 
@@ -57,6 +58,7 @@ Aliases are enabled by default. You can disable them with:
   - `gc` records changes to the repository.
   - `gca` stages all modified and deleted files.
   - `gcm` records changes to the repository with the given message.
+  - `gcam` stages all modified and deleted files, and records changes to the repository with the given message.
   - `gco` checks out a branch or paths to work tree.
   - `gcO` checks out hunks from the index or the tree interactively.
   - `gcf` amends the tip of the current branch using the same log message as
@@ -187,6 +189,8 @@ Aliases are enabled by default. You can disable them with:
   - `giu` adds file contents to the index (updates only known files).
   - `gid` displays changes between the index and a named commit (diff).
   - `giD` displays changes between the index and a named commit (word diff).
+  - `gii` temporarily ignore differences in a given file.
+  - `giI` unignore differences in a given file.
   - `gir` resets the current HEAD to the specified state.
   - `giR` resets the current index interactively.
   - `gix` removes files/directories from the index (recursively).

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -40,6 +40,8 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gbL='git branch --all --verbose'
   alias gbm='git branch --move'
   alias gbM='git branch --move --force'
+  alias gbr='git branch --move'
+  alias gbR='git branch --move --force'
   alias gbs='git show-branch'
   alias gbS='git show-branch --all'
   alias gbv='git branch --verbose'

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -32,16 +32,16 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
 
   # Branch (b)
   alias gb='git branch'
-  alias gbc='git checkout -b'
-  alias gbv='git branch -v'
-  alias gbV='git branch -vv'
   alias gba='git branch -av'
-  alias gbx='git branch -d'
-  alias gbX='git branch -D'
+  alias gbc='git checkout -b'
+  alias gbd='git branch -d'
+  alias gbD='git branch -D'
   alias gbm='git branch -m'
   alias gbM='git branch -M'
   alias gbs='git show-branch'
   alias gbS='git show-branch -a'
+  alias gbv='git branch -v'
+  alias gbV='git branch -vv'
 
   # Commit (c)
   alias gc='git commit --verbose'

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -33,8 +33,9 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   # Branch (b)
   alias gb='git branch'
   alias gbc='git checkout -b'
-  alias gbl='git branch -v'
-  alias gbL='git branch -av'
+  alias gbv='git branch -v'
+  alias gbV='git branch -vv'
+  alias gba='git branch -av'
   alias gbx='git branch -d'
   alias gbX='git branch -D'
   alias gbm='git branch -m'
@@ -46,6 +47,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gc='git commit --verbose'
   alias gca='git commit --verbose --all'
   alias gcm='git commit --message'
+  alias gcam='git commit --all --message'
   alias gco='git checkout'
   alias gcO='git checkout --patch'
   alias gcf='git commit --amend --reuse-message HEAD'
@@ -58,7 +60,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gcl='git-commit-lost'
 
   # Conflict (C)
-  alias gCl='git status | sed -n "s/^.*both [a-z]*ed: *//p"'
+  alias gCl='git --no-pager diff --name-only --diff-filter=U'
   alias gCa='git add $(gCl)'
   alias gCe='git mergetool $(gCl)'
   alias gCo='git checkout --ours --'
@@ -158,6 +160,8 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias giu='git add --update'
   alias gid='git diff --no-ext-diff --cached'
   alias giD='git diff --no-ext-diff --cached --word-diff'
+  alias gii='git update-index --assume-unchanged'
+  alias giI='git update-index --no-assume-unchanged'
   alias gir='git reset'
   alias giR='git reset --patch'
   alias gix='git rm -r --cached'

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -32,16 +32,20 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
 
   # Branch (b)
   alias gb='git branch'
-  alias gba='git branch -av'
+  alias gba='git branch --all --verbose'
   alias gbc='git checkout -b'
-  alias gbd='git branch -d'
-  alias gbD='git branch -D'
-  alias gbm='git branch -m'
-  alias gbM='git branch -M'
+  alias gbd='git branch --delete'
+  alias gbD='git branch --delete --force'
+  alias gbl='git branch --verbose'
+  alias gbL='git branch --all --verbose'
+  alias gbm='git branch --move'
+  alias gbM='git branch --move --force'
   alias gbs='git show-branch'
-  alias gbS='git show-branch -a'
-  alias gbv='git branch -v'
-  alias gbV='git branch -vv'
+  alias gbS='git show-branch --all'
+  alias gbv='git branch --verbose'
+  alias gbV='git branch --verbose --verbose'
+  alias gbx='git branch --delete'
+  alias gbX='git branch --delete --force'
 
   # Commit (c)
   alias gc='git commit --verbose'


### PR DESCRIPTION
# Additions
* Add `gbV` command to show more verbose git branch info.
* Add `gcam` to make it possible to execute `gca; gcm '<your message
  here>'` more simply.
* Add `gii` command to temporarily untrack (ignore) a file.
* Add `giI` command to uningore a file.

# Modifications
* Change alias of `gbl` to `gbv`. Personally, I think aliases that
  include a switch in the command should include the switch in the alias
  if possible.  This makes them easier to remember.
* Change alias of `gbL` to `gba`. I think the `-a` switch is more
  salient to what this alias does than the `-v`.  Furthermore, with this
  PR there are already `gbv` and `gbV` aliases, so those are out.
* Rename `gbx` and `gbX` commands to `gbd` and `gbD` respectively
* Change implementation of `gCl` alias to use built-in capabilities of
  git, rather than sed.