### PR TITLE
Set INTERACTIVE_COMMENTS by default

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -14,8 +14,8 @@ fi
 # Options
 #
 
-# Beep on error in line editor.
-setopt BEEP
+setopt BEEP                     # Beep on error in line editor.
+setopt INTERACTIVE_COMMENTS     # Enable comments in interactive shell.
 
 #
 # Variables


### PR DESCRIPTION
This allows using `#` to comment lines in the interactive shell:

![image](https://user-images.githubusercontent.com/1177900/35409648-28bcc2f4-0213-11e8-9416-645fffcf4716.png)

Seems to me a pretty reasonable default, that's why making a PR.

Here's a more realistic example of when this can be useful:

- Start typing a command
- Realize you need to run another command first
- Prepend current command with `#` and hit Enter
- Run another command
- Up, Up in history to get the commented command
- Remove the `#` and keep typing the first command

I am in a little doubt of whether this is the correct module to set this option.