### PR TITLE
[utility] Add safe-ops zstyle option to allow disabling rm -i alias

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -66,16 +66,19 @@ alias sftp='noglob sftp'
 # Define general aliases.
 alias _='sudo'
 alias b='${(z)BROWSER}'
-alias cp="${aliases[cp]:-cp} -i"
+
 alias diffu="diff --unified"
 alias e='${(z)VISUAL:-${(z)EDITOR}}'
-alias ln="${aliases[ln]:-ln} -i"
 alias mkdir="${aliases[mkdir]:-mkdir} -p"
-alias mv="${aliases[mv]:-mv} -i"
 alias p='${(z)PAGER}'
 alias po='popd'
 alias pu='pushd'
-alias rm="${aliases[rm]:-rm} -i"
+if zstyle -T ':prezto:module:utility' safe-ops; then
+    alias rm="${aliases[rm]:-rm} -i"
+    alias mv="${aliases[mv]:-mv} -i"
+    alias cp="${aliases[cp]:-cp} -i"
+    alias ln="${aliases[ln]:-ln} -i"
+fi
 alias sa='alias | grep -i'
 alias type='type -a'
 

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -171,6 +171,11 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 # Set the terminal multiplexer title format.
 # zstyle ':prezto:module:terminal:multiplexer-title' format '%s'
 
+# safe-ops is enabled by default. This aliases rm, mv, cp, and ln so that they
+# prompt before deleting or copying over files. Set to no to disable this safer
+# behavior.
+# zstyle ':prezto:module:utility' safe-ops yes
+
 #
 # Tmux
 #


### PR DESCRIPTION
Currently rm is aliased to rm -i so that it will prompt before removing files.
Some people would not like this functionality and wish for an easy way to
disable it. This adds a new option:

zstyle ':prezto:module:utility' safe-ops yes/no

It is enabled by default even if zstyle is not set, but can be set to no
to disable rm from being aliased to rm -i.

This should resolve issue #205