### PR TITLE
[gitmodules] ignore dirty modules to make it easier for users

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,28 @@
 [submodule "modules/autosuggestions/external"]
 	path = modules/autosuggestions/external
 	url = https://github.com/zsh-users/zsh-autosuggestions
+	ignore = dirty
 [submodule "modules/history-substring-search/external"]
 	path = modules/history-substring-search/external
 	url = https://github.com/zsh-users/zsh-history-substring-search.git
+	ignore = dirty
 [submodule "modules/syntax-highlighting/external"]
 	path = modules/syntax-highlighting/external
 	url = https://github.com/zsh-users/zsh-syntax-highlighting.git
+	ignore = dirty
 [submodule "modules/completion/external"]
 	path = modules/completion/external
 	url = https://github.com/zsh-users/zsh-completions.git
+	ignore = dirty
 [submodule "modules/prompt/external/powerline"]
 	path = modules/prompt/external/powerline
 	url = https://github.com/davidjrice/prezto_powerline.git
+	ignore = dirty
 [submodule "modules/prompt/external/agnoster"]
 	path = modules/prompt/external/agnoster
 	url = https://github.com/agnoster/agnoster-zsh-theme.git
+	ignore = dirty
 [submodule "modules/prompt/functions/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
+	ignore = dirty


### PR DESCRIPTION
When trying to add changes line by line by running `git add -p` the
user is prompted every time for each of the submodules, even if
there are no real changes to any of their directories.

Ignore them if dirty to be less annoying to people trying to add
changes by line.