### PR TITLE
Cache the completion for a quicker startup

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -14,9 +14,6 @@ fi
 # Add zsh-completions to $fpath.
 fpath=("${0:h}/external/src" $fpath)
 
-# Load and initialize the completion system ignoring insecure directories.
-autoload -Uz compinit && compinit -i
-
 #
 # Options
 #
@@ -27,8 +24,20 @@ setopt PATH_DIRS           # Perform path search even on command names with slas
 setopt AUTO_MENU           # Show completion menu on a successive tab press.
 setopt AUTO_LIST           # Automatically list choices on ambiguous completion.
 setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a trailing slash.
+setopt EXTENDED_GLOB       # Needed for file modification glob modifiers with compinit
 unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
 unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
+
+# Load and initialize the completion system ignoring insecure directories with a
+# cache time of 20 hours, so it should almost always regenerate the first time a
+# shell is opened each day.
+autoload -Uz compinit
+compfiles=(${ZDOTDIR:-$HOME}/.zcompdump(Nm-20))
+if [[ $#compfiles > 0 ]]; then
+  compinit -i -C
+else
+  compinit -i
+fi
 
 #
 # Styles


### PR DESCRIPTION
The original idea was by @samjonester in #1210. This version aims to avoid
relying on the stat or date programs because they have different flags depending
on the OS and if it uses BSD or GNU coreutils.

This relies on extendedglob which allows us to list all files matching the "glob" .zcompdump which have been modified in the last 20 hours. If there are any, we load the cached completion, rather than simply initializing completion.

While this doesn't fix the issue with insecure directories being ignored (I specifically left that check in for now), it should ensure caching is used which will lessen the impact of that check.

CC @malikoth, @jeffcox, @Eriner 