### PR TITLE
command-not-found: Restore idiomatic loading of homebrewed handler on MacOS

### DIFF
--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -12,9 +12,28 @@ if [[ -s '/etc/zsh_command_not_found' ]]; then
 # Load command-not-found on Arch Linux-based distributions.
 elif [[ -s '/usr/share/doc/pkgfile/command-not-found.zsh' ]]; then
   source '/usr/share/doc/pkgfile/command-not-found.zsh'
-# Load command-not-found on macOS when homebrew tap is configured.
-elif [[ -s '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh' ]]; then
-  source '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh'
+# Load command-not-found on macOS when Homebrew tap is configured.
+# To avoid performance penalty, we do not use Homebrew's ruby based command
+# lookup mechanism (viz., `brew command command-not-found-init`) and instead
+# `find` it ourselves from `TAP_DIRECTORY` defined internally in Homebrew.
+elif (( $+commands[brew] )); then
+  cnf_command="$(brew --repository 2> /dev/null)"/Library/Taps/homebrew/homebrew-command-not-found/cmd/brew-command-not-found-init.rb
+  if [[ -s "$cnf_command" ]]; then
+    cache_file="${TMPDIR:-/tmp}/prezto-brew-command-not-found-cache.$UID.zsh"
+
+    if [[ "$cnf_command" -nt "$cache_file" \
+          || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
+          || ! -s "$cache_file" ]]; then
+      # brew command-not-found-init is slow; cache its output.
+      brew command-not-found-init >! "$cache_file" 2> /dev/null
+    fi
+
+    source "$cache_file"
+
+    unset cache_file
+  fi
+
+  unset cnf_command
 # Return if requirements are not found.
 else
   return 1


### PR DESCRIPTION
## Proposed Changes

As is the convention in prezto, we cache the command-not-found handler to avoid
incurring the performance penalty of loading ruby interpreter on every call.
This restores the 'homebrew way' of loading command-not-found handler.

This also reinstates support for custom taps or non-standard homebrew location.

Fixes #1577, Fixes #1451
