### PR TITLE
[editor] set forward/backward word for Ctrl+Right Ctrl+Left

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -274,6 +274,14 @@ fi
 # Emacs and Vi Key Bindings
 #
 
+# Ctrl + Left and Ctrl + Right bindings to forward/backward word
+for keymap in viins vicmd; do
+  for key in "${(s: :)key_info[ControlLeft]}"
+    bindkey -M "$keymap" "$key" vi-backward-word
+  for key in "${(s: :)key_info[ControlRight]}"
+    bindkey -M "$keymap" "$key" vi-forward-word
+done
+
 for keymap in 'emacs' 'viins'; do
   bindkey -M "$keymap" "$key_info[Home]" beginning-of-line
   bindkey -M "$keymap" "$key_info[End]" end-of-line


### PR DESCRIPTION
Set forward/backward word to be mapped the same as they are in vim,
instead of having weird functionality when unset.