### PR TITLE
Add make to gnu-utility commands

### DIFF
--- a/modules/gnu-utility/init.zsh
+++ b/modules/gnu-utility/init.zsh
@@ -42,7 +42,7 @@ _gnu_utility_cmds=(
   'libtool' 'libtoolize'
 
   # Miscellaneous
-  'getopt' 'grep' 'indent' 'sed' 'tar' 'time' 'units' 'which'
+  'getopt' 'grep' 'indent' 'make' 'sed' 'tar' 'time' 'units' 'which'
 )
 
 # Wrap GNU utilities in functions.


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

## Fixes

Adds a `make` utility to wrap the `gmake` command provided by `brew install make`