### PR TITLE
Fix unbound keys in vicmd/viins mode

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -307,7 +307,8 @@ unbound_keys=(
   "${key_info[PageDown]}"
 )
 for keymap in $unbound_keys; do
-  bindkey -M main "${keymap}" _prezto-zle-noop
+  bindkey -M viins "${keymap}" _prezto-zle-noop
+  bindkey -M vicmd "${keymap}" _prezto-zle-noop
 done
 # Ctrl + Left and Ctrl + Right bindings to forward/backward word
 for keymap in viins vicmd; do


### PR DESCRIPTION
Previously I made a change to try and bind these unbound keys to the main
keymap in thoughts that in vicmd or viins mode it would fallback if it wasn't
bound in vicmd/viins mode. This turned out not to be the case.

Explicitly bind the keys in both viins and vicmd mode as works properly.