### PR TITLE
Fix English mistakes in the autosuggestions module README.md

### DIFF
--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -11,11 +11,12 @@ Integrates [zsh-autosuggestions][1] into Prezto, which implements the
 of a previously entered command and Zsh suggests commands as you type based on
 history and completions.
 
-If this module is used in conjunction with the *syntax-highlighting* module, it
-must be loaded **after** it.
+If this module is used in conjunction with the *syntax-highlighting* module,
+the *syntax-highlighting* module must be loaded **after** this module.
 
 If this module is used in conjunction with the *history-substring-search*
-module, it must be loaded **after** it.
+module, the *history-substring-search* module must be loaded **after** this
+module.
 
 Contributors
 ------------

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -11,10 +11,10 @@ Integrates [zsh-autosuggestions][1] into Prezto, which implements the
 of a previously entered command and Zsh suggests commands as you type based on
 history and completions.
 
-If this module is used in conjuncture with the *syntax-highlighting* module, it
+If this module is used in conjunction with the *syntax-highlighting* module, it
 must be loaded **after** it.
 
-If this module is used in conjuncture with the *history-substring-search*
+If this module is used in conjunction with the *history-substring-search*
 module, it must be loaded **after** it.
 
 Contributors


### PR DESCRIPTION
Fixes #1441 

## Proposed Changes
* Fix English mistakes in the README.md of the autosuggestions module:
⋅⋅* Fix the incorrect use of 'conjuncture' by replacing it with 'conjunction'.
⋅⋅* Fix ambiguous pronoun references. 