### PR TITLE
broken $path and $PATH  if nodenv exists

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -16,7 +16,7 @@ elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2>/dev/null)" ]]; then
 
 # Load manually installed nodenv into the shell session.
 elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then
-  path=("$HOME/.nodenv/bin $path")
+  path=("$HOME/.nodenv/bin" $path)
   eval "$(nodenv init - --no-rehash zsh)"
 
 # Load package manager installed nodenv into the shell session.


### PR DESCRIPTION
This change fixes a bug where no command can be found
(e.g. `ls`) due to the $path array being set to one element
with all the previous paths separated by spaces.

This makes zsh break $PATH, instead of colons there are
spaces, and nothing works.

The idea is to have the array be set laveraging the word splitting
that we usually are told to avoid by quoting.

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md) before submitting your pull request.

Fixes #

## Proposed Changes

  - Unquote the $path array so it's redefinition contains all elements it contained before.
