### PR TITLE
Don't double-source chruby

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -25,9 +25,14 @@ elif (( $+commands[rbenv] )); then
 
 # Load package manager installed chruby into the shell session.
 elif (( $+commands[chruby-exec] )); then
-  source "${commands[chruby-exec]:h:h}/share/chruby/chruby.sh"
+  if (( ! $+functions[chruby] )); then
+    source "${commands[chruby-exec]:h:h}/share/chruby/chruby.sh"
+  fi
+
   if zstyle -t ':prezto:module:ruby:chruby' auto-switch; then
-    source "${commands[chruby-exec]:h:h}/share/chruby/auto.sh"
+    if (( ! $+functions[chruby_auto] )); then
+      source "${commands[chruby-exec]:h:h}/share/chruby/auto.sh"
+    fi
 
     # If a default Ruby is set, switch to it.
     chruby_auto


### PR DESCRIPTION
If chruby was installed using default way, most likely chruby and
auto-switching will be already sourced (at least on most Linuxes).