### PR TITLE
Drop `easy_install`, everyone now uses `pip`

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -28,8 +28,7 @@ documentation.
 
 ### Usage
 
-Install packages into the per user site directory with `easy_install --user` or
-`pip install --user`.
+Install packages into the per user site directory with `pip install --user`.
 
 virtualenvwrapper
 -----------------


### PR DESCRIPTION
Everyone now uses `pip`, drop reference to `easy_install`