### PR TITLE
[editor] Set Delete key in vicmd mode to delete character

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -322,6 +322,9 @@ for keymap in 'emacs' 'viins'; do
   bindkey -M "$keymap" "$key_info[Control]X$key_info[Control]S" prepend-sudo
 done
 
+# Delete key deletes character in vimcmd cmd mode instead of weird default functionality
+bindkey -M vicmd "$key_info[Delete]" delete-char
+
 # Do not expand .... to ../.. during incremental search.
 if zstyle -t ':prezto:module:editor' dot-expansion; then
   bindkey -M isearch . self-insert 2> /dev/null


### PR DESCRIPTION
Delete key deletes character in vimcmd cmd mode instead of weird
default functionality. The default functionality in vicmd mode
is the Delete key will change the case of many of the characters
on the screen, which is not the default thing that vim does.

This could be confusing and frustrating to users, so set it to delete
a character instead.