### PR TITLE
Update reference to Bombich's rsync

### DIFF
--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -23,5 +23,5 @@ Authors
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: http://rsync.samba.org
-[2]: https://bombich.com/kb/ccc4/credits#rsync
+[2]: https://bombich.com/kb/ccc5/credits#rsync
 [3]: https://github.com/sorin-ionescu/prezto/issues


### PR DESCRIPTION
It points to the same file version, but old destination page threw warnings about being outdated. This is the newest ccc link.