### PR TITLE
Explicitly set PYENV_ROOT

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -9,10 +9,12 @@
 # Load manually installed pyenv into the shell session.
 if [[ -s "$HOME/.pyenv/bin/pyenv" ]]; then
   path=("$HOME/.pyenv/bin" $path)
+  export PYENV_ROOT=$(pyenv root)
   eval "$(pyenv init -)"
 
 # Load package manager installed pyenv into the shell session.
 elif (( $+commands[pyenv] )); then
+  export PYENV_ROOT=$(pyenv root)
   eval "$(pyenv init -)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to


### PR DESCRIPTION
Explicitly set the `$PYENV_ROOT` environment variable to conform to pyenv's install instructions. Other applications (e.g. neovim) depend on this value being set.
