### PR TITLE
Do not redisplay if there is no completion indicator.

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -201,9 +201,13 @@ zle -N expand-dot-to-parent-directory-path
 function expand-or-complete-with-indicator {
   local indicator
   zstyle -s ':prezto:module:editor:info:completing' format 'indicator'
-  print -Pn "$indicator"
-  zle expand-or-complete
-  zle redisplay
+  if [[ -z "${indicator}" ]]; then
+    zle expand-or-complete
+  else
+    print -Pn "$indicator"
+    zle expand-or-complete
+    zle redisplay
+  fi
 }
 zle -N expand-or-complete-with-indicator
 


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md) before submitting your pull request.

Fixes #1245 

## Proposed Changes

Currently, even if the user did not set completion indicator, it will still try to print empty indicator and do a `redisplay`.

Normally this does not impose a problem. But according to #1245 , this is actually an upstream bug in `redisplay` and even though it is fixed in upstream version (still not package-manager-gettable even in Arch Linux), the fix introduces some other nasty new display bugs.

Anyways I'm proposing this patch to prezto. If the user does not have a indicator style, he does not want one. So it is reasonable to not print empty string and `redisplay`. This does not change any existing correct behavior. But on the other hand, any one experiencing #1245 could just comment out completion indicator in their customization file and be good.
