### PR TITLE
Add a .editorconfig file to setup tabstyle preferences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+[{.gitignore,.gitmodules}]
+indent_style = tab


### PR DESCRIPTION
With editors that support it it will setup preferences so that it
will use 2 spaces as the indent, except in .gitignore and .gitmodules
which in our files use tabs.

For more info see http://EditorConfig.org