### PR TITLE
[prompt_sorin] Use ✘ and show return value for non-0 rtrns

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -129,10 +129,15 @@ function prompt_sorin_setup {
   zstyle ':prezto:module:git:info:keys' format \
     'status' '%b %p %c:%s%A%B%S%a%d%m%r%U%u'
 
-
+  # Set up non-zero return value display
+  local show_return="✘ "
+  # Default is to show the return value
+  if zstyle -T ':prezto:module:prompt' show-return-val; then
+    show_return+='%? '
+  fi
   # Set python-info format
   zstyle ':prezto:module:python:info:virtualenv' format '%f%F{3}(%v)%F{7} '
-  
+
   # Get the async worker set up
   async_start_worker async_sorin_git -n
   async_register_callback async_sorin_git prompt_sorin_git_info
@@ -143,7 +148,9 @@ function prompt_sorin_setup {
 
   # Define prompts.
   PROMPT='${SSH_TTY:+"%F{9}%n%f%F{7}@%f%F{3}%m%f "}%F{4}${_prompt_sorin_pwd}%(!. %B%F{1}#%f%b.)${editor_info[keymap]} '
-  RPROMPT='$python_info[virtualenv]${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_sorin_git}'
+  RPROMPT='$python_info[virtualenv]${editor_info[overwrite]}%(?:: %F{1}'
+  RPROMPT+=${show_return}
+  RPROMPT+='%f)${VIM:+" %B%F{6}V%f%b"}${_prompt_sorin_git}'
   SPROMPT='zsh: correct %F{1}%R%f to %F{2}%r%f [nyae]? '
 }
 


### PR DESCRIPTION
If you do not want it to show the return code, you can set:
`zstyle ':prezto:module:prompt' show-return-val false`