### PR TITLE
Fix README.md for autosuggestions and history-substring-search

### DIFF
--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -12,10 +12,10 @@ of a previously entered command and Zsh suggests commands as you type based on
 history and completions.
 
 If this module is used in conjunction with the *syntax-highlighting* module,
-the *syntax-highlighting* module must be loaded **after** this module.
+this module must be loaded **after** the *syntax-highlighting* module.
 
 If this module is used in conjunction with the *history-substring-search*
-module, the *history-substring-search* module must be loaded **after** this
+module, this module must be loaded **after** the the *history-substring-search*
 module.
 
 Contributors

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -15,7 +15,7 @@ If this module is used in conjunction with the *syntax-highlighting* module,
 this module must be loaded **after** the *syntax-highlighting* module.
 
 If this module is used in conjunction with the *history-substring-search*
-module, this module must be loaded **after** the the *history-substring-search*
+module, this module must be loaded **after** the *history-substring-search*
 module.
 
 Contributors

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -6,8 +6,8 @@ the [Fish shell][2]'s history search feature, where the user can type in any
 part of a previously entered command and press up and down to cycle through
 matching commands.
 
-If this module is used in conjuncture with the *syntax-highlighting* module, it
-must be loaded **after** it.
+If this module is used in conjunction with the *syntax-highlighting* module,
+this module must be loaded **after** the the *syntax-highlighting* module.
 
 Contributors
 ------------

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -7,7 +7,7 @@ part of a previously entered command and press up and down to cycle through
 matching commands.
 
 If this module is used in conjunction with the *syntax-highlighting* module,
-this module must be loaded **after** the the *syntax-highlighting* module.
+this module must be loaded **after** the *syntax-highlighting* module.
 
 Contributors
 ------------


### PR DESCRIPTION
Fixes #1441 and #1444 

## Proposed Changes

  - Fixed documentation regression for autosuggestions module
  - Fixed the incorrect use of 'conjuncture' by replacing it with 'conjunction'.
