### PR TITLE
[osx] Support custom keyword used by `mand` to open man pages in Dash.app

### DIFF
--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -3,6 +3,19 @@ OSX
 
 Defines [Mac OS X][1] aliases and functions.
 
+Settings
+--------
+
+### Dash Keyword
+
+To change the keyword used by `mand` to open man pages in [_Dash.app_][2] from
+its default value of 'manpages', add the following line in *zpreztorc* and
+replace the **keyword** with the one configured in [_Dash.app_][2].
+
+```sh
+zstyle ':prezto:module:osx:man' dash-keyword 'keyword'
+```
+
 Aliases
 -------
 

--- a/modules/osx/functions/mand
+++ b/modules/osx/functions/mand
@@ -7,7 +7,8 @@
 
 function mand {
   if (( $# > 0 )); then
-    open "dash://manpages:$1" 2>/dev/null
+    zstyle -s ':prezto:module:osx:man' dash-keyword 'dashkw' || dashkw='manpages'
+    open "dash://$dashkw:$1" 2>/dev/null
     if (( $? != 0 )); then
       print "$0: Dash is not installed" >&2
       break

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -82,6 +82,13 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # zstyle ':prezto:module:history-substring-search' globbing-flags ''
 
 #
+# OS X
+#
+
+# Set the keyword used by `mand` to open man pages in Dash.app
+# zstyle ':prezto:module:osx:man' dash-keyword 'manpages'
+
+#
 # Pacman
 #
 


### PR DESCRIPTION
`zstyle` based customization is now avaialble in *zpreztorc* as so:

```sh
zstyle ':prezto:module:osx:man' dash-keyword 'keyword'
```