### PR TITLE
[git] Fix 'git-hub-shorten-url' helper

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -317,7 +317,7 @@ Functions
   - `git-commit-lost` lists lost commits.
   - `git-dir` displays the path to the Git directory.
   - `git-hub-browse` opens the [GitHub][3] repository in the default browser.
-  - `git-hub-shorten-url` shortens GitHub URLs.
+  - `git-hub-shorten-url` shortens [GitHub URLs][10].
   - `git-info` exposes repository information via the `$git_info` associative
     array.
   - `git-root` displays the path to the working tree root.
@@ -422,3 +422,4 @@ Authors
 [7]: https://github.com/sorin-ionescu/prezto/issues/219
 [8]: http://www.kernel.org/pub/software/scm/git/docs/git-log.html
 [9]: https://getgb.io/
+[10]: https://github.com/blog/985-git-io-github-url-shortener

--- a/modules/git/functions/_git-hub-shorten-url
+++ b/modules/git/functions/_git-hub-shorten-url
@@ -8,4 +8,4 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-_arguments '1:url:' && return 0
+_arguments '::GitHub URL:_urls' && return 0

--- a/modules/git/functions/git-hub-shorten-url
+++ b/modules/git/functions/git-hub-shorten-url
@@ -13,12 +13,12 @@ if [[ "$url" == '-' ]]; then
   read url <&0
 fi
 
-if [[ -z "$url" ]]; then
-  print "usage: $0 [ url | - ]" >&2
+if [[ -z "$url" || ! "$url" =~ ^https?:\/\/.*github.com\/ ]]; then
+  print "usage: $0 [ url | - ] ; must be a github.com URL" >&2
 fi
 
 if (( $+commands[curl] )); then
-  curl -s -i 'http://git.io' -F "url=$url" | sed -n 's/^Location: //p'
+  curl -s -i 'https://git.io' -F "url=$url" | sed -n 's/^Location: //p'
 else
   print "$0: command not found: curl" >&2
 fi


### PR DESCRIPTION
## Proposed Changes
- Use git.io over 'https'
- Add extra check to conform to *.github.com URLs
- Use built-in _urls function for completion
- Update readme with GitHub blog URL
