### PR TITLE
Ignore tmux autostart in vscode terminal

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -23,7 +23,7 @@ if ([[ "$TERM_PROGRAM" = 'iTerm.app' ]] && \
   _tmux_iterm_integration='-CC'
 fi
 
-if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" && -z "$INSIDE_EMACS" ]] && ( \
+if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" && -z "$INSIDE_EMACS" && -z "$VSCODE_PID" ]] && ( \
   ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' remote ) ||
   ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' local ) \
 ); then


### PR DESCRIPTION
This PR makes prezto ignore tmux autostart when using integrated VSCode terminal. VSCODE_PID variable is not documented in any official docs for VSCode, except of this issue: https://github.com/Microsoft/vscode/issues/18556#issuecomment-299636934