### PR TITLE
Clarify in README that brewu updates AND upgrades packages / formula

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -14,7 +14,7 @@ Aliases
   - `brewl` lists installed formulae.
   - `brewo` lists brews which have an update available.
   - `brews` searches for a formula.
-  - `brewu` updates Homebrew and formulae.
+  - `brewu` updates and upgrades Homebrew packages and formulae.
   - `brewx` uninstalls a formula.
 
 ### Homebrew Cask


### PR DESCRIPTION
As homebrew includes both an update and upgrade command, it is beneficial to clarify that this performs both, rather than just the update.

## Proposed Changes

  - Update homebrew module README to clarify that both update and upgrade is run by the `brewu` alias.