### PR TITLE
make the pydf alias optional

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -175,9 +175,13 @@ elif (( $+commands[wget] )); then
   alias get='wget --continue --progress=bar --timestamping'
 fi
 
-# Resource Usage
-if (( $+commands[pydf] )); then
-  alias df=pydf
+if zstyle -s ':prezto:module:utility' pydf 'yes'; then
+  # Resource Usage
+  if (( $+commands[pydf] )); then
+    alias df=pydf
+  else
+    alias df='df -kh'
+  fi
 else
   alias df='df -kh'
 fi


### PR DESCRIPTION
pydf is not a true replacement for df, as it cannot stat remote disks.
This alias being a default is inappropriate, especially without making it very clear in the documentation.

pydf should not stat remote disks because it is a single threaded application, and stating a remote disk can hang. However, it's simply disabled (and cannot be enabled) on pydf. While the color output is nice, it's not a simple drop in replacement the way that htop is for top.