### PR TITLE
Fix spelling error in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ there are a number of additional things to keep in mind.
    - Prefer `zstyle` over environment variables for configuration.
    - Prefer (( ... )) over [[ ... ]] for arithmetic expression.
    - Use the function keyword to define functions.
-   - The 80 character hard limit can be waved for readability.
+   - The 80 character hard limit can be waived for readability.
 
 #### Using an Alternative zprezto Directory
 


### PR DESCRIPTION
This PR fixes a spelling error in CONTRIBUTING.md.

If we're on a page that's asking for grammatically correct PRs, we may as well be picky about spelling. :)