### PR TITLE
[python] Improve and document `virtualenvwrapper` initialization flow

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -56,6 +56,20 @@ is used. Replace *Developer* with your projects directory.
 export PROJECT_HOME="$HOME/Developer"
 ```
 
+The variable `VIRTUALENVWRAPPER_PYTHON` tells virtualenvwrapper to use the
+specified full path of `python` interpreter overriding the `$PATH` search.
+
+```sh
+export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python
+```
+
+The variable `VIRTUALENVWRAPPER_VIRTUALENV` tells virtualenvwrapper to use the
+specified full path of `virtualenv` binary overriding the `$PATH` search.
+
+```sh
+export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv
+```
+
 The variable `$VIRTUALENVWRAPPER_VIRTUALENV_ARGS` tells virtualenvwrapper what
 arguments to pass to `virtualenv`. For example, set the value to
 *--system-site-packages* to ensure that all new environments have access to the
@@ -76,10 +90,20 @@ This can be enabled with:
 zstyle ':prezto:module:python:virtualenv' auto-switch 'yes'
 ```
 
+virtualenvwrapper is automatically initialized if pre-requisites are met
+(`$VIRTUALENVWRAPPER_VIRTUALENV` is explicitly set or `virtualenv` is in
+`$PATH`). This can be disabled with:
+
+```
+zstyle ':prezto:module:python:virtualenv' initialize 'no'
+```
+
 Aliases
 -------
 
   - `py` is short for `python`.
+  - `py2` is short for `python2`.
+  - `py3` is short for `python3`.
 
 Functions
 ---------

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -123,6 +123,9 @@ zstyle ':prezto:module:prompt' theme 'sorin'
 # Auto switch the Python virtualenv on directory change.
 # zstyle ':prezto:module:python:virtualenv' auto-switch 'yes'
 
+# Automatically initialize virtualenvwrapper if pre-requisites are met.
+# zstyle ':prezto:module:python:virtualenv' initialize 'yes'
+
 #
 # Screen
 #


### PR DESCRIPTION
### Changes:
* Simplify zstyle name `skip-virtualenvwrapper-init` to `initialize`
  avoiding double negation in name
* Always perform `eval (pyenv virtualenv-init -)` at initialization
* Prefer `virtualenvwrapper_lazy` over `virtualenvwrapper` when available
* Honor `VIRTUALENVWRAPPER_VIRTUALENV` if it is defined.
* Document about `VIRTUALENVWRAPPER_PYTHON` and `VIRTUALENVWRAPPER_VIRTUALENV`
  (this would be particularly important in macOS after recent homebrew update)
* Add additional documentation for `initialize` in _README.md_ and _runcoms/zpreztorc_
* Add aliases `py2`, `py3` as shortcut for `python2`, `python3` respectively