### PR TITLE
rsync: Update reference to Bombich's rsync page

### DIFF
--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -23,5 +23,5 @@ Authors
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: http://rsync.samba.org
-[2]: http://help.bombich.com/kb/overview/credits#opensource
+[2]: https://bombich.com/kb/ccc4/credits#rsync
 [3]: https://github.com/sorin-ionescu/prezto/issues


### PR DESCRIPTION
Seems like Bombich's rsync page moved with the previous link doing 404.
Adjusted to fix this.

FWIW, a similar change was done in the past (#436). But the link moved to their new KB.