### PR TITLE
Lower requirements down to 4.3.11 again

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 ------------
 
 Prezto will work with any recent release of Zsh, but the minimum required
-version is 4.3.17.
+version is 4.3.11.
 
   1. Launch Zsh:
 

--- a/init.zsh
+++ b/init.zsh
@@ -10,7 +10,7 @@
 #
 
 # Check for the minimum supported version.
-min_zsh_version='4.3.17'
+min_zsh_version='4.3.11'
 if ! autoload -Uz is-at-least || ! is-at-least "$min_zsh_version"; then
   printf "prezto: old shell detected, minimum required: %s\n" "$min_zsh_version" >&2
   return 1


### PR DESCRIPTION

## Proposed Changes

  - ZSH Syntax Highlighter added a dependency for zsh version 4.3.17 as minimum due to a feature that they added. That broke `prezto` for everyone under `4.3.17`. They have now re-added compatibility for zsh `4.3.11`, so we can support it again. I request this because `4.3.11` is the maximum zsh release found in epel for CentOS6. 
 
I tested this for my environment and it works there peachy. 