### PR TITLE
feature: add first zypper commands module

### DIFF
--- a/modules/zypper/README.md
+++ b/modules/zypper/README.md
@@ -1,0 +1,31 @@
+Zypper
+===
+
+Defines [zypper][1] aliases.
+
+Aliases
+-------
+
+  - `zypc`  # Cleans the cache.
+  - `zyph`  # Displays history.
+  - `zypi`  # Installs package(s).
+  - `zypl`  # Clean packages cache.
+  - `zypq`  # Displays package information.
+  - `zypr`  # Removes package(s).
+  - `zyps`  # Searches for a package.
+  - `zypv`  # Verifies dependencies.
+  - `zypu`  # Updates packages.
+  - `zypU`  # Dist Upgrade.
+  - `zypUD` # Dist Upgrade download only.
+  - `zypUn` # Dist Upgrade no repository refresh.
+  - `zypR`  # Refresh repositories caches.
+
+Authors
+-------
+
+*The authors of this module should be contacted via the [issue tracker][2].*
+
+  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+
+[1]: https://en.opensuse.org/Portal:Zypper
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/zypper/init.zsh
+++ b/modules/zypper/init.zsh
@@ -1,0 +1,31 @@
+#
+# Defines zypper aliases.
+#
+# Authors:
+#   Simon <contact@saimon.org>
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Andrea Ceccarelli <gltch2003@gmail.com>
+#
+
+# Return if requirements are not found.
+if (( ! $+commands[zypper] )); then
+  return 1
+fi
+
+#
+# Aliases
+#
+
+alias zypc='sudo zypper clean -a'                     # Cleans the cache.
+alias zyph='zypper history'                           # Displays history.
+alias zypi='sudo zypper install'                      # Installs package(s).
+alias zypl='zypper clean'                             # Clean packages cache.
+alias zypq='zypper info'                              # Displays package information.
+alias zypr='sudo zypper remove'                       # Removes package(s).
+alias zyps='zypper search'                            # Searches for a package.
+alias zypv='sudo zypper ve'                           # Verifies dependencies.
+alias zypu='sudo zypper up'                           # Updates packages.
+alias zypU='sudo zypper dup'                          # Dist Upgrade.
+alias zypUD='sudo zypper dup --download-only'         # Dist Upgrade download only.
+alias zypUn='sudo zypper --no-refresh'                # Dist Upgrade no repository refresh.
+alias zypR='sudo zypper ref'                          # Refresh repositories caches.


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #

## Proposed Changes
Add zypper module:
provides basic zypper installer commands for SUSE/OperSUSE
  -
  -
  -
