### PR TITLE
Update init.zsh

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -34,9 +34,9 @@ function zprezto-update {
     if [[ "$orig_branch" == "master" ]]; then
       git fetch || return "$?"
       local UPSTREAM=$(git rev-parse '@{u}')
-      local LOCAL=$(git rev-parse @)
+      local LOCAL=$(git rev-parse HEAD)
       local REMOTE=$(git rev-parse "$UPSTREAM")
-      local BASE=$(git merge-base @ "$UPSTREAM")
+      local BASE=$(git merge-base HEAD "$UPSTREAM")
       if [[ $LOCAL == $REMOTE ]]; then
         printf "There are no updates.\n"
         return 0


### PR DESCRIPTION
It seems that my older git does not support '@' yet.

## Proposed Changes

  - I run git version `1.8.3.1`, and it does not seem to like '@', so I seek to use a slightly verbose solution that works for me. 