### PR TITLE
Update prompt_sorin_setup (python support)

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -131,7 +131,7 @@ function prompt_sorin_setup {
 
 
   # Set python-info format
-  zstyle ':prezto:module:python:info:virtualenv' format '%f%F{208}(%v)%F{7}'
+  zstyle ':prezto:module:python:info:virtualenv' format '%f%F{208}(%v)%F{7} '
   
   # Get the async worker set up
   async_start_worker async_sorin_git -n
@@ -143,7 +143,7 @@ function prompt_sorin_setup {
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '
-  RPROMPT='$python_info[virtualenv] ${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_devel_git}'
+  RPROMPT='$python_info[virtualenv]${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_devel_git}'
   SPROMPT='zsh: correct %F{1}%R%f to %F{2}%r%f [nyae]? '
 }
 

--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -131,7 +131,7 @@ function prompt_sorin_setup {
 
 
   # Set python-info format
-  zstyle ':prezto:module:python:info:virtualenv' format '%f%F{208}(%v)%F{7} '
+  zstyle ':prezto:module:python:info:virtualenv' format '%f%F{3}(%v)%F{7} '
   
   # Get the async worker set up
   async_start_worker async_sorin_git -n
@@ -143,7 +143,7 @@ function prompt_sorin_setup {
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '
-  RPROMPT='$python_info[virtualenv]${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_devel_git}'
+  RPROMPT='$python_info[virtualenv]${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_sorin_git}'
   SPROMPT='zsh: correct %F{1}%R%f to %F{2}%r%f [nyae]? '
 }
 

--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -81,6 +81,12 @@ function prompt_sorin_precmd {
     fi
   fi
 
+  
+  # Run python info (this should be fast and not require any async)
+  if (( $+functions[python-info] )); then
+    python-info
+  fi
+  
   # Compute slow commands in the background.
   async_job async_sorin_git prompt_sorin_async_git "$PWD"
 }
@@ -123,6 +129,10 @@ function prompt_sorin_setup {
   zstyle ':prezto:module:git:info:keys' format \
     'status' '%b %p %c:%s%A%B%S%a%d%m%r%U%u'
 
+
+  # Set python-info format
+  zstyle ':prezto:module:python:info:virtualenv' format '%f%F{208}(%v)%F{7}'
+  
   # Get the async worker set up
   async_start_worker async_sorin_git -n
   async_register_callback async_sorin_git prompt_sorin_git_info
@@ -133,7 +143,7 @@ function prompt_sorin_setup {
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '
-  RPROMPT='${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_sorin_git}'
+  RPROMPT='$python_info[virtualenv] ${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_devel_git}'
   SPROMPT='zsh: correct %F{1}%R%f to %F{2}%r%f [nyae]? '
 }
 


### PR DESCRIPTION
Added python support

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #
Deals with half of issue #924


## Proposed Changes

  - Add `python-info` into the `precmd` (does not require async because is looking at env vars 
  - Made the virtual env color orange
  
<img width="232" alt="sorin2" src="https://user-images.githubusercontent.com/6491743/29041611-8a94670c-7b81-11e7-9374-904e31f4d526.png">
