### PR TITLE
Fix ps-context edge cases

### DIFF
--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -26,6 +26,8 @@ zstyle ':prezto:module:editor' dot-expansion 'yes'
 
 ### PS Context
 
+**NOTE:** *This is deprecated and will be removed in future versions.*
+
 To enable the prompt context to be set, add the following to your
 *zpreztorc*.
 

--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -116,20 +116,21 @@ function editor-info {
 }
 zle -N editor-info
 
-# Reset the prompt based on the current context and
-# the ps-context option.
+# Reset the prompt based on the current context and whether the prompt utilizes
+# the editor:info zstyle. If the prompt does utilize the editor:info, we must
+# reset the prompt, otherwise the change in the prompt will never update. If the
+# prompt does not utilize the editor:info, we simply redisplay the command line.
 function zle-reset-prompt {
-  if zstyle -t ':prezto:module:editor' ps-context; then
+  # Explicitly check to see if there is an editor info keymap set that would
+  # require a reset of the prompt
+  if zstyle -L ':prezto:module:editor:info*' | grep -v 'completing' > /dev/null 2>&1; then
     # If we aren't within one of the specified contexts, then we want to reset
     # the prompt with the appropriate editor_info[keymap] if there is one.
     if [[ $CONTEXT != (select|cont) ]]; then
       zle reset-prompt
-      zle -R
     fi
-  else
-    zle reset-prompt
-    zle -R
   fi
+  zle -R
 }
 zle -N zle-reset-prompt
 

--- a/modules/prompt/functions/prompt_smiley_setup
+++ b/modules/prompt/functions/prompt_smiley_setup
@@ -36,7 +36,7 @@ function prompt_smiley_precmd {
 
 function prompt_smiley_setup {
   unsetopt XTRACE KSH_ARRAYS
-  prompt_opts=(percent subst)
+  prompt_opts=(cr percent sp subst)
 
   # Add hook for calling git-info before each command.
   add-zsh-hook precmd prompt_smiley_precmd

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -62,9 +62,6 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # Auto convert .... to ../..
 # zstyle ':prezto:module:editor' dot-expansion 'yes'
 
-# Allow the zsh prompt context to be shown.
-#zstyle ':prezto:module:editor' ps-context 'yes'
-
 #
 # Git
 #


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #1524.

## Proposed Changes

  - Checks to determine whether or not the prompt utilizes the `editor:info` before resetting the prompt. We ignore the completing as I did not observe it being an issue and only one prompt utilizes it with nothing else.
  - Removes the `ps-context`.
  - Fixes the smiley prompt.