### PR TITLE
[editor] Add bindkey-all function to show all bound keys

### DIFF
--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -58,6 +58,21 @@ To indicate when the editor is completing, add the following to your
 Then add `$editor_info[context]`, where context is *keymap*, *insert*, or
 *overwrite*, to `$PROMPT` or `$RPROMPT`.
 
+Convenience Functions
+---------------------
+
+### bindkey-all
+
+Provides a function `bindkey-all` which can be useful for checking how all of the
+keys are bound. Normal `bindkey` command will only list the keys bound for one
+keymap, which is not as useful if you want to grep through the output. The
+keymap's names go to stderr so when you grep through bindkey-all's output you
+will still see the headings and can tell which keymap each binding goes to.
+
+It will also pass through arguments so you can use bindkey-all to set bindings
+for all keymaps at once. If provided arguments it will *not* print out the
+names of each of the keymaps, and just run the command fear each keymap.
+
 Authors
 -------
 

--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -78,7 +78,15 @@ zle -N edit-command-line
 #
 # Functions
 #
-
+# Runs bindkey but for all of the keymaps. Running it with no arguments will
+# print out the mappings for all of the keymaps.
+function bindkey-all {
+  local keymap=''
+  for keymap in $(bindkey -l); do
+    [[ "$#" -eq 0 ]] && printf "#### %s\n" "${keymap}" 1>&2
+    bindkey -M "${keymap}" "$@"
+  done
+}
 # Exposes information about the Zsh Line Editor via the $editor_info associative
 # array.
 function editor-info {


### PR DESCRIPTION
Function which allows you to see all the bound keys for all of
the different keymaps. It does accept arguments and passes them
through to bindkey -m "$keymap" so you could set a shortcut to
all keymaps as well if you wished.

Makes it much easier to see and grep what keys are bound to each of
the different keymaps.