### PR TITLE
[fasd] Document that `fasd` is now bundled with prezto

### DIFF
--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -15,8 +15,8 @@ been disabled.
 Installation
 ------------
 
-Since fasd is not an external module it needs to be installed.
-`brew install fasd`
+`fasd` is bundled with prezto as a git submodule. Alternatively, you can manually install `fasd`.
+If a manual install is found, it will be used instead of the bundled version.
 
 Aliases
 -------


### PR DESCRIPTION
Document that `fasd` is now bundled with prezto (19990c80252a588ef0983fe16c2f001391775af8) and that it's a fallback to a manually installed version (04bfb5131b63c626062af535a1c429f9ff303ca4).