### PR TITLE
Update submodules URLs to use git URLs explicitly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/autosuggestions/external"]
 	path = modules/autosuggestions/external
-	url = https://github.com/zsh-users/zsh-autosuggestions
+	url = https://github.com/zsh-users/zsh-autosuggestions.git
 [submodule "modules/history-substring-search/external"]
 	path = modules/history-substring-search/external
 	url = https://github.com/zsh-users/zsh-history-substring-search.git
@@ -21,4 +21,4 @@
 	url = https://github.com/sindresorhus/pure.git
 [submodule "modules/fasd/external"]
 	path = modules/fasd/external
-	url = https://github.com/clvv/fasd
+	url = https://github.com/clvv/fasd.git


### PR DESCRIPTION
Even though GitHub redirects git calls based on user-agent, using git URLs
consistently is preferable.