### PR TITLE
Add git alias to show log with GPG signatures

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -218,6 +218,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
   - `glg` displays the graph log.
   - `glb` displays the brief commit log.
   - `glc` displays the commit count for each contributor in descending order.
+  - `glss` displays GPG signatures in commits.
 
 ### Merge
 

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -188,6 +188,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias glg='git log --topo-order --all --graph --pretty=format:"${_git_log_oneline_format}"'
   alias glb='git log --topo-order --pretty=format:"${_git_log_brief_format}"'
   alias glc='git shortlog --summary --numbered'
+  alias glss='git log --topo-order --show-signature --pretty=format:"${_git_log_medium_format}"'
 
   # Merge (m)
   alias gm='git merge'


### PR DESCRIPTION
## Proposed Changes

  - Add one new alias (`glss`) for `git log --show-signature`

## Description

Would consider as a follow up on #1126, now adding a command to show the GPG signatures in commits.