### PR TITLE
Use unique tmpdir

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -87,7 +87,7 @@ function prompt_sorin_setup {
   unsetopt XTRACE KSH_ARRAYS
   prompt_opts=(cr percent subst)
   _prompt_sorin_precmd_async_pid=0
-  _prompt_sorin_precmd_async_data="${TMPPREFIX}-prompt_sorin_data"
+  _prompt_sorin_precmd_async_data=$(mktemp "${TMPDIR}/sorin-prompt-async-XXXXXXXXXX")
 
   # Load required functions.
   autoload -Uz add-zsh-hook

--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -74,5 +74,3 @@ if [[ ! -d "$TMPDIR" ]]; then
   mkdir "$TMPDIR"
   chmod 700 "$TMPDIR"
 fi
-
-TMPPREFIX="${TMPDIR%/}/zsh"

--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -65,9 +65,14 @@ fi
 #
 # Temporary Files
 #
+#
+if [[ -z "$TMPDIR" ]]; then
+  export TMPDIR="/tmp/zsh-$UID"
+fi
 
 if [[ ! -d "$TMPDIR" ]]; then
-  export TMPDIR="$(mktemp -d)"
+  mkdir "$TMPDIR"
+  chmod 700 "$TMPDIR"
 fi
 
 TMPPREFIX="${TMPDIR%/}/zsh"


### PR DESCRIPTION
Fixes #1319

## Proposed Changes

  - Use a non-random `TMPDIR` which is unique for each user
  - Use a random tempfile for each shell for async theme data
