### PR TITLE
Add missing highlighter to readme

### DIFF
--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -38,6 +38,7 @@ zstyle ':prezto:module:syntax-highlighting' highlighters \
   'main' \
   'brackets' \
   'pattern' \
+  'line' \
   'cursor' \
   'root'
 ```


### PR DESCRIPTION
This was added to `.zpreztorc` in 4f19700919c8ebbaf75755fc0d03716d13183f49 but forgot to add it here.