### PR TITLE
Make ssh-add use $SSH_ASKPASS

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -40,9 +40,9 @@ fi
 if ssh-add -l 2>&1 | grep -q 'The agent has no identities'; then
   zstyle -a ':prezto:module:ssh:load' identities '_ssh_identities'
   if (( ${#_ssh_identities} > 0 )); then
-    ssh-add "$_ssh_dir/${^_ssh_identities[@]}" 2> /dev/null
+    ssh-add "$_ssh_dir/${^_ssh_identities[@]}"  < /dev/null 2> /dev/null
   else
-    ssh-add 2> /dev/null
+    ssh-add  < /dev/null 2> /dev/null
   fi
 fi
 


### PR DESCRIPTION
Fixes #1320

## Proposed Changes

- Make `ssh-add` use `$SSH_ASKPASS` instead of using terminal input