### PR TITLE
Document `gpf` vs `gpF`

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -233,7 +233,8 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 ### Push
 
   - `gp` updates remote refs along with associated objects.
-  - `gpf` forcefully updates remote refs along with associated objects.
+  - `gpf` forcefully updates remote refs along with associated objects using the safer `--force-with-lease` option.
+  - `gpF` forcefully updates remote refs along with associated objects using the riskier `--force` option.
   - `gpa` updates remote branches along with associated objects.
   - `gpA` updates remote branches and tags along with associated objects.
   - `gpt` updates remote tags along with associated objects.


### PR DESCRIPTION
Document the difference between `gpf` and `gpF`. These were changed in https://github.com/sorin-ionescu/prezto/pull/1040 / https://github.com/sorin-ionescu/prezto/commit/ddfc870f9aae4f43da10863a175cee2c91485cde, but never documented.