### PR TITLE
[zpreztorc] Use an array to load the plugins for ease of use

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -22,17 +22,19 @@ zstyle ':prezto:*:*' color 'yes'
 # zstyle ':prezto:load' zfunction 'zargs' 'zmv'
 
 # Set the Prezto modules to load (browse modules).
-# The order matters.
-zstyle ':prezto:load' pmodule \
-  'environment' \
-  'terminal' \
-  'editor' \
-  'history' \
-  'directory' \
-  'spectrum' \
-  'utility' \
-  'completion' \
-  'prompt'
+# The order matters. Comment out lines to not load them.
+local zprezto_plugins=(
+  environment
+  terminal
+  editor
+  history
+  directory
+  spectrum
+  utility
+  completion
+  prompt
+)
+zstyle ':prezto:load' pmodule $zprezto_plugins
 
 #
 # Autosuggestions


### PR DESCRIPTION
Previously we used a newline separated list of arguments which had
the downside of requiring a backslash at the end of each newline,
and in many cases made it difficult to comment out lines to disable
particular plugins. By using an array we can easily comment them out
and not have to deal with using backslashes at the end of lines.

Note: it may be a good idea to list all of the plugins, but leave some
commented out, making it even easier for people to enable plugins?
Even if not, this would make it much easier to do things like store
the array in another file if we decide to changeup the setup of 
zpreztorc and have a zpreztorc.local or something.