### PR TITLE
Prefer evaluation over test for arithmetic expression

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ there are a number of additional things to keep in mind.
 
    - Local variables should be used whenever possible.
    - Prefer `zstyle` over environment variables for configuration.
+   - Prefer (( ... )) over [[ ... ]] for arithmetic expression.
    - Use the function keyword to define functions.
    - The 80 character hard limit can be waved for readability.
 

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -32,12 +32,13 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 # cache time of 20 hours, so it should almost always regenerate the first time a
 # shell is opened each day.
 autoload -Uz compinit
-compfiles=(${ZDOTDIR:-$HOME}/.zcompdump(Nm-20))
-if [[ $#compfiles > 0 ]]; then
+_comp_files=(${ZDOTDIR:-$HOME}/.zcompdump(Nm-20))
+if (( $#_comp_files )); then
   compinit -i -C
 else
   compinit -i
 fi
+unset _comp_files
 
 #
 # Styles


### PR DESCRIPTION
Usage of `(( ... ))` over `[[ ... ]]` is preferred for arithmetic expression since
the former is less error prone.

Also, unset local variable whenever possible.

Ref: [word of wisdom](https://github.com/sorin-ionescu/prezto/pull/1314#discussion_r115126654) :)