### PR TITLE
Add cwd hook to change node version via nvm

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -28,6 +28,48 @@ elif (( ! $+commands[node] )); then
   return 1
 fi
 
+# Auto node version switch cwd hook
+function _node-nvm-switch-cwd {
+  # Check if this is a Git repo
+  local GIT_REPO_ROOT=""
+  local GIT_TOPLEVEL="$(git rev-parse --show-toplevel 2> /dev/null)"
+  if [[ $? == 0 ]]; then
+    GIT_REPO_ROOT="$GIT_TOPLEVEL"
+  fi
+  # Get absolute path, resolving symlinks
+  local PROJECT_ROOT="${PWD:A}"
+  while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.nvmrc" \
+            && ! -d "$PROJECT_ROOT/.git"  && "$PROJECT_ROOT" != "$GIT_REPO_ROOT" ]]; do
+    PROJECT_ROOT="${PROJECT_ROOT:h}"
+  done
+  if [[ "$PROJECT_ROOT" == "/" ]]; then
+    PROJECT_ROOT="."
+  fi
+  # Check for nvmrc
+  # We cache the location of the nvmrc file instead of the version itself because nvm's version lookup is slow
+  local ENV_VER=""
+  if [[ -f "$PROJECT_ROOT/.nvmrc" ]]; then
+    ENV_VER="$PROJECT_ROOT/.nvmrc"
+  fi
+  if [[ -n $CD_NODE_USE && "$ENV_VER" != "$CD_NODE_USE" ]]; then
+    # We've just left the repo, return to the default node version
+    # Note: this only happens if the node version was selected automatically
+    nvm use default && unset CD_NODE_USE
+  fi
+  if [[ "$ENV_VER" != "" ]]; then
+    # Activate the node version only if it is not already active
+    if [[ "$CD_NODE_USE" != "$ENV_VER" ]]; then
+      nvm use $(cat $ENV_VER) && export CD_NODE_USE="$ENV_VER"
+    fi
+  fi
+}
+
+# Load auto workon cwd hook
+if zstyle -t ':prezto:module:node:nvm' auto-switch 'yes'; then
+  # Auto workon when changing directory
+  add-zsh-hook chpwd _node-nvm-switch-cwd
+fi
+
 # Load NPM completion.
 if (( $+commands[npm] )); then
   cache_file="${0:h}/cache.zsh"


### PR DESCRIPTION
This is based on the python virtualenv auto-workon cwd hook.

It isn't *perfect*: if you change your .nvmrc file it will not pick up the change until you cwd outside of the project, which in turn returns you to the 'default' alias in nvm. This imperfection is because nvm's resolving of .nvmrc is too slow to fire on every cwd. Instead, I'm caching the absolute path of the relevant .nvmrc.
