### PR TITLE
Source correct module's `init.zsh`

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -123,8 +123,8 @@ function pmodload {
         done
       }
 
-      if [[ -s "$ZPREZTODIR/modules/$pmodule/init.zsh" ]]; then
-        source "$ZPREZTODIR/modules/$pmodule/init.zsh"
+      if [[ -s "${pmodule_location}/init.zsh" ]]; then
+        source "${pmodule_location}/init.zsh"
       fi
 
       if (( $? == 0 )); then


### PR DESCRIPTION
Now that modules can be located in multiple placed (#1458) 
the appropriate `init.zsh` should be sourced. 

## Proposed Changes

  - Source `init.zsh` from the `$module_location` and not `$ZPREZTODIR/modules/$pmodule`