### PR TITLE
[utility] Reuse interactive aliases when 'safe-ops' is set

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -89,10 +89,10 @@ alias mvi="${aliases[mv]:-mv} -i"
 alias cpi="${aliases[cp]:-cp} -i"
 alias lni="${aliases[ln]:-ln} -i"
 if zstyle -T ':prezto:module:utility' safe-ops; then
-  alias rm="${aliases[rm]:-rm} -i"
-  alias mv="${aliases[mv]:-mv} -i"
-  alias cp="${aliases[cp]:-cp} -i"
-  alias ln="${aliases[ln]:-ln} -i"
+  alias rm='rmi'
+  alias mv='mvi'
+  alias cp='cpi'
+  alias ln='lni'
 fi
 
 # ls


### PR DESCRIPTION
When `safe-ops` is set, we can reuse the aliases that are already available.