### PR TITLE
Fix #1337 by removing top alias to htop.

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -107,11 +107,9 @@ Aliases
 
   - `df` displays free disk space using human readable units (aliases to `pydf`, if installed).
   - `du` displays disk usage using human readable units.
-  - `top` displays information about processes (aliased to `htop`, if installed).
-  - `topc` displays information about processes sorted by CPU usage (`htop` not
-    installed).
-  - `topm` displays information about processes sorted by RAM usage (`htop` not
-    installed).
+  - `top` displays information about processes.
+  - `topc` displays information about processes sorted by CPU usage.
+  - `topm` displays information about processes sorted by RAM usage.
 
 ### Miscellaneous
 

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -150,16 +150,12 @@ fi
 
 alias du='du -kh'
 
-if (( $+commands[htop] )); then
-  alias top=htop
+if [[ "$OSTYPE" == (darwin*|*bsd*) ]]; then
+  alias topc='top -o cpu'
+  alias topm='top -o vsize'
 else
-  if [[ "$OSTYPE" == (darwin*|*bsd*) ]]; then
-    alias topc='top -o cpu'
-    alias topm='top -o vsize'
-  else
-    alias topc='top -o %CPU'
-    alias topm='top -o %MEM'
-  fi
+  alias topc='top -o %CPU'
+  alias topm='top -o %MEM'
 fi
 
 # Miscellaneous


### PR DESCRIPTION
- Remove the `alias top=htop` behavior from the utility module.