### PR TITLE
Improve startup time by skipping pyenv rehash

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -11,12 +11,12 @@
 if [[ -s "$HOME/.pyenv/bin/pyenv" ]]; then
   path=("$HOME/.pyenv/bin" $path)
   export PYENV_ROOT=$(pyenv root)
-  eval "$(pyenv init -)"
+  eval "$(pyenv init - --no-rehash zsh)"
 
 # Load package manager installed pyenv into the shell session.
 elif (( $+commands[pyenv] )); then
   export PYENV_ROOT=$(pyenv root)
-  eval "$(pyenv init -)"
+  eval "$(pyenv init - --no-rehash zsh)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to
 # ~/Library/Python on macOS and ~/.local elsewhere, to PATH. The
@@ -106,7 +106,7 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) && \
 
   if (( $pyenv_plugins[(i)virtualenv-init] <= $#pyenv_plugins )); then
     # Enable 'virtualenv' with 'pyenv'.
-    eval "$(pyenv virtualenv-init -)"
+    eval "$(pyenv virtualenv-init - zsh)"
 
     # Optionally activate 'virtualenvwrapper' plugin when available.
     if (( $pyenv_plugins[(i)virtualenvwrapper(_lazy|)] <= $#pyenv_plugins )); then


### PR DESCRIPTION
After profiling startup time, I found that "pyenv rehash" is
by far the slowest piece. This change skips rehashing on init.

See https://github.com/pyenv/pyenv/issues/784#issuecomment-404850327

Also pass the shell explicitly, as suggested in
https://github.com/pyenv/pyenv/issues/784#issuecomment-404944318,
which provides a modest improvement.

In total, this improves startup time from 1s to 0.3s on my machine.
Using the following command:
`python -m timeit "__import__('subprocess').Popen(['zsh', '-i', '-c', 'echo']).communicate()"`

Result before this change:
10 loops, best of 3: 1 sec per loop

Result after this change:
10 loops, best of 3: 334 msec per loop

