### PR TITLE
Prunes local tracking branches that do not exist on remote anymore

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -114,6 +114,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
   - `gfcr` clones a repository into a new directory including all submodules.
   - `gfm` fetches from and merges with another repository or local branch.
   - `gfp` prunes local tracking branches that do not exist on remote anymore.
+  - `gfP` forcefully prunes local tracking branches that do not exist on remote anymore.
   - `gfr` fetches from and rebases on another repository or local branch.
 
 ### Flow

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -113,6 +113,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
   - `gfc` clones a repository into a new directory.
   - `gfcr` clones a repository into a new directory including all submodules.
   - `gfm` fetches from and merges with another repository or local branch.
+  - `gfp` prunes local tracking branches that do not exist on remote anymore.
   - `gfr` fetches from and rebases on another repository or local branch.
 
 ### Flow

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -98,6 +98,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gfcr='git clone --recurse-submodules'
   alias gfm='git pull'
   alias gfp="git fetch --prune && git branch -r | awk '{print \$1}' | egrep -v -f /dev/fd/0 <(git branch -vv | grep origin) | awk '{print \$1}' | xargs git branch -d"
+  alias gfP="git fetch --prune && git branch -r | awk '{print \$1}' | egrep -v -f /dev/fd/0 <(git branch -vv | grep origin) | awk '{print \$1}' | xargs git branch -D"
   alias gfr='git pull --rebase'
 
   # Flow (F)

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -97,6 +97,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gfc='git clone'
   alias gfcr='git clone --recurse-submodules'
   alias gfm='git pull'
+  alias gfp="git fetch --prune && git branch -r | awk '{print \$1}' | egrep -v -f /dev/fd/0 <(git branch -vv | grep origin) | awk '{print \$1}' | xargs git branch -d"
   alias gfr='git pull --rebase'
 
   # Flow (F)


### PR DESCRIPTION
Here is a usage example : 

```
❯ gfp
From git.example.com:example/repo
 - [deleted]         (none)     -> origin/feature/branch
Deleted branch feature/branch (was 4eaac1c).
```

inspired by : [SO — how to prune local tracking branches that do not exist on remote anymore](https://stackoverflow.com/questions/13064613/how-to-prune-local-tracking-branches-that-do-not-exist-on-remote-anymore)