### PR TITLE
[utility] Remove premature call to `compdef`

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -67,8 +67,6 @@ function rsync_wrap {
 function scp_wrap {
   rsync_scp_wrap "scp" "$@"
 }
-compdef _rsync rsync_wrap
-compdef _scp scp_wrap
 
 alias sftp='noglob sftp'
 


### PR DESCRIPTION
This is a temporary fix to work-around a minor regression in 90071d3.

Related to #1378 
