### PR TITLE
Fix the pacu alias in the pacman module.

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -70,9 +70,9 @@ alias pacman-list-orphans="${_pacman_sudo}${_pacman_frontend} --query --deps --u
 alias pacman-remove-orphans="${_pacman_sudo}${_pacman_frontend} --remove --recursive \$(${_pacman_frontend} --quiet --query --deps --unrequired)"
 
 # Synchronizes the local package and Arch Build System databases against the
-# repositories.
-if (( $+commands[abs] )); then
-  alias pacu="${_pacman_sudo}${_pacman_frontend} --sync --refresh && sudo abs"
+# repositories using the asp tool.
+if (( $+commands[asp] )); then
+  alias pacu="${_pacman_sudo}${_pacman_frontend} --sync --refresh && sudo asp update"
 else
   alias pacu="${_pacman_sudo}${_pacman_frontend} --sync --refresh"
 fi


### PR DESCRIPTION
Since the deprecation of abs [1], the call for the `pacu` alias was resulting in a rsync error.
This PR just updates the alias with the equivalent command, `asp update`.

[1] https://www.archlinux.org/news/deprecation-of-abs/