### PR TITLE
Pwd length

### DIFF
--- a/modules/prompt/functions/prompt-pwd
+++ b/modules/prompt/functions/prompt-pwd
@@ -12,11 +12,11 @@ setopt localoptions extendedglob
 local current_pwd="${PWD/#$HOME/~}"
 local ret_directory
 
-if [[ "$current_pwd" == (#m)[/~] ]]; then
+if zstyle -m ':prezto:module:prompt' pwd-length 'full'; then
+  ret_directory=${PWD}
+elif [[ "$current_pwd" == (#m)[/~] ]]; then
   ret_directory="$MATCH"
   unset MATCH
-elif zstyle -m ':prezto:module:prompt' pwd-length 'full'; then
-  ret_directory=${PWD}
 elif zstyle -m ':prezto:module:prompt' pwd-length 'long'; then
   ret_directory=${current_pwd}
 else

--- a/modules/prompt/functions/prompt-pwd
+++ b/modules/prompt/functions/prompt-pwd
@@ -19,6 +19,8 @@ elif [[ "$current_pwd" == (#m)[/~] ]]; then
   unset MATCH
 elif zstyle -m ':prezto:module:prompt' pwd-length 'long'; then
   ret_directory=${current_pwd}
+elif zstyle -m ':prezto:module:prompt' pwd-length 'tail'; then
+  ret_directory=${current_pwd:t}
 else
   ret_directory="${${${${(@j:/:M)${(@s:/:)current_pwd}##.#?}:h}%/}//\%/%%}/${${current_pwd:t}//\%/%%}"
 fi


### PR DESCRIPTION
## Proposed Changes

  - Ensure prompt-pwd always expands '~' when pwd-length is set to 'full', so the path format is consistent between directories.
  - Add pwd-length option 'tail' to only show the last directory in the path, for minimalist prompts.