### PR TITLE
Allow users to easily define LS_COLORS and LSCOLORS

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -76,10 +76,13 @@ if is-callable 'dircolors'; then
   alias ls='ls --group-directories-first'
 
   if zstyle -t ':prezto:module:utility:ls' color; then
-    if [[ -s "$HOME/.dir_colors" ]]; then
-      eval "$(dircolors --sh "$HOME/.dir_colors")"
-    else
-      eval "$(dircolors --sh)"
+    # Call dircolors to define colors if they're missing
+    if [[ -z "$LS_COLORS" ]]; then
+      if [[ -s "$HOME/.dir_colors" ]]; then
+        eval "$(dircolors --sh "$HOME/.dir_colors")"
+      else
+        eval "$(dircolors --sh)"
+      fi
     fi
 
     alias ls="${aliases[ls]:-ls} --color=auto"
@@ -89,11 +92,15 @@ if is-callable 'dircolors'; then
 else
   # BSD Core Utilities
   if zstyle -t ':prezto:module:utility:ls' color; then
-    # Define colors for BSD ls.
-    export LSCOLORS='exfxcxdxbxGxDxabagacad'
+    # Define colors for BSD ls if they're not already defined
+    if [[ -z "$LSCOLORS" ]]; then
+      export LSCOLORS='exfxcxdxbxGxDxabagacad'
+    fi
 
-    # Define colors for the completion system.
-    export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
+    # Define colors for the completion system if they're not already defined
+    if [[ -z "$LS_COLORS" ]]; then
+      export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
+    fi
 
     alias ls="${aliases[ls]:-ls} -G"
   else


### PR DESCRIPTION
Fixes #1539 

## Proposed Changes

  - Only set LSCOLORS and LS_COLORS if not already set

I'm not sure if there's a better solution, but this should allow users to define LS_COLORS and LSCOLORS while still falling back to our settings.