### PR TITLE
[runcoms/zprofile+zshenv] Ensure TMPDIR is always set

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -66,11 +66,11 @@ fi
 # Temporary Files
 #
 #
-if [[ -z "$TMPDIR" ]]; then
-  export TMPDIR="/tmp/zsh-$UID"
+# Set TMPDIR if the variable is not set/empty or the directory doesn't exist
+if [[ -z "${TMPDIR}" ]]; then
+  export TMPDIR="/tmp/zsh-${UID}"
 fi
 
-if [[ ! -d "$TMPDIR" ]]; then
-  mkdir "$TMPDIR"
-  chmod 700 "$TMPDIR"
+if [[ ! -d "${TMPDIR}" ]]; then
+  mkdir -m 700 "${TMPDIR}"
 fi

--- a/runcoms/zshenv
+++ b/runcoms/zshenv
@@ -6,6 +6,6 @@
 #
 
 # Ensure that a non-login, non-interactive shell has a defined environment.
-if [[ "$SHLVL" -eq 1 && ! -o LOGIN && -s "${ZDOTDIR:-$HOME}/.zprofile" ]]; then
+if [[ ( "$SHLVL" -eq 1 && ! -o LOGIN || -z "${TMPDIR}" ) && -s "${ZDOTDIR:-$HOME}/.zprofile" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprofile"
 fi


### PR DESCRIPTION
In some cases TMPDIR may not be set, in which case it could cause issues
for zsh modules.

This change was prompted by issue #1331.

Also when creating a missing TMPDIR, use mkdir --mode=700 instead
of creating the directory and then chmoding it afterward.