### PR TITLE
[git] Support short-code and improve completion in 'git-hub-shorten-url'

### DIFF
--- a/modules/git/functions/_git-hub-shorten-url
+++ b/modules/git/functions/_git-hub-shorten-url
@@ -8,4 +8,9 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-_arguments '::GitHub URL:_urls' && return 0
+local service="$service"
+
+zstyle ":completion:*:${service}:*:prefixes" ignored-patterns '^http(|s)://'
+zstyle ":completion:*:${service}:*:hosts" ignored-patterns '^*github.com'
+
+_arguments '1::GitHub URL:_urls' '2::code:' && return 0

--- a/modules/git/functions/git-hub-shorten-url
+++ b/modules/git/functions/git-hub-shorten-url
@@ -7,20 +7,22 @@
 
 # function git-hub-shorten-url {
 
-local url="$1"
+local url="$1" code="$2"
 
 if [[ "$url" == '-' ]]; then
   read url <&0
 fi
 
 if [[ -z "$url" || ! "$url" =~ ^https?:\/\/.*github.com\/ ]]; then
-  print "usage: $0 [ url | - ] ; must be a github.com URL" >&2
+  print "usage: $0 [ url | - ] [code] ; url must be a github.com URL" >&2
+  return 1
 fi
 
 if (( $+commands[curl] )); then
-  curl -s -i 'https://git.io' -F "url=$url" | sed -n 's/^Location: //p'
+  curl -s -i 'https://git.io' -F "url=$url" ${(s: :)code:+ -F "code=$code"} | sed -n 's/^Location: //p'
 else
   print "$0: command not found: curl" >&2
+  return 1
 fi
 
 # }


### PR DESCRIPTION
### Proposed Changes
- Add optional short-code support
- Improve completion for github.com URL (`http(s)://*.github.com` only)
- Return with non-zero exit code appropriately

_**Edit:** This is a quick followup to #1367, for the sake of completeness._