### PR TITLE
[completion] Allow ignores for '/etc/hosts' entries to be dynamic

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -104,15 +104,13 @@ zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-va
 
 # Populate hostname completion. But allow ignoring custom entries from static
 # */etc/hosts* which might be uninteresting.
-zstyle -a ':prezto:module:completion:*:hosts' etc-host-ignores 'etc_host_ignores'
-etc_host_ignores=('\#' $etc_host_ignores)
+zstyle -a ':prezto:module:completion:*:hosts' etc-host-ignores '_etc_host_ignores'
 
 zstyle -e ':completion:*:hosts' hosts 'reply=(
   ${=${=${=${${(f)"$(cat {/etc/ssh_,~/.ssh/known_}hosts(|2)(N) 2>/dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/ }//\[/ }
-  ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%${(j:*|:)~etc_host_ignores}*}
+  ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%(\#${_etc_host_ignores:+|${(j:|:)~_etc_host_ignores}})*}
   ${=${${${${(@M)${(f)"$(cat ~/.ssh/config 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}}
 )'
-unset etc_host_ignores
 
 # Don't complete uninteresting users...
 zstyle ':completion:*:*:*:users' ignored-patterns \


### PR DESCRIPTION
By keeping the variable `etc_host_ignores` around, it can be resolved lazily
which is turn should allow selective ignores on a per invocation basis.

Also, `'\#'` doesn't need to be added to `etc_host_ignores` anymore. It is
enforced inline.

This is a followup to #1406