### PR TITLE
ssh: always redirect input from /dev/null when adding keys

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -39,21 +39,10 @@ fi
 # Load identities.
 if ssh-add -l 2>&1 | grep -q 'The agent has no identities'; then
   zstyle -a ':prezto:module:ssh:load' identities '_ssh_identities'
-  # ssh-add has strange requirements for running SSH_ASKPASS, so we duplicate
-  # them here. Essentially, if the other requirements are met, we redirect stdin
-  # from /dev/null in order to meet the final requirement.
-  #
-  # From ssh-add(1):
-  # If ssh-add needs a passphrase, it will read the passphrase from the current
-  # terminal if it was run from a terminal. If ssh-add does not have a terminal
-  # associated with it but DISPLAY and SSH_ASKPASS are set, it will execute the
-  # program specified by SSH_ASKPASS and open an X11 window to read the
-  # passphrase.
-  if [[ -n "$DISPLAY" && -x "$SSH_ASKPASS" ]]; then
-    ssh-add "${_ssh_identities:+$_ssh_dir/${^_ssh_identities[@]}}" < /dev/null 2> /dev/null
-  else
-    ssh-add "${_ssh_identities:+$_ssh_dir/${^_ssh_identities[@]}}" 2> /dev/null
-  fi
+
+  # Note that the input redirection from /dev/null is needed because on linux,
+  # this is the only way to make sure the SSH_ASKPASS variable is respected.
+  ssh-add "${_ssh_identities:+$_ssh_dir/${^_ssh_identities[@]}}" < /dev/null 2> /dev/null
 fi
 
 # Clean up.


### PR DESCRIPTION
Should fix #1489

## Proposed Changes

  - Always redirect input from /dev/null

## Notes

From my limited testing, this doesn't break anything on OSX with or without identities or keys. I'm not 100% sure how this will interact with Linux if SSH_ASKPASS isn't set, but pulling together all the issues I've seen, this *should* fix the issue.

CC @leshow

Also CC @crivotz because this essentially reverts the change you made... can you provide any more context as to why the input redirection was removed in your PR?