### PR TITLE
[prompt/sorin] Fix branch code exploit vulnerability

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -54,7 +54,23 @@ function prompt_sorin_precmd_async {
   # Get Git repository information.
   if (( $+functions[git-info] )); then
     git-info
-    typeset -p git_info >! "$_prompt_sorin_precmd_async_data"
+    ### TODO XXX
+    # This section exists to patch over vulnerabilities when sourcing the
+    # file in $_prompt_sorin_precmd_async_data. Without it if a branch is named
+    # $foo it will expand if we have a $foo variable, and a branch named
+    # $(IFS=_;cmd=rm_-rf_~;$cmd) could delete the users home directory.
+    # This is a stopgap to prevent code execution and fix the vulnerability,
+    # but it eventually needs to be removed in favor of zsh_async and not using
+    # a file to store the prompt data in.
+    ###
+    local tmp_prompt_var=$(typeset -p git_info)
+    # Replace all $ with $\ to escape
+    tmp_prompt_var=${tmp_prompt_var//\$/\\$}
+    # Unescape the first \$ as it's our $( )
+    tmp_prompt_var=${tmp_prompt_var:s/\\$/\$}
+    # Escape all backticks ` to \`
+    tmp_prompt_var=${tmp_prompt_var//\`/\\\`}
+    printf "%s\n" "$tmp_prompt_var" >! "$_prompt_sorin_precmd_async_data"
   fi
 
   # Signal completion to parent process.


### PR DESCRIPTION
Escape all $ except the first $. Escape all backtick `'s. This prevents
variable names or shell expansions placed as branch names from
remotely exploiting code.

Fixes issue #1267 for sorin prompt.