### PR TITLE
[completion] Support ignoring '/etc/hosts' entries in host completion

### DIFF
--- a/modules/completion/README.md
+++ b/modules/completion/README.md
@@ -6,6 +6,23 @@ the [zsh-completions][1] project.
 
 This module must be loaded **after** the *utility* module.
 
+Settings
+--------
+
+### Ignore */etc/hosts* Entries
+
+To ignore certain entries from static */etc/hosts* for host completion, add the
+following lines in *zpreztorc* with the IP addresses of the hosts as they
+appear in */etc/hosts*. Both IP address and the corresponding hostname will be
+ignored during host completion. However, some of the entries ignored from
+*/etc/hosts* still might appear during completion because of their presence in
+*ssh* configuration or history).
+
+```sh
+zstyle ':prezto:module:completion:*:hosts' etc-host-ignores \
+  '0.0.0.0' '127.0.0.1'
+```
+
 Contributors
 ------------
 

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -102,12 +102,17 @@ zstyle ':completion:*:history-words' menu yes
 # Environmental Variables
 zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
 
-# Populate hostname completion.
+# Populate hostname completion. But allow ignoring custom entries from static
+# */etc/hosts* which might be uninteresting.
+zstyle -a ':prezto:module:completion:*:hosts' etc-host-ignores 'etc_host_ignores'
+etc_host_ignores=('\#' $etc_host_ignores)
+
 zstyle -e ':completion:*:hosts' hosts 'reply=(
   ${=${=${=${${(f)"$(cat {/etc/ssh_,~/.ssh/known_}hosts(|2)(N) 2>/dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/ }//\[/ }
-  ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%\#*}
+  ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%${(j:*|:)~etc_host_ignores}*}
   ${=${${${${(@M)${(f)"$(cat ~/.ssh/config 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}}
 )'
+unset etc_host_ignores
 
 # Don't complete uninteresting users...
 zstyle ':completion:*:*:*:users' ignored-patterns \

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -42,6 +42,14 @@ zstyle ':prezto:load' pmodule \
 # zstyle ':prezto:module:autosuggestions:color' found ''
 
 #
+# Completions
+#
+
+# Set the entries to ignore in static */etc/hosts* for host completion.
+# zstyle ':prezto:module:completion:*:hosts' etc-host-ignores \
+#   '0.0.0.0' '127.0.0.1'
+
+#
 # Editor
 #
 


### PR DESCRIPTION
Entries from static */etc/hosts* can now be ignored via 'zstyle' configuration in *zpreztorc*. Both IP address and corresponding hostname will be ignored during host completion. However, some of
the entries ignored from */etc/hosts* still might appear during completion because of their presence in *ssh* configuration or history).

Fixes #1387