### PR TITLE
Convert long-pwd to pwd-length

### DIFF
--- a/modules/prompt/functions/promptpwd
+++ b/modules/prompt/functions/promptpwd
@@ -9,7 +9,9 @@ local ret_directory
 if [[ "$current_pwd" == (#m)[/~] ]]; then
   ret_directory="$MATCH"
   unset MATCH
-elif zstyle -t ':prezto:module:prompt' long-pwd; then
+elif zstyle -m ':prezto:module:prompt' pwd-length 'full'; then
+  ret_directory=${PWD}
+elif zstyle -m ':prezto:module:prompt' pwd-length 'long'; then
   ret_directory=${current_pwd}
 else
   ret_directory="${${${${(@j:/:M)${(@s:/:)current_pwd}##.#?}:h}%/}//\%/%%}/${${current_pwd:t}//\%/%%}"

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -97,8 +97,8 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # Auto set to 'off' on dumb terminals.
 zstyle ':prezto:module:prompt' theme 'sorin'
 
-# Display pwd in long format for themes that use promptpwd function
-# zstyle ':prezto:module:prompt' long-pwd 'yes'
+# Set how themes that use promptpwd function display the pwd, can be 'short', 'long', or 'full'
+# zstyle ':prezto:module:prompt' pwd-length 'short'
 
 #
 # Ruby


### PR DESCRIPTION
Extend #1310 to specify a length for `pwd` output, rather than just have a boolean for whether than output should be short or long form.