### PR TITLE
Change print to printf in init.zsh error

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -12,7 +12,7 @@
 # Check for the minimum supported version.
 min_zsh_version='4.3.17'
 if ! autoload -Uz is-at-least || ! is-at-least "$min_zsh_version"; then
-  print "prezto: old shell detected, minimum required: $min_zsh_version" >&2
+  printf "prezto: old shell detected, minimum required: %s\n" "$min_zsh_version" >&2
   return 1
 fi
 unset min_zsh_version


### PR DESCRIPTION
When my zsh had issues, and I was debugging it, this line would
end up being run but no output would be made to the screen.

Changing it from print to printf caused the error to properly be
displayed.