### PR TITLE
[utility] Simplify enabling 'diff' color conditions in wrapper function

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -144,7 +144,7 @@ Functions
 
 ### Developer
 
-  - `diff` highlights diff output (requires `colordiff` or `Git`).
+  - `diff` highlights diff output (requires `colordiff`).
   - `make` highlights make output (requires `colormake`).
   - `wdiff` highlights wdiff output (requires `wdiff `or `Git`).
 

--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -6,12 +6,9 @@
 #
 
 function diff {
-  if zstyle -t ':prezto:module:utility:diff' color; then
-    if (( $+commands[colordiff] )); then
+  if zstyle -t ':prezto:module:utility:diff' color \
+    && (( $+commands[colordiff] )); then
       command colordiff "$@"
-    else
-      command diff "$@"
-    fi
   else
     command diff "$@"
   fi


### PR DESCRIPTION
Nested `if` can be removed for simple cases like these.