### PR TITLE
Fix  .zprezto/modules/python/init.zsh:85: command not found: add-zsh-…

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -82,6 +82,7 @@ function _python-workon-cwd {
 # Load auto workon cwd hook
 if zstyle -t ':prezto:module:python:virtualenv' auto-switch 'yes'; then
   # Auto workon when changing directory
+  autoload -Uz add-zsh-hook
   add-zsh-hook chpwd _python-workon-cwd
 fi
 


### PR DESCRIPTION
Fixes ".zprezto/modules/python/init.zsh:85: command not found: add-zsh-hook"  error that started happening recently upon zsh start

```
Last login: Thu Feb xx xx:xx:xx on ttys000
/Users/xxxxx/.zprezto/modules/python/init.zsh:85: command not found: add-zsh-hook
```

happens on
  zsh 5.3 (x86_64-apple-darwin17.0)
  zsh 5.4.2 (x86_64-apple-darwin17.3.0)

with the latest prezto
