### PR TITLE
Rename "Mac OS X" to "macOS" in comments

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -122,7 +122,7 @@ Initializes OCaml package management.
 OSX
 ---
 
-Defines Mac OS X aliases and functions.
+Defines macOS aliases and functions.
 
 Pacman
 ------
@@ -132,7 +132,7 @@ Provides aliases and functions for the Pacman package manager and frontends.
 Perl
 ----
 
-Enables local Perl module installation on Mac OS X and defines alises.
+Enables local Perl module installation on macOS and defines alises.
 
 Prompt
 ------

--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -12,7 +12,7 @@ if [[ -s '/etc/zsh_command_not_found' ]]; then
 # Load command-not-found on Arch Linux-based distributions.
 elif [[ -s '/usr/share/doc/pkgfile/command-not-found.zsh' ]]; then
   source '/usr/share/doc/pkgfile/command-not-found.zsh'
-# Load command-not-found on Mac OS X when homebrew tap is configured.
+# Load command-not-found on macOS when homebrew tap is configured.
 elif (( $+commands[brew] )) && brew command command-not-found-init > /dev/null 2>&1; then
   eval "$(brew command-not-found-init)"
 # Return if requirements are not found.

--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -1,7 +1,7 @@
 OSX
 ===
 
-Defines [Mac OS X][1] aliases and functions.
+Defines [macOS][1] aliases and functions.
 
 Settings
 --------
@@ -34,8 +34,8 @@ Functions
   - `tab` creates a new tab (works in both _Terminal_ and [_iTerm_][3]).
   - `ql` previews files in Quick Look.
   - `osx-rm-dir-metadata` deletes .DS\_Store, \_\_MACOSX cruft.
-  - `osx-ls-download-history` displays the Mac OS X download history.
-  - `osx-rm-download-history` deletes the Mac OS X download history.
+  - `osx-ls-download-history` displays the macOS download history.
+  - `osx-rm-download-history` deletes the macOS download history.
 
 Authors
 -------

--- a/modules/osx/functions/osx-ls-download-history
+++ b/modules/osx/functions/osx-ls-download-history
@@ -1,5 +1,5 @@
 #
-# Displays the Mac OS X download history.
+# Displays the macOS download history.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>

--- a/modules/osx/functions/osx-rm-download-history
+++ b/modules/osx/functions/osx-rm-download-history
@@ -1,5 +1,5 @@
 #
-# Deletes the Mac OS X download history.
+# Deletes the macOS download history.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>

--- a/modules/osx/init.zsh
+++ b/modules/osx/init.zsh
@@ -1,5 +1,5 @@
 #
-# Defines Mac OS X aliases and functions.
+# Defines macOS aliases and functions.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>

--- a/modules/perl/README.md
+++ b/modules/perl/README.md
@@ -1,14 +1,14 @@
 Perl
 ====
 
-Enables local [Perl][1] module installation on Mac OS X and defines aliases.
+Enables local [Perl][1] module installation on macOS and defines aliases.
 
 Local Module Installation
 -------------------------
 
 Perl versions older than 5.14 do not support the local installation of Perl
 modules natively. This module allows for local installation of Perl modules on
-Mac OS X in *~/Library/Perl/5.12* by altering the environment.
+macOS in *~/Library/Perl/5.12* by altering the environment.
 
 ### Usage
 

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -1,5 +1,5 @@
 #
-# Enables local Perl module installation on Mac OS X and defines aliases.
+# Enables local Perl module installation on macOS and defines aliases.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -19,7 +19,7 @@ elif (( $+commands[pyenv] )); then
   eval "$(pyenv init -)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to
-# ~/Library/Python on Mac OS X and ~/.local elsewhere, to PATH. The
+# ~/Library/Python on macOS and ~/.local elsewhere, to PATH. The
 # path can be overridden using PYTHONUSERBASE.
 else
   if [[ -n "$PYTHONUSERBASE" ]]; then

--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -3,7 +3,7 @@ Rsync
 
 Defines [rsync][1] aliases.
 
-Mac OS X users are encouraged to use [Bombich's rsync][2], which has HFS+
+macOS users are encouraged to use [Bombich's rsync][2], which has HFS+
 enhancements.
 
 Aliases

--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -20,7 +20,7 @@ if grep -q 'xattrs' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --acls --xattrs"
 fi
 
-# Mac OS X and HFS+ Enhancements
+# macOS and HFS+ Enhancements
 # http://help.bombich.com/kb/overview/credits#opensource
 if [[ "$OSTYPE" == darwin* ]] && grep -q 'file-flags' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --protect-decmpfs --force-change"

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -62,7 +62,7 @@ Aliases
 Caveats
 -------
 
-On Mac OS X, launching tmux can cause the error **launch_msg(...): Socket is not
+On macOS, launching tmux can cause the error **launch_msg(...): Socket is not
 connected** to be displayed, which can be fixed by installing
 [reattach-to-user-namespace][3], available in [Homebrew][4], and adding the
 following to *tmux.conf*:
@@ -71,7 +71,7 @@ following to *tmux.conf*:
 set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
 ```
 
-Furthermore, tmux is known to cause **kernel panics** on Mac OS X. A discussion
+Furthermore, tmux is known to cause **kernel panics** on macOS. A discussion
 about this and Prezto has already been [opened][2].
 
 Authors

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -128,7 +128,7 @@ if zstyle -t ':prezto:module:utility:grep' color; then
   alias grep="${aliases[grep]:-grep} --color=auto"
 fi
 
-# Mac OS X Everywhere
+# macOS Everywhere
 if [[ "$OSTYPE" == darwin* ]]; then
   alias o='open'
 elif [[ "$OSTYPE" == cygwin* ]]; then

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -93,7 +93,7 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # zstyle ':prezto:module:history-substring-search' globbing-flags ''
 
 #
-# OS X
+# macOS
 #
 
 # Set the keyword used by `mand` to open man pages in Dash.app


### PR DESCRIPTION
This only changes references in text for human consumption. It leaves
out renaming paths because that can cause breaking changes.

Related issue https://github.com/sorin-ionescu/prezto/issues/1449.