### PR TITLE
[prompt] Rename helper function `promptpwd` to `prompt-pwd` for consistency

### DIFF
--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -6,11 +6,21 @@ Loads prompt [themes][1].
 Settings
 --------
 
+### Prompt Theme
+
 To select a prompt theme, add the following to *zpreztorc*, and replace **name**
 with the name of the theme you wish to load. Setting it to **random** will load
 a random theme.
 
     zstyle ':prezto:module:prompt' theme 'name'
+
+### Prompt Display Length
+
+To change working directory prompt display length from 'short', set the
+following to 'long' (without '~' expansion) or 'full' (with '~' expansion)
+in *zpreztorc*.
+
+    zstyle ':prezto:module:prompt' pwd-length 'short'
 
 Theming
 -------

--- a/modules/prompt/functions/prompt-pwd
+++ b/modules/prompt/functions/prompt-pwd
@@ -1,7 +1,11 @@
-# prompt setup function common to many prompts
-# moved to external function to reduce code redundancy
+#
+# Prompt setup function commonly used by prompt themes.
+#
+# Authors:
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#
 
-# function promptpwd {
+# function prompt-pwd {
 
 setopt localoptions extendedglob
 
@@ -18,6 +22,8 @@ elif zstyle -m ':prezto:module:prompt' pwd-length 'long'; then
 else
   ret_directory="${${${${(@j:/:M)${(@s:/:)current_pwd}##.#?}:h}%/}//\%/%%}/${${current_pwd:t}//\%/%%}"
 fi
+
+unset current_pwd
 
 print "$ret_directory"
 

--- a/modules/prompt/functions/prompt_damoekri_setup
+++ b/modules/prompt/functions/prompt_damoekri_setup
@@ -16,7 +16,7 @@ prompt_damoekri_precmd() {
   unsetopt XTRACE KSH_ARRAYS
 
   # Format PWD.
-  _prompt_damoekri_pwd=$(promptpwd)
+  _prompt_damoekri_pwd=$(prompt-pwd)
 
   # Get Git repository information.
   if (( $+functions[git-info] )); then

--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -84,7 +84,7 @@ function prompt_paradox_precmd {
   unsetopt XTRACE KSH_ARRAYS
 
   # Format PWD.
-  _prompt_paradox_pwd=$(promptpwd)
+  _prompt_paradox_pwd=$(prompt-pwd)
 
   # Get Git repository information.
   if (( $+functions[git-info] )); then

--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -82,7 +82,7 @@ function prompt_sorin_precmd {
   unsetopt XTRACE KSH_ARRAYS
 
   # Format PWD.
-  _prompt_sorin_pwd=$(promptpwd)
+  _prompt_sorin_pwd=$(prompt-pwd)
 
   # Define prompts.
   RPROMPT='${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}'

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -97,7 +97,9 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # Auto set to 'off' on dumb terminals.
 zstyle ':prezto:module:prompt' theme 'sorin'
 
-# Set how themes that use promptpwd function display the pwd, can be 'short', 'long', or 'full'
+# Set the working directory prompt display length.
+# By default, it is set to 'short'. Set it to 'long' (without '~' expansion)
+# for longer or 'full' (with '~' expansion) for even longer prompt display.
 # zstyle ':prezto:module:prompt' pwd-length 'short'
 
 #


### PR DESCRIPTION
### Changes:
* In prezto, function names are hyphenated ('-') by convention, rename `promptpwd` to `prompt-pwd` accordingly.
* Unset local variable `current_pwd` proactively.
* Tweak additional documentation for `prompt-pwd`.
