### PR TITLE
Export VIRTUAL_ENV_DISABLE_PROMPT when enabling virutalenv

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -94,7 +94,7 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) && \
   export WORKON_HOME="${WORKON_HOME:-$HOME/.virtualenvs}"
 
   # Disable the virtualenv prompt.
-  VIRTUAL_ENV_DISABLE_PROMPT=1
+  export VIRTUAL_ENV_DISABLE_PROMPT=1
 
   # Create a sorted array of available virtualenv related 'pyenv' commands to
   # look for plugins of interest. Scanning shell '$path' isn't enough as they


### PR DESCRIPTION
Add `export` to ensure the define is available in the shell so pyenv
or virtualenvwrapper do not duplicate the virtualenv name on the
prompt.


