### PR TITLE
[python] Edit pyenv virtualenv-init check to support non-brew installations

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -93,7 +93,9 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) && \
   VIRTUAL_ENV_DISABLE_PROMPT=1
 
   # Enable 'virtualenv' with 'pyenv'.
-  if (( $+commands[pyenv] && $+commands[pyenv-virtualenv-init] )); then
+  if (( $+commands[pyenv] )) && \
+     pyenv commands | command grep -q virtualenv-init
+  then
     eval "$(pyenv virtualenv-init -)"
     # Optionall activate 'virtualenvwrapper' with 'pyenv' is available.
     if (( $#commands[(i)pyenv-virtualenvwrapper(_lazy|)] )); then


### PR DESCRIPTION
Fixes #1428 

## Proposed Changes
If the pyenv virtualenv plugin is installed using the [pyenv-installer][1]
app script or directly via a [Git clone][2], then the pyenv-virtualenv-init
executable, that the `pyenv virtualenv-init` command uses, will not
exist in the user's PATH and therefore cannot be found using `$commands[pyenv-virtualenv-init]`.
Installing the pyenv-virtualenv plugin in this manner is common among Linux users.

Using the pyenv `commands` command, which lists all commands pyenv can
run, we can find if the virtualenv-init command is available to pyenv
and subsequently the virtualenv plugin, without relying on
pyenv-virtualenv-init to exist in the user's PATH.

[1]: https://github.com/pyenv/pyenv-installer
[2]: https://github.com/pyenv/pyenv-virtualenv#installing-as-a-pyenv-plugin