### PR TITLE
Fix shell prompts on Termux. (#1560)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -103,8 +103,7 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    else 
- 
+    else
       setopt CASE_GLOB
       locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(-/FN)})
       setopt ${cg}_CASE_GLOB

--- a/init.zsh
+++ b/init.zsh
@@ -106,7 +106,7 @@ function pmodload {
     else
       setopt CASE_GLOB
       locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(-/FN)})
-      setopt ${cg}_CASE_GLOB
+      setopt ${case_glob_prefix}_CASE_GLOB
       if (( ${#locations} > 1 )); then
         print "$0: conflicting module locations: $locations"
         continue


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #1560

Basically, on Termux, completion sets NO_CASE_GLOB, but prompt can only be found if CASE_GLOB is set. This forces the glob to use CASE_GLOB. 

This is really more of a workaround for termux/termux-packages#1894, and once we find the bigger issue, this workaround should be removed.

## Proposed Changes

  - Temporarily enable CASE_GLOB when searching for plugins, as globbing acts weird on Termux.
  - This allows the prompt to load.
  - This works on macOS, but I haven't tested desktop Linux or Windows.
  - To do: More testing. 