### PR TITLE
Don't set auto_name_dirs because it messes up prompts

### DIFF
--- a/modules/directory/init.zsh
+++ b/modules/directory/init.zsh
@@ -16,7 +16,6 @@ setopt PUSHD_IGNORE_DUPS    # Do not store duplicates in the stack.
 setopt PUSHD_SILENT         # Do not print the directory stack after pushd or popd.
 setopt PUSHD_TO_HOME        # Push to home directory when no argument is given.
 setopt CDABLE_VARS          # Change directory to a path stored in a variable.
-setopt AUTO_NAME_DIRS       # Auto add variable-stored paths to ~ list.
 setopt MULTIOS              # Write to multiple descriptors.
 setopt EXTENDED_GLOB        # Use extended globbing syntax.
 unsetopt CLOBBER            # Do not overwrite existing files with > and >>.


### PR DESCRIPTION
This was ported from Oh-My-Zsh and since have been disabled in OMZ.

Explained in more detail https://github.com/rvm/rvm/issues/3091#issuecomment-60083194

Related: #998 , #1081
