### PR TITLE
Fix broken gitref link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ SOFTWARE.
 [3]: http://git-scm.com
 [4]: https://github.com
 [5]: http://gitimmersion.com
-[6]: http://gitref.org
+[6]: https://git.github.io/git-reference/
 [7]: http://www.bash2zsh.com/zsh_refcard/refcard.pdf
 [8]: http://grml.org/zsh/zsh-lovers.html


### PR DESCRIPTION
gitref.org points to services.github.com, and has been for some time[0].

[0] https://github.com/git/git-reference/issues/112