### PR TITLE
Introduce the 'kubectl' module.

### DIFF
--- a/modules/kubectl/README.md
+++ b/modules/kubectl/README.md
@@ -1,0 +1,24 @@
+# `kubectl` Aliases and Utilities
+
+Provides [`kubectl`][1] aliases and utilities.
+
+## Aliases
+
+- `kc` is an alias for `kubectl`
+- `kca` is an alias for `ubectl apply`
+- `kcc` is an alias for `kubectl create`
+- `kcD` is an alias for `kubectl delete`
+- `kcd` is an alias for `kubectl describe`
+- `kce` is an alias for `kubectl exec`
+- `kcf` is an alias for `kubectl port-forward`
+- `kcg` is an alias for `kubectl get`
+- `kcl` is an alias for `kubectl logs`
+- `kcr` is an alias for `kubectl run`
+- `kclf` is an alias for `kubectl logs --follow`.
+
+## Authors
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+[1]: https://kubernetes.io/
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/kubectl/init.zsh
+++ b/modules/kubectl/init.zsh
@@ -1,0 +1,40 @@
+#
+# Provides 'kubectl' aliases and utiities.
+#
+# Authors:
+#   Bruno Miguel Custodio <brunomcustodio@gmail.com>
+#
+
+# Return if requirements are not found.
+if (( ! ${+commands[kubectl]} )); then
+  return 1
+fi
+
+# Enable completion for 'kubectl'.
+cache_file="${0:h}/cache.zsh"
+kubectl_command="${commands[kubectl]}"
+
+if [[ "${kubectl_command}" -nt "${cache_file}" || ! -s "${cache_file}" ]]; then
+  ${kubectl_command} completion zsh >! "${cache_file}" 2> /dev/null
+fi
+
+source "${cache_file}"
+unset cache_file kubectl_command
+
+#
+# Aliases
+#
+
+alias kc='kubectl'
+
+alias kca='kubectl apply'
+alias kcc='kubectl create'
+alias kcD='kubectl delete'
+alias kcd='kubectl describe'
+alias kce='kubectl exec'
+alias kcf='kubectl port-forward'
+alias kcg='kubectl get'
+alias kcl='kubectl logs'
+alias kcr='kubectl run'
+
+alias kclf='kubectl logs --follow'


### PR DESCRIPTION
This PR introduces a `kubectl` module which enables completion and provides a few aliases for most commonly used commands.

`README.md` is included. I intend to expand on the module whenever I have the time.