### PR TITLE
Make node-info work without nvm/nodenv

### DIFF
--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -19,6 +19,8 @@ if (( $+functions[nvm_version] )); then
   version="${$(nvm_version)#v}"
 elif (( $+commands[nodenv] )); then
   version="${${$(nodenv version)#v}[(w)0]}"
+elif (( $+commands[node] )) ; then
+  version="${$(node -v)#v}"  
 fi
 
 if [[ "$version" != (none|) ]]; then


### PR DESCRIPTION
## Proposed Changes

  - I'm using [n](https://github.com/tj/n) as my Node version manager and `node-info` didn't work, so I used a similar check as in `modules/node/init.zsh` to get it to work.