### PR TITLE
[command-not-found] Load brew 'command-not-found' if homebrew tap is available

### DIFF
--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -3,6 +3,7 @@
 #
 # Authors:
 #   Joseph Jon Booker <joe@neoturbine.net>
+#   Indrajit Raychaudhuri <irc+code@indrajit.com>
 #
 
 # Load command-not-found on Debian-based distributions.
@@ -11,6 +12,9 @@ if [[ -s '/etc/zsh_command_not_found' ]]; then
 # Load command-not-found on Arch Linux-based distributions.
 elif [[ -s '/usr/share/doc/pkgfile/command-not-found.zsh' ]]; then
   source '/usr/share/doc/pkgfile/command-not-found.zsh'
+# Load command-not-found on Mac OS X when homebrew tap is configured.
+elif (( $+commands[brew] )) && brew command command-not-found-init > /dev/null 2>&1; then
+  eval "$(brew command-not-found-init)"
 # Return if requirements are not found.
 else
   return 1


### PR DESCRIPTION
Homebrew has _official_ tap that supports `command-not-found`. Enable it when possible.
