### PR TITLE
Allow module to be a symbolic link (but still must point to a non-empty directory).

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -96,7 +96,7 @@ function pmodload {
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
     else
-      locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(/FN)})
+      locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(-/FN)})
       if (( ${#locations} > 1 )); then
         print "$0: conflicting module locations: $locations"
         continue


### PR DESCRIPTION
A recent commit ce349dff81c6ca1f636c3ca9118d4d60b56617cd allows modules to be loaded from user specified directories. This is great and adds a lot of flexibility.

But I have been putting symbolic links in the `.zprezto/modules` directory for a very long time. And due to my directory structure, I cannot easily migrate to the new way of adding modules.  After this commit, existing behavior breaks.That is because the glob flag used allows only non-empty directories. By adding this single `-`, it will allow non-empty directories, and symbolic links that point to non-empty directories.

Even with `user_pmodule_dirs`, my feeling is it would better to allow symbolic links. User (like me) might put links inside `.zprezto-contrib` that point to a separately version controlled directory.