### PR TITLE
Allow modules to be loaded from multiple places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zwc
 *.zwc.old
 modules/*/cache.zsh
+contrib

--- a/init.zsh
+++ b/init.zsh
@@ -89,9 +89,6 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    elif [[ ! -d "$ZPREZTODIR/modules/$pmodule" ]]; then
-      print "$0: no such module: $pmodule" >&2
-      continue
     else
       locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(/FN)})
       if (( ${#locations} > 1 )); then

--- a/init.zsh
+++ b/init.zsh
@@ -78,9 +78,15 @@ function pmodload {
   local pmodule_location
   local pfunction_glob='^([_.]*|prompt_*_setup|README*|*~)(-.N:t)'
 
-  # Any dirs which prezto modules can be loaded from. Currently this is only the
-  # main modules dir and the optional contrib dir.
-  pmodule_dirs=("$ZPREZTODIR/modules" "$ZPREZTODIR/contrib")
+  # Load in any additional directories and warn if they don't exist
+  zstyle -a ':prezto:load' pmodule-dirs 'user_pmodule_dirs'
+  for user_dir in "$user_pmodule_dirs[@]"; do
+    if [[ ! -d "$user_dir" ]]; then
+      echo "$0: Missing user module dir: $user_dir"
+    fi
+  done
+
+  pmodule_dirs=("$ZPREZTODIR/modules" "$ZPREZTODIR/contrib" "$user_pmodule_dirs[@]")
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")

--- a/init.zsh
+++ b/init.zsh
@@ -72,26 +72,18 @@ function zprezto-update {
 # Loads Prezto modules.
 function pmodload {
   local -a pmodules
+  local -a pmodule_dirs
+  local -a locations
   local pmodule
+  local pmodule_location
   local pfunction_glob='^([_.]*|prompt_*_setup|README*|*~)(-.N:t)'
+
+  # Any dirs which prezto modules can be loaded from. Currently this is only the
+  # main modules dir and the optional contrib dir.
+  pmodule_dirs=("$ZPREZTODIR/modules" "$ZPREZTODIR/contrib")
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")
-
-  # Add functions to $fpath.
-  fpath=(${pmodules:+$ZPREZTODIR/modules/${^pmodules}/functions(/FN)} $fpath)
-
-  function {
-    local pfunction
-
-    # Extended globbing is needed for listing autoloadable function directories.
-    setopt LOCAL_OPTIONS EXTENDED_GLOB
-
-    # Load Prezto functions.
-    for pfunction in $ZPREZTODIR/modules/${^pmodules}/functions/$~pfunction_glob; do
-      autoload -Uz "$pfunction"
-    done
-  }
 
   # Load Prezto modules.
   for pmodule in "$pmodules[@]"; do
@@ -101,6 +93,33 @@ function pmodload {
       print "$0: no such module: $pmodule" >&2
       continue
     else
+      locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(/FN)})
+      if (( ${#locations} > 1 )); then
+        print "$0: conflicting module locations: $locations"
+        continue
+      elif (( ${#locations} < 1 )); then
+        print "$0: no such module: $pmodule"
+        continue
+      fi
+
+      # Grab the full path to this module
+      pmodule_location=${locations[1]}
+
+      # Add functions to $fpath.
+      fpath=(${pmodule_location}/functions(/FN) $fpath)
+
+      function {
+        local pfunction
+
+        # Extended globbing is needed for listing autoloadable function directories.
+        setopt LOCAL_OPTIONS EXTENDED_GLOB
+
+        # Load Prezto functions.
+        for pfunction in ${pmodule_location}/functions/$~pfunction_glob; do
+          autoload -Uz "$pfunction"
+        done
+      }
+
       if [[ -s "$ZPREZTODIR/modules/$pmodule/init.zsh" ]]; then
         source "$ZPREZTODIR/modules/$pmodule/init.zsh"
       fi
@@ -109,7 +128,7 @@ function pmodload {
         zstyle ":prezto:module:$pmodule" loaded 'yes'
       else
         # Remove the $fpath entry.
-        fpath[(r)${ZPREZTODIR}/modules/${pmodule}/functions]=()
+        fpath[(r)${pmodule_location}/functions]=()
 
         function {
           local pfunction
@@ -119,7 +138,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in $ZPREZTODIR/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in ${pmodule_location}/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -15,6 +15,9 @@
 # Color output (auto set to 'no' on dumb terminals).
 zstyle ':prezto:*:*' color 'yes'
 
+# Add additional directories to load prezto modules from
+# zstyle ':prezto:load' pmodule-dirs $HOME/.zprezto-contrib
+
 # Set the Zsh modules to load (man zshmodules).
 # zstyle ':prezto:load' zmodule 'attr' 'stat'
 


### PR DESCRIPTION
This is initial work for the contrib repo, mentioned in #1424

## Proposed Changes

  - Allow for loading additional modules from `$ZPREZTODIR/contrib`
  - Note that this changes how functions from modules are loaded if multiple modules are loaded at once... this was done to make the code a bit simpler, but it could be changed back if need be. Previously we added all the modules being loaded to the fpath then loaded the modules one by one. The new code adds a module to the fpath then tries to load the module, following that pattern for each module.

## Additional Ideas
  - Add a zstyle option to add additional module dirs, so someone could add ~/.zmodules if they wanted to
  - A simple way of cloning the contrib repo (which currently doesn't exist)
