### PR TITLE
Remove zlogout's Apu quote

### DIFF
--- a/runcoms/zlogout
+++ b/runcoms/zlogout
@@ -9,12 +9,12 @@
 [[ -o INTERACTIVE && -t 2 ]] && {
 
 # To print a message on logout:
-# uncomment the commented-out lines below, an
-# insert your content below the cat:
+# uncomment all of the commented-out lines below, and
+# insert your content at <your message here>
 
 # cat <<-EOF
 #
-# add your message here
+# <your message here>
 #
 # EOF
 #

--- a/runcoms/zlogout
+++ b/runcoms/zlogout
@@ -8,14 +8,12 @@
 # Execute code only if STDERR is bound to a TTY.
 [[ -o INTERACTIVE && -t 2 ]] && {
 
-# To print a message on logout:
-# uncomment all of the commented-out lines below, and
-# insert your content at <your message here>
+SAYINGS=(
+    "So long and thanks for all the fish.\n  -- Douglas Adams"
+    "Good morning! And in case I don't see ya, good afternoon, good evening and goodnight.\n  --Truman Burbank"
+)
 
-# cat <<-EOF
-#
-# <your message here>
-#
-# EOF
-#
-# } >&2
+# Print a randomly-chosen message:
+echo $SAYINGS[$(($RANDOM % ${#SAYINGS} + 1))]
+
+} >&2

--- a/runcoms/zlogout
+++ b/runcoms/zlogout
@@ -8,11 +8,14 @@
 # Execute code only if STDERR is bound to a TTY.
 [[ -o INTERACTIVE && -t 2 ]] && {
 
-# Print the message.
-cat <<-EOF
+# To print a message on logout:
+# uncomment the commented-out lines below, an
+# insert your content below the cat:
 
-Thank you. Come again!
-  -- Dr. Apu Nahasapeemapetilon
-EOF
-
-} >&2
+# cat <<-EOF
+#
+# add your message here
+#
+# EOF
+#
+# } >&2


### PR DESCRIPTION
## Proposed Changes

  - Remove the Apu quote on logout. It's unnecessary, and I personally find it in poor taste. For more context about Apu and the examination and critique of his role on The Simpsons, read about and watch https://en.wikipedia.org/wiki/The_Problem_with_Apu
