### PR TITLE
Fix sorin prompt double expansion

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -117,7 +117,7 @@ function prompt_sorin_setup {
   zstyle ':prezto:module:git:info:unmerged' format ' %%B%F{3}═%f%%b'
   zstyle ':prezto:module:git:info:untracked' format ' %%B%F{7}◼%f%%b'
   zstyle ':prezto:module:git:info:keys' format \
-    'status' '$(coalesce "%b" "%p" "%c")%s%A%B%S%a%d%m%r%U%u'
+    'status' "\$(coalesce '%b' '%p' '%c')%s%A%B%S%a%d%m%r%U%u"
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '


### PR DESCRIPTION
Refs #1267

This is fairly easy to reproduce with the https://github.com/njhartwell/pw3nage repo.

That being said, I think how this prompt actually goes about handling the git info is probably ripe for other injection issues. A more complete fix would probably be good at some point.