### PR TITLE
[general] Switch code block formatting to use fence formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,25 @@ version is 4.3.17.
 
   1. Launch Zsh:
 
-        `zsh`
+    ```console
+    zsh
+    ```
 
   2. Clone the repository:
 
-        `git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"`
+     ```console
+     git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
+     ```
 
   3. Create a new Zsh configuration by copying the Zsh configuration files
      provided:
 
-        ```
-        setopt EXTENDED_GLOB
-        for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
-          ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
-        done
-        ```
+     ```sh
+     setopt EXTENDED_GLOB
+     for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
+       ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+     done
+     ```
 
      Note: If you already have any of the given config files, ln will error. In
      simple cases you can add `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"` to
@@ -37,7 +41,9 @@ version is 4.3.17.
 
   4. Set Zsh as your default shell:
 
-        `chsh -s /bin/zsh`
+     ```console
+     chsh -s /bin/zsh
+     ```
 
   5. Open a new Zsh terminal window or tab.
 
@@ -57,9 +63,11 @@ into the `$ZPREZTODIR` directory and resolve them yourself.
 
 To pull the latest changes and update submodules manually:
 
-    cd $ZPREZTODIR
-    git pull
-    git submodule update --init --recursive
+```console
+cd $ZPREZTODIR
+git pull
+git submodule update --init --recursive
+```
 
 Usage
 -----

--- a/modules/README.md
+++ b/modules/README.md
@@ -3,7 +3,9 @@ Modules
 
 Load modules in *zpreztorc*. The order matters.
 
-    zstyle ':prezto:load' pmodule 'environment' 'terminal'
+```sh
+zstyle ':prezto:load' pmodule 'environment' 'terminal'
+```
 
 Archive
 -------

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -35,11 +35,15 @@ positive results.
 To enable highlighting for this module only, add the following line to
 *zpreztorc*:
 
-    zstyle ':prezto:module:autosuggestions' color 'yes'
+```sh
+zstyle ':prezto:module:autosuggestions' color 'yes'
+```
 
 To set the query found color, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:autosuggestions:color' found ''
+```sh
+zstyle ':prezto:module:autosuggestions:color' found ''
+```
 
 Authors
 -------

--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -11,21 +11,27 @@ Settings
 To enable key bindings, add the following to *zpreztorc*, and replace 'bindings'
 with 'emacs' or 'vi'.
 
-    zstyle ':prezto:module:editor' key-bindings 'bindings'
+```sh
+zstyle ':prezto:module:editor' key-bindings 'bindings'
+```
 
 ### Dot Expansion
 
 To enable the auto conversion of .... to ../.., add the following to
 *zpreztorc*.
 
-    zstyle ':prezto:module:editor' dot-expansion 'yes'
+```sh
+zstyle ':prezto:module:editor' dot-expansion 'yes'
+```
 
 ### PS Context
 
 To enable the prompt context to be set, add the following to your
 *zpreztorc*.
 
-    zstyle ':prezto:module:editor' ps-context 'yes'
+```sh
+zstyle ':prezto:module:editor' ps-context 'yes'
+```
 
 Theming
 -------
@@ -33,27 +39,37 @@ Theming
 To indicate when the editor is in the primary keymap (emacs or viins), add
 the following to your `theme_prompt_setup` function.
 
-    zstyle ':prezto:module:editor:info:keymap:primary' format '>>>'
+```sh
+zstyle ':prezto:module:editor:info:keymap:primary' format '>>>'
+```
 
 To indicate when the editor is in the primary keymap (emacs or viins) insert
 mode, add the following to your `theme_prompt_setup` function.
 
-    zstyle ':prezto:module:editor:info:keymap:primary:insert' format 'I'
+```sh
+zstyle ':prezto:module:editor:info:keymap:primary:insert' format 'I'
+```
 
 To indicate when the editor is in the primary keymap (emacs or viins) overwrite
 mode, add the following to your `theme_prompt_setup` function.
 
-    zstyle ':prezto:module:editor:info:keymap:primary:overwrite' format 'O'
+```sh
+zstyle ':prezto:module:editor:info:keymap:primary:overwrite' format 'O'
+```
 
 To indicate when the editor is in the alternate keymap (vicmd), add the
 following to your `theme_prompt_setup` function.
 
-    zstyle ':prezto:module:editor:info:keymap:alternate' format '<<<'
+```sh
+zstyle ':prezto:module:editor:info:keymap:alternate' format '<<<'
+```
 
 To indicate when the editor is completing, add the following to your
 `theme_prompt_setup` function.
 
-    zstyle ':prezto:module:editor:info:completing' format '...'
+```sh
+zstyle ':prezto:module:editor:info:completing' format '...'
+```
 
 Then add `$editor_info[context]`, where context is *keymap*, *insert*, or
 *overwrite*, to `$PROMPT` or `$RPROMPT`.

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -15,14 +15,18 @@ The format of the [git-log][8] output is configurable via the following style,
 where context is *brief*, *oneline*, and *medium*, which will be passed to the
 `--pretty=format:` switch.
 
-    zstyle ':prezto:module:git:log:context' format ''
+```sh
+zstyle ':prezto:module:git:log:context' format ''
+```
 
 ### Status
 
 Retrieving the status of a repository with submodules can take a long time.
 Submodules may be ignored when they are *dirty*, *untracked*, *all*, or *none*.
 
-    zstyle ':prezto:module:git:status:ignore' submodules 'all'
+```sh
+zstyle ':prezto:module:git:status:ignore' submodules 'all'
+```
 
 This setting affects all aliases and functions that call `git-status`.
 
@@ -31,7 +35,9 @@ Aliases
 
 Aliases are enabled by default. You can disable them with:
 
-    zstyle ':prezto:module:git:alias' skip 'yes'
+```sh
+zstyle ':prezto:module:git:alias' skip 'yes'
+```
 
 ### Git
 
@@ -335,7 +341,9 @@ To display information about the current repository in a prompt, define the
 following styles in the `prompt_name_setup` function, where the syntax for
 setting a style is as follows.
 
-    zstyle ':prezto:module:git:info:context:subcontext' format 'string'
+```sh
+zstyle ':prezto:module:git:info:context:subcontext' format 'string'
+```
 
 ### Main Contexts
 
@@ -362,7 +370,9 @@ setting a style is as follows.
 
 The following contexts must be enabled with the following zstyle:
 
-    zstyle ':prezto:module:git:info' verbose 'yes'
+```sh
+zstyle ':prezto:module:git:info' verbose 'yes'
+```
 
 ### Verbose Contexts
 
@@ -395,14 +405,18 @@ The following contexts must be enabled with the following zstyle:
 First, format the repository state attributes. For example, to format the branch
 and remote names, define the following styles.
 
-    zstyle ':prezto:module:git:info:branch' format 'branch:%b'
-    zstyle ':prezto:module:git:info:remote' format 'remote:%R'
+```sh
+zstyle ':prezto:module:git:info:branch' format 'branch:%b'
+zstyle ':prezto:module:git:info:remote' format 'remote:%R'
+```
 
 Second, format how the above attributes are displayed in prompts.
 
-    zstyle ':prezto:module:git:info:keys' format \
-      'prompt'  ' git(%b)' \
-      'rprompt' '[%R]'
+```sh
+zstyle ':prezto:module:git:info:keys' format \
+  'prompt'  ' git(%b)' \
+  'rprompt' '[%R]'
+```
 
 Last, add `$git_info[prompt]` to `$PROMPT` and `$git_info[rprompt]` to
 `$RPROMPT` respectively and call `git-info` in the `prompt_name_preexec` hook

--- a/modules/gnu-utility/README.md
+++ b/modules/gnu-utility/README.md
@@ -20,7 +20,9 @@ Settings
 To use a different prefix, add the following to *zpreztorc*, and replace 'g' with
 the desired prefix:
 
-    zstyle ':prezto:module:gnu-utility' prefix 'g'
+```sh
+zstyle ':prezto:module:gnu-utility' prefix 'g'
+```
 
 Authors
 -------

--- a/modules/gpg/README.md
+++ b/modules/gpg/README.md
@@ -9,7 +9,9 @@ To enable OpenSSH Agent protocol emulation, and make `gpg-agent` a drop-in
 replacement for `ssh-agent`, add the following line to
 *~/.gnupg/gpg-agent.conf*:
 
-    enable-ssh-support
+```conf
+enable-ssh-support
+```
 
 When OpenSSH Agent protocol emulation is enabled, this module will load the SSH
 module for additional processing.

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -24,7 +24,9 @@ Settings
 To enable case-sensitivity for this module only, add the following line to
 *zpreztorc*:
 
-    zstyle ':prezto:module:history-substring-search' case-sensitive 'yes'
+```sh
+zstyle ':prezto:module:history-substring-search' case-sensitive 'yes'
+```
 
 ### Highlighting
 
@@ -34,19 +36,27 @@ positive results.
 To enable highlighting for this module only, add the following line to
 *zpreztorc*:
 
-    zstyle ':prezto:module:history-substring-search' color 'yes'
+```sh
+zstyle ':prezto:module:history-substring-search' color 'yes'
+```
 
 To set the query found color, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:history-substring-search:color' found ''
+```sh
+zstyle ':prezto:module:history-substring-search:color' found ''
+```
 
 To set the query not found color, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:history-substring-search:color' not-found ''
+```sh
+zstyle ':prezto:module:history-substring-search:color' not-found ''
+```
 
 To set the search globbing flags, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:history-substring-search' globbing-flags ''
+```sh
+zstyle ':prezto:module:history-substring-search' globbing-flags ''
+```
 
 Authors
 -------

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -31,8 +31,10 @@ Theming
 To display the version number of the current Node.js version, define the
 following style inside the `prompt_name_setup` function.
 
-    # %v - Node.js version.
-    zstyle ':prezto:module:node:info:version' format 'version:%v'
+```sh
+# %v - Node.js version.
+zstyle ':prezto:module:node:info:version' format 'version:%v'
+```
 
 Then add `$node_info[version]` to either `$PROMPT` or `$RPROMPT` and call
 `node-info` in `prompt_name_preexec` hook function.

--- a/modules/pacman/README.md
+++ b/modules/pacman/README.md
@@ -10,14 +10,18 @@ Settings
 To enable a Pacman frontend, for example, [Yaourt][2], add the following line to
 *zpreztorc*:
 
-    zstyle ':prezto:module:pacman' frontend 'yaourt'
+```sh
+zstyle ':prezto:module:pacman' frontend 'yaourt'
+```
 
 If you have enabled color globally in *zpreztorc*, you may disable it for certain
 commands.
 
 To disable `yaourt` highlighting, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:pacman:yaourt' color 'no'
+```sh
+zstyle ':prezto:module:pacman:yaourt' color 'no'
+```
 
 Aliases
 -------

--- a/modules/perl/README.md
+++ b/modules/perl/README.md
@@ -14,15 +14,19 @@ Mac OS X in *~/Library/Perl/5.12* by altering the environment.
 
 For Perl versions older than 5.14, install *local::lib*.
 
-    curl -L -C - -O http://search.cpan.org/CPAN/authors/id/A/AP/APEIRON/local-lib-1.008004.tar.gz
-    tar xvf local-lib-1.008004.tar.gz
-    cd local-lib-1.008004
-    perl Makefile.PL --bootstrap=$HOME/Library/Perl/5.12
-    make && make test && make install
+```console
+curl -L -C - -O http://search.cpan.org/CPAN/authors/id/A/AP/APEIRON/local-lib-1.008004.tar.gz
+tar xvf local-lib-1.008004.tar.gz
+cd local-lib-1.008004
+perl Makefile.PL --bootstrap=$HOME/Library/Perl/5.12
+make && make test && make install
+```
 
 Install *cpanminus*:
 
-    curl -L http://cpanmin.us | perl - --self-upgrade
+```console
+curl -L http://cpanmin.us | perl - --self-upgrade
+```
 
 Perlbrew
 --------
@@ -86,11 +90,13 @@ Functions
 Theming
 -------
 
-To display the name of the currach Perl version in a prompt, define the
+To display the name of the current Perl version in a prompt, define the
 following style in the `prompt_name_setup` function.
 
-    # %v - perl version.
-    zstyle ':prezto:module:perl:info:version' format 'version:%v'
+```sh
+# %v - perl version.
+zstyle ':prezto:module:perl:info:version' format 'version:%v'
+```
 
 Then add `$perl_info[version]` to `$PROMPT` or `$RPROMPT` and call
 `perl-info` in the `prompt_name_precmd` hook function.

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -6,11 +6,25 @@ Loads prompt [themes][1].
 Settings
 --------
 
+### Prompt Theme
+
 To select a prompt theme, add the following to *zpreztorc*, and replace **name**
 with the name of the theme you wish to load. Setting it to **random** will load
 a random theme.
 
-    zstyle ':prezto:module:prompt' theme 'name'
+```sh
+zstyle ':prezto:module:prompt' theme 'name'
+```
+
+### Prompt Display Length
+
+To change working directory prompt display length from 'short', set the
+following to 'long' (without '~' expansion) or 'full' (with '~' expansion)
+in *zpreztorc*.
+
+```sh
+zstyle ':prezto:module:prompt' pwd-length 'short'
+```
 
 Theming
 -------
@@ -26,7 +40,7 @@ There are three theme functions, a setup function, a help function, and
 a preview function. The setup function **must** always be defined. The help
 function and the preview functions are optional.
 
-#### prompt_name_setup
+#### `prompt_name_setup`
 
 This function is called by the `prompt` function to install the theme. This
 function may define other functions as necessary to maintain the prompt,
@@ -36,51 +50,57 @@ including a function that displays help or a function used to preview it.
 
 The most basic example of this function can be seen below.
 
-    function prompt_name_setup {
-      PROMPT='%m%# '
-      RPROMPT=''
-    }
+```sh
+function prompt_name_setup {
+  PROMPT='%m%# '
+  RPROMPT=''
+}
+```
 
-#### prompt_name_help
+#### `prompt_name_help`
 
 If the `prompt_name_setup` function is customizable via parameters, a help
 function **should** be defined. The user will access it via `prompt -h name`.
 
 The most basic example of this function can be seen below.
 
-    function prompt_name_help {
-      cat <<EOH
-    This prompt is color-scheme-able. You can invoke it thus:
+```sh
+function prompt_name_help {
+  cat <<EOH
+This prompt is color-scheme-able. You can invoke it thus:
 
-      prompt theme [<color1>] [<color2>]
+  prompt theme [<color1>] [<color2>]
 
-    where the color is for the left-hand prompt.
-    EOH
-    }
+where the color is for the left-hand prompt.
+EOH
+}
+```
 
-#### prompt_name_preview
+#### `prompt_name_preview`
 
 If the `prompt_name_setup` function is customizable via parameters, a preview
 function **should** be defined. The user will access it via `prompt -p name`.
 
 The most basic example of this function can be seen below.
 
-    function prompt_name_preview {
-      if (( $# > 0 )); then
-        prompt_preview_theme theme "$@"
-      else
-        prompt_preview_theme theme red green blue
-        print
-        prompt_preview_theme theme yellow magenta black
-      fi
-    }
+```sh
+function prompt_name_preview {
+  if (( $# > 0 )); then
+    prompt_preview_theme theme "$@"
+  else
+    prompt_preview_theme theme red green blue
+    print
+    prompt_preview_theme theme yellow magenta black
+  fi
+}
+```
 
 ### Hook Functions
 
 There are many Zsh [hook][2] functions, but mostly the *precmd* hook will be
 used.
 
-#### prompt_name_precmd
+#### `prompt_name_precmd`
 
 This hook is called before the prompt is displayed and is useful for getting
 information to display in a prompt.
@@ -93,11 +113,13 @@ a function before you calling it.
 
 The most basic example of this function can be seen below.
 
-    function prompt_name_precmd {
-      if (( $+functions[git-info] )); then
-        git-info
-      fi
-    }
+```sh
+function prompt_name_precmd {
+  if (( $+functions[git-info] )); then
+    git-info
+  fi
+}
+```
 
 Authors
 -------

--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -52,14 +52,18 @@ The variable `$PROJECT_HOME` tells virtualenvwrapper where to place project
 working directories. It must be set and the directory created before `mkproject`
 is used. Replace *Developer* with your projects directory.
 
-    export PROJECT_HOME="$HOME/Developer"
+```sh
+export PROJECT_HOME="$HOME/Developer"
+```
 
 The variable `$VIRTUALENVWRAPPER_VIRTUALENV_ARGS` tells virtualenvwrapper what
 arguments to pass to `virtualenv`. For example, set the value to
 *--system-site-packages* to ensure that all new environments have access to the
 system site-packages directory.
 
-    export VIRTUALENVWRAPPER_VIRTUALENV_ARGS='--system-site-packages'
+```sh
+export VIRTUALENVWRAPPER_VIRTUALENV_ARGS='--system-site-packages'
+```
 
 ### Additional Options
 
@@ -68,7 +72,9 @@ directory where the root of the project matches a virtualenv name.
 
 This can be enabled with:
 
-    zstyle ':prezto:module:python:virtualenv' auto-switch 'yes'
+```sh
+zstyle ':prezto:module:python:virtualenv' auto-switch 'yes'
+```
 
 Aliases
 -------

--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -45,7 +45,9 @@ rbenv.
 To enable auto switching the Ruby version on directory change based on the
 .ruby-version file, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:ruby:chruby' auto-switch 'yes'
+```sh
+zstyle ':prezto:module:ruby:chruby' auto-switch 'yes'
+```
 
 Bundler
 -------

--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -13,12 +13,16 @@ Starts a GNU Screen session automatically when Zsh is launched.
 To enable this feature when launching Zsh in a local terminal, add the
 following line to *zpreztorc*:
 
-    zstyle ':prezto:module:screen:auto-start' local 'yes'
+```sh
+zstyle ':prezto:module:screen:auto-start' local 'yes'
+```
 
 To enable this feature when launching Zsh in a SSH connection, add the
 following line to *zpreztorc*:
 
-    zstyle ':prezto:module:screen:auto-start' remote 'yes'
+```sh
+zstyle ':prezto:module:screen:auto-start' remote 'yes'
+```
 
 Aliases
 -------

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -14,7 +14,9 @@ Settings
 
 To load multiple identities, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_dsa' 'id_github'
+```sh
+zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_dsa' 'id_github'
+```
 
 Authors
 -------

--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -22,7 +22,9 @@ Settings
 To enable highlighting for this module only, add the following line to
 *zpreztorc*:
 
-    zstyle ':prezto:module:syntax-highlighting' color 'yes'
+```sh
+zstyle ':prezto:module:syntax-highlighting' color 'yes'
+```
 
 ### Highlighters
 
@@ -31,12 +33,14 @@ only enables the *main* highlighter by default.
 
 To enable all highlighters, add the following to *zpreztorc*:
 
-    zstyle ':prezto:module:syntax-highlighting' highlighters \
-      'main' \
-      'brackets' \
-      'pattern' \
-      'cursor' \
-      'root'
+```sh
+zstyle ':prezto:module:syntax-highlighting' highlighters \
+  'main' \
+  'brackets' \
+  'pattern' \
+  'cursor' \
+  'root'
+```
 
 ### Highlighting Styles
 
@@ -45,10 +49,12 @@ Each syntax highlighter defines styles used to highlight tokens.
 To highlight, for example, builtins, commands, and functions in blue instead of
 green, add the following to *zpreztorc*:
 
-    zstyle ':prezto:module:syntax-highlighting' styles \
-      'builtin' 'bg=blue' \
-      'command' 'bg=blue' \
-      'function' 'bg=blue'
+```sh
+zstyle ':prezto:module:syntax-highlighting' styles \
+  'builtin' 'bg=blue' \
+  'command' 'bg=blue' \
+  'function' 'bg=blue'
+```
 
 Authors
 -------

--- a/modules/terminal/README.md
+++ b/modules/terminal/README.md
@@ -11,21 +11,27 @@ Settings
 To auto set the terminal window and tab titles with the current command or
 directory, add the following to *zpreztorc*:
 
-    zstyle ':prezto:module:terminal' auto-title 'yes'
+```sh
+zstyle ':prezto:module:terminal' auto-title 'yes'
+```
 
 Auto titling is disabled inside terminal multiplexers (except inside dvtm)
 since it interferes with window names defined in configuration files and
 profile managers. This can be overridden by setting it to `always`.
 
-    zstyle ':prezto:module:terminal' auto-title 'always'
+```sh
+zstyle ':prezto:module:terminal' auto-title 'always'
+```
 
 ### Title formats
 
 To format terminal window and tab titles, add the following to *zpreztorc*:
 
-    zstyle ':prezto:module:terminal:window-title' format '%n@%m: %s'
-    zstyle ':prezto:module:terminal:tab-title' format '%m: %s'
-    zstyle ':prezto:module:terminal:multiplexer-title' format '%s'
+```sh
+zstyle ':prezto:module:terminal:window-title' format '%n@%m: %s'
+zstyle ':prezto:module:terminal:tab-title' format '%m: %s'
+zstyle ':prezto:module:terminal:multiplexer-title' format '%s'
+```
 
 `%s` will be replaced with the current working directory path or the currently
 executing program name.

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -13,33 +13,43 @@ Starts a tmux session automatically when Zsh is launched.
 To enable this feature when launching Zsh in a local terminal, add the
 following line to *zpreztorc*:
 
-    zstyle ':prezto:module:tmux:auto-start' local 'yes'
+```sh
+zstyle ':prezto:module:tmux:auto-start' local 'yes'
+```
 
 To enable this feature when launching Zsh in a SSH connection, add the
 following line to *zpreztorc*:
 
-    zstyle ':prezto:module:tmux:auto-start' remote 'yes'
+```sh
+zstyle ':prezto:module:tmux:auto-start' remote 'yes'
+```
 
 In both cases, it will create a background session named _prezto_ if the tmux
 server is not started.
 
 You can change the default session name with:
 
-    zstyle ':prezto:module:tmux:session' name 'YOUR DEFAULT SESSION NAME'
+```sh
+zstyle ':prezto:module:tmux:session' name '<YOUR DEFAULT SESSION NAME>'
+```
 
 With `auto-start` enabled, you may want to control how multiple sessions are
 managed. The `destroy-unattached` option of tmux controls if the unattached
 sessions must be kept alive, making sessions available for later use, configured
 in *tmux.conf*:
 
-    set-option -g destroy-unattached [on | off]
+```conf
+set-option -g destroy-unattached [on | off]
+```
 
 #### iTerm2 Integration
 
 [iTerm2][6] offers significant integration with tmux. This can be enabled by
 adding the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:tmux:iterm' integrate 'yes'
+```sh
+zstyle ':prezto:module:tmux:iterm' integrate 'yes'
+```
 
 Read [iTerm2 and tmux Integration][7] for more information.
 
@@ -57,7 +67,9 @@ connected** to be displayed, which can be fixed by installing
 [reattach-to-user-namespace][3], available in [Homebrew][4], and adding the
 following to *tmux.conf*:
 
-    set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
+```conf
+set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
+```
 
 Furthermore, tmux is known to cause **kernel panics** on Mac OS X. A discussion
 about this and Prezto has already been [opened][2].

--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -14,19 +14,27 @@ commands.
 To disable `ls` color, add the following line to *zpreztorc*; when coloring is
 disabled, type indicators (\*, /, =>, @, =, |, %) will be appended to entries.
 
-    zstyle ':prezto:module:utility:ls' color 'no'
+```sh
+zstyle ':prezto:module:utility:ls' color 'no'
+```
 
 To disable `diff` highlighting, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:utility:diff' color 'no'
+```sh
+zstyle ':prezto:module:utility:diff' color 'no'
+```
 
 To disable `wdiff` highlighting, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:utility:wdiff' color 'no'
+```sh
+zstyle ':prezto:module:utility:wdiff' color 'no'
+```
 
 To disable `make` highlighting, add the following line to *zpreztorc*:
 
-    zstyle ':prezto:module:utility:make' color 'no'
+```sh
+zstyle ':prezto:module:utility:make' color 'no'
+```
 
 Aliases
 -------

--- a/modules/wakeonlan/README.md
+++ b/modules/wakeonlan/README.md
@@ -14,11 +14,15 @@ Each file should contain a line with the MAC address of the target device and
 the network broadcast address. For instance, there might be a file
 *~/.wakeonlan/leto* with the following contents:
 
-    00:11:22:33:44:55:66 192.168.0.255
+```conf
+00:11:22:33:44:55:66 192.168.0.255
+```
 
 To wake that device, use the following command:
 
-    wake leto
+```sh
+$ wake leto
+```
 
 For more information on the configuration file format, read the
 [wakeonlan man page][2].


### PR DESCRIPTION
### Changes:
* Indented code block doesn't support syntax highlighting, use fenced
formatting (```) instead for better syntax highlighting
* Wrap commands/functions in backticks
* Typo fixes
