### PR TITLE
Update the gnu-utility shortcuts to match coreutils

### DIFF
--- a/modules/gnu-utility/init.zsh
+++ b/modules/gnu-utility/init.zsh
@@ -15,16 +15,16 @@ fi
 
 _gnu_utility_cmds=(
   # Coreutils
-  '[' 'base64' 'basename' 'cat' 'chcon' 'chgrp' 'chmod' 'chown'
+  '[' 'b2sum' 'base32' 'base64' 'basename' 'cat' 'chcon' 'chgrp' 'chmod' 'chown'
   'chroot' 'cksum' 'comm' 'cp' 'csplit' 'cut' 'date' 'dd' 'df'
   'dir' 'dircolors' 'dirname' 'du' 'echo' 'env' 'expand' 'expr'
   'factor' 'false' 'fmt' 'fold' 'groups' 'head' 'hostid' 'id'
-  'install' 'join' 'kill' 'link' 'ln' 'logname' 'ls' 'md5sum'
-  'mkdir' 'mkfifo' 'mknod' 'mktemp' 'mv' 'nice' 'nl' 'nohup' 'nproc'
-  'od' 'paste' 'pathchk' 'pinee' 'pr' 'printenv' 'printf' 'ptx'
+  'install' 'join' 'kill' 'link' 'ln' 'logname' 'ls' 'md5sum' 'mkdir'
+  'mkfifo' 'mknod' 'mktemp' 'mv' 'nice' 'nl' 'nohup' 'nproc'
+  'numfmt' 'od' 'paste' 'pathchk' 'pinky' 'pr' 'printenv' 'printf' 'ptx'
   'pwd' 'readlink' 'realpath' 'rm' 'rmdir' 'runcon' 'seq' 'sha1sum'
   'sha224sum' 'sha256sum' 'sha384sum' 'sha512sum' 'shred' 'shuf'
-  'sleep' 'sort' 'split' 'stat' 'stty' 'sum' 'sync' 'tac' 'tail'
+  'sleep' 'sort' 'split' 'stat' 'stdbuf' 'stty' 'sum' 'sync' 'tac' 'tail'
   'tee' 'test' 'timeout' 'touch' 'tr' 'true' 'truncate' 'tsort'
   'tty' 'uname' 'unexpand' 'uniq' 'unlink' 'uptime' 'users' 'vdir'
   'wc' 'who' 'whoami' 'yes'


### PR DESCRIPTION
Some binaries have been added to coreutils, it should be reflected in the gnu utility module