### PR TITLE
Ensure the function keyword is used everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ there are a number of additional things to keep in mind.
 
    - Local variables should be used whenever possible.
    - Prefer `zstyle` over environment variables for configuration.
-   - Use the `my_func()` syntax for defining functions.
+   - Use the function keyword to define functions.
    - The 80 character hard limit can be waved for readability.
 
 #### Using an Alternative zprezto Directory

--- a/init.zsh
+++ b/init.zsh
@@ -20,49 +20,51 @@ unset min_zsh_version
 # zprezto convenience updater
 # The function is surrounded by ( ) instead of { } so it starts in a subshell
 # and won't affect the environment of the calling shell
-function zprezto-update () (
-  function cannot-fast-forward {
-    local STATUS="$1"
-    [[ -n "${STATUS}" ]] && printf "%s\n" "${STATUS}"
-    printf "Unable to fast-forward the changes. You can fix this by "
-    printf "running\ncd '%s' and then\n'git pull' " "${ZPREZTODIR}"
-    printf "to manually pull and possibly merge in changes\n"
-  }
-  cd -q -- "${ZPREZTODIR}" || return 7
-  local orig_branch="$(git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f 3)"
-  if [[ "$orig_branch" == "master" ]]; then
-    git fetch || return "$?"
-    local UPSTREAM=$(git rev-parse '@{u}')
-    local LOCAL=$(git rev-parse @)
-    local REMOTE=$(git rev-parse "$UPSTREAM")
-    local BASE=$(git merge-base @ "$UPSTREAM")
-    if [[ $LOCAL == $REMOTE ]]; then
-      printf "There are no updates.\n"
-      return 0
-    elif [[ $LOCAL == $BASE ]]; then
-      printf "There is an update availible. Trying to pull.\n\n"
-      if git pull --ff-only; then
-        printf "Syncing submodules\n"
-        git submodule update --recursive
-        return $?
+function zprezto-update {
+  (
+    function cannot-fast-forward {
+      local STATUS="$1"
+      [[ -n "${STATUS}" ]] && printf "%s\n" "${STATUS}"
+      printf "Unable to fast-forward the changes. You can fix this by "
+      printf "running\ncd '%s' and then\n'git pull' " "${ZPREZTODIR}"
+      printf "to manually pull and possibly merge in changes\n"
+    }
+    cd -q -- "${ZPREZTODIR}" || return 7
+    local orig_branch="$(git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f 3)"
+    if [[ "$orig_branch" == "master" ]]; then
+      git fetch || return "$?"
+      local UPSTREAM=$(git rev-parse '@{u}')
+      local LOCAL=$(git rev-parse @)
+      local REMOTE=$(git rev-parse "$UPSTREAM")
+      local BASE=$(git merge-base @ "$UPSTREAM")
+      if [[ $LOCAL == $REMOTE ]]; then
+        printf "There are no updates.\n"
+        return 0
+      elif [[ $LOCAL == $BASE ]]; then
+        printf "There is an update availible. Trying to pull.\n\n"
+        if git pull --ff-only; then
+          printf "Syncing submodules\n"
+          git submodule update --recursive
+          return $?
+        else
+          cannot-fast-forward
+          return 1
+        fi
+      elif [[ $REMOTE == $BASE ]]; then
+        cannot-fast-forward "Commits in master that aren't in upstream."
+        return 1
       else
-        cannot-fast-forward
+        cannot-fast-forward "Upstream and local have diverged."
         return 1
       fi
-    elif [[ $REMOTE == $BASE ]]; then
-      cannot-fast-forward "Commits in master that aren't in upstream."
-      return 1
     else
-      cannot-fast-forward "Upstream and local have diverged."
+      printf "zprezto install at '%s' is not on the master branch " "${ZPREZTODIR}"
+      printf "(you're on '%s')\nUnable to automatically update.\n" "${orig_branch}"
       return 1
     fi
-  else
-    printf "zprezto install at '%s' is not on the master branch " "${ZPREZTODIR}"
-    printf "(you're on '%s')\nUnable to automatically update.\n" "${orig_branch}"
     return 1
-  fi
-  return 1
-)
+  )
+}
 #
 # Module Loader
 #

--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -6,6 +6,8 @@
 #   Matt Hamilton <m@tthamilton.com>
 #
 
+# function archive {
+
 local archive_name dir_to_archive _gzip_bin _bzip2_bin
 
 if (( $# != 2 )); then
@@ -65,3 +67,5 @@ case "${archive_name}" in
   (*.lzma) print "\n.lzma is only useful for single files, and does not capture permissions. Use .tar.lzma" ;;
   (*) print "\nunknown archive type for archive: ${archive_name}" ;;
 esac
+
+# }

--- a/modules/archive/functions/lsarchive
+++ b/modules/archive/functions/lsarchive
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function lsarchive {
+
 local verbose
 
 if (( $# == 0 )); then
@@ -53,3 +55,5 @@ while (( $# > 0 )); do
 
   shift
 done
+
+# }

--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function unarchive {
+
 local remove_archive
 local success
 local file_name
@@ -78,3 +80,5 @@ while (( $# > 0 )); do
   (( $success == 0 )) && (( $remove_archive == 0 )) && rm "$1"
   shift
 done
+
+# }

--- a/modules/dpkg/functions/deb-clone
+++ b/modules/dpkg/functions/deb-clone
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function deb-clone {
+
 local clone_script="${0}.sh"
 local package_list=$(
   perl \
@@ -23,3 +25,5 @@ rm "$clone_script"
 print '#!/bin/sh\n' > "$clone_script"
 print "aptitude install ${package_list}\n" >> "$clone_script"
 chmod +x "$clone_script"
+
+# }

--- a/modules/dpkg/functions/deb-history
+++ b/modules/dpkg/functions/deb-history
@@ -7,6 +7,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function deb-history {
+
 case "$1" in
   (install)
     zgrep --no-filename 'install ' $(ls -rt /var/log/dpkg*)
@@ -34,3 +36,5 @@ Commands:
 EOF
   ;;
 esac
+
+# }

--- a/modules/dpkg/functions/deb-kbuild
+++ b/modules/dpkg/functions/deb-kbuild
@@ -6,9 +6,13 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function deb-kbuild {
+
 make-kpkg clean
 MAKEFLAGS='' time fakeroot make-kpkg \
   --append-to-version '-custom' \
   --revision "$(date +"%Y%m%d")" \
   kernel_image \
   kernel_headers
+
+# }

--- a/modules/git/functions/git-branch-current
+++ b/modules/git/functions/git-branch-current
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-branch-current {
+
 if ! git rev-parse 2> /dev/null; then
   print "$0: not a repository: $PWD" >&2
   return 1
@@ -18,3 +20,5 @@ if [[ -n "$ref" ]]; then
 else
   return 1
 fi
+
+# }

--- a/modules/git/functions/git-commit-lost
+++ b/modules/git/functions/git-commit-lost
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-commit-lost {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -18,3 +20,5 @@ git fsck 2> /dev/null \
       --no-walk \
       --stdin \
       --pretty=format:${_git_log_oneline_format}
+
+# }

--- a/modules/git/functions/git-dir
+++ b/modules/git/functions/git-dir
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-dir {
+
 local git_dir="${$(git rev-parse --git-dir):A}"
 
 if [[ -n "$git_dir" ]]; then
@@ -14,3 +16,5 @@ else
   print "$0: not a repository: $PWD" >&2
   return 1
 fi
+
+# }

--- a/modules/git/functions/git-hub-browse
+++ b/modules/git/functions/git-hub-browse
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-hub-browse {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -56,3 +58,5 @@ else
   print "$0: not a Git repository or remote not set" >&2
   return 1
 fi
+
+# }

--- a/modules/git/functions/git-hub-shorten-url
+++ b/modules/git/functions/git-hub-shorten-url
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-hub-shorten-url {
+
 local url="$1"
 
 if [[ "$url" == '-' ]]; then
@@ -20,3 +22,5 @@ if (( $+commands[curl] )); then
 else
   print "$0: command not found: curl" >&2
 fi
+
+# }

--- a/modules/git/functions/git-root
+++ b/modules/git/functions/git-root
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-root {
+
 local root="$(git rev-parse --show-toplevel 2> /dev/null)"
 
 if [[ -n "$root" ]]; then
@@ -14,3 +16,5 @@ else
   print "$0: not a repository work tree: $PWD" >&2
   return 1
 fi
+
+# }

--- a/modules/git/functions/git-stash-clear-interactive
+++ b/modules/git/functions/git-stash-clear-interactive
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-stash-clear-interactive {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -20,3 +22,5 @@ if [[ -f "$(git-dir)/refs/stash" ]]; then
     fi
   fi
 fi
+
+# }

--- a/modules/git/functions/git-stash-dropped
+++ b/modules/git/functions/git-stash-dropped
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-stash-dropped {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -20,3 +22,5 @@ git fsck --unreachable 2> /dev/null \
       --merges \
       --no-walk \
       --stdin
+
+# }

--- a/modules/git/functions/git-stash-recover
+++ b/modules/git/functions/git-stash-recover
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-stash-recover {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -16,3 +18,5 @@ for commit in "$@"; do
   git update-ref \
     -m "$(git log -1 --pretty="format:%s" "$commit")" refs/stash "$commit"
 done
+
+# }

--- a/modules/git/functions/git-submodule-move
+++ b/modules/git/functions/git-submodule-move
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-submodule-move {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -30,3 +32,5 @@ git-submodule-remove "$src"
 git submodule add "$url" "$dst"
 
 return 0
+
+# }

--- a/modules/git/functions/git-submodule-remove
+++ b/modules/git/functions/git-submodule-remove
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function git-submodule-remove {
+
 if ! is-true "$(git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "$0: not a repository work tree: $PWD" >&2
   return 1
@@ -25,3 +27,5 @@ rm -rf "${1}"
 rm -rf "$(git-dir)/modules/${1}"
 
 return 0
+
+# }

--- a/modules/node/functions/node-doc
+++ b/modules/node/functions/node-doc
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function node-doc {
+
 if [[ -z "$BROWSER" ]]; then
   print "$0: no web browser defined" >&2
   return 1
@@ -12,3 +14,5 @@ fi
 
 # TODO: Make the sections easier to use.
 "$BROWSER" "http://nodejs.org/docs/$(node --version | sed 's/-.*//')/api/all.html#${1}"
+
+# }

--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -6,6 +6,8 @@
 #   Zeh Rizzatti <zehrizzatti@gmail.com>
 #
 
+# function node-info {
+
 local version
 local version_format
 local version_formatted
@@ -24,3 +26,5 @@ if [[ "$version" != (none|) ]]; then
   zformat -f version_formatted "$version_format" "v:$version"
   node_info[version]="$version_formatted"
 fi
+
+# }

--- a/modules/osx/functions/osx-ls-download-history
+++ b/modules/osx/functions/osx-ls-download-history
@@ -5,9 +5,13 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function osx-ls-download-history {
+
 local db
 for db in ~/Library/Preferences/com.apple.LaunchServices.QuarantineEventsV*; do
   if grep -q 'LSQuarantineEvent' < <(sqlite3 "$db" .tables); then
     sqlite3 "$db" 'SELECT LSQuarantineDataURLString FROM LSQuarantineEvent'
   fi
 done
+
+# }

--- a/modules/osx/functions/osx-rm-dir-metadata
+++ b/modules/osx/functions/osx-rm-dir-metadata
@@ -5,7 +5,11 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function osx-rm-dir-metadata {
+
 find "${@:-$PWD}" \( \
   -type f -name '.DS_Store' -o \
   -type d -name '__MACOSX' \
 \) -print0 | xargs -0 rm -rf
+
+# }

--- a/modules/osx/functions/osx-rm-download-history
+++ b/modules/osx/functions/osx-rm-download-history
@@ -5,9 +5,13 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function osx-rm-download-history {
+
 local db
 for db in ~/Library/Preferences/com.apple.LaunchServices.QuarantineEventsV*; do
   if grep -q 'LSQuarantineEvent' < <(sqlite3 "$db" .tables); then
     sqlite3 "$db" 'DELETE FROM LSQuarantineEvent; VACUUM'
   fi
 done
+
+# }

--- a/modules/osx/functions/pfd
+++ b/modules/osx/functions/pfd
@@ -5,8 +5,12 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function pfd {
+
 osascript 2>/dev/null <<EOF
   tell application "Finder"
     return POSIX path of (target of first window as text)
   end tell
 EOF
+
+# }

--- a/modules/osx/functions/pfs
+++ b/modules/osx/functions/pfs
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function pfs {
+
 osascript 2>&1 <<EOF
   tell application "Finder" to set the_selection to selection
   if the_selection is not {}
@@ -13,3 +15,5 @@ osascript 2>&1 <<EOF
     end repeat
   end if
 EOF
+
+# }

--- a/modules/osx/functions/ql
+++ b/modules/osx/functions/ql
@@ -5,6 +5,10 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function ql {
+
 if (( $# > 0 )); then
   qlmanage -p "$@" &> /dev/null
 fi
+
+# }

--- a/modules/osx/functions/tab
+++ b/modules/osx/functions/tab
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function tab {
+
 local command="cd \\\"$PWD\\\""
 (( $# > 0 )) && command="${command}; $*"
 
@@ -50,3 +52,5 @@ EOF
     end tell
 EOF
 }
+
+# }

--- a/modules/pacman/functions/pacman-list-disowned
+++ b/modules/pacman/functions/pacman-list-disowned
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function pacman-list-disowned {
+
 local tmp="${TMPDIR:-/tmp}/pacman-disowned-$UID-$$"
 local db="$tmp/db"
 local fs="$tmp/fs"
@@ -20,3 +22,5 @@ find /bin /etc /lib /sbin /usr \
     \( -type d -printf '%p/\n' -o -print \) | sort > "$fs"
 
 comm -23 "$fs" "$db"
+
+# }

--- a/modules/pacman/functions/pacman-list-explicit
+++ b/modules/pacman/functions/pacman-list-explicit
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function pacman-list-explicit {
+
 pacman --query --explicit --info \
   | awk '
       BEGIN {
@@ -18,3 +20,5 @@ pacman --query --explicit --info \
         print $2
       }
     '
+
+# }

--- a/modules/perl/functions/perl-info
+++ b/modules/perl/functions/perl-info
@@ -6,6 +6,8 @@
 #   JINNOUCHI Yasushi <delphinus@remora.cx>
 #
 
+# function perl-info {
+
 local version
 local version_format
 local version_formatted
@@ -28,3 +30,5 @@ if [[ -n "$version" ]]; then
   zformat -f version_formatted "$version_format" "v:$version"
   perl_info[version]="$version_formatted"
 fi
+
+# }

--- a/modules/prompt/functions/promptpwd
+++ b/modules/prompt/functions/promptpwd
@@ -1,6 +1,8 @@
 # prompt setup function common to many prompts
 # moved to external function to reduce code redundancy
 
+# function promptpwd {
+
 setopt localoptions extendedglob
 
 local current_pwd="${PWD/#$HOME/~}"
@@ -18,3 +20,5 @@ else
 fi
 
 print "$ret_directory"
+
+# }

--- a/modules/python/functions/python-info
+++ b/modules/python/functions/python-info
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function python-info {
+
 local virtualenv_format
 local virtualenv_formatted
 
@@ -19,3 +21,5 @@ if [[ -n "$VIRTUAL_ENV" ]]; then
   zformat -f virtualenv_formatted "$virtualenv_format" "v:${VIRTUAL_ENV:t}"
   python_info[virtualenv]="$virtualenv_formatted"
 fi
+
+# }

--- a/modules/ruby/functions/ruby-app-root
+++ b/modules/ruby/functions/ruby-app-root
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function ruby-app-root {
+
 local root_dir="$PWD"
 
 while [[ "$root_dir" != '/' ]]; do
@@ -16,3 +18,5 @@ while [[ "$root_dir" != '/' ]]; do
 done
 
 return 1
+
+# }

--- a/modules/ruby/functions/ruby-info
+++ b/modules/ruby/functions/ruby-info
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function ruby-info {
+
 local version
 local version_format
 local version_formatted
@@ -28,3 +30,5 @@ if [[ -n "$version" ]]; then
   zformat -f version_formatted "$version_format" "v:$version"
   ruby_info[version]="$version_formatted"
 fi
+
+# }

--- a/modules/utility/functions/prep
+++ b/modules/utility/functions/prep
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function prep {
+
 local usage pattern modifiers invert
 
 usage="$(
@@ -50,3 +52,5 @@ pattern="$1"
 shift
 
 perl -n -l -e "print if ${invert:+not} m/${pattern//\//\\/}/${modifiers}" "$@"
+
+# }

--- a/modules/utility/functions/psub
+++ b/modules/utility/functions/psub
@@ -5,6 +5,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function psub {
+
 local usage pattern replacement modifiers
 
 usage="$(
@@ -51,3 +53,5 @@ replacement="$2"
 repeat 2 shift
 
 perl -i'.orig' -n -l -e "s/${pattern//\//\\/}/${replacement//\//\\/}/${modifiers}; print" "$@"
+
+# }

--- a/modules/wakeonlan/functions/wake
+++ b/modules/wakeonlan/functions/wake
@@ -6,6 +6,8 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# function wake {
+
 local config_file="$HOME/.wakeonlan/$1"
 if [[ ! -s "$config_file" ]]; then
   print "$0: invalid device file: $1" >&2
@@ -18,3 +20,5 @@ if (( ! $+commands[wakeonlan] )); then
 fi
 
 wakeonlan -f "$config_file"
+
+# }


### PR DESCRIPTION
This is an alternate fix for #692. We already use this syntax everywhere, so this is mostly a readme update, some tweaks, and adding `# function x {` to each of the autoloaded function files which don't redefine the function in the file.