### PR TITLE
Also check "commondir" when checking for a stash

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -212,10 +212,16 @@ function git-info {
 
   # Format stashed.
   zstyle -s ':prezto:module:git:info:stashed' format 'stashed_format'
-  if [[ -n "$stashed_format" && -f "$(git-dir)/refs/stash" ]]; then
-    stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
-    if [[ -n "$stashed" ]]; then
-      zformat -f stashed_formatted "$stashed_format" "S:$stashed"
+  if [[ -n "$stashed_format" ]]; then
+    commondir=""
+    if [[ -f "$(git-dir)/commondir" ]]; then
+      commondir="$(git-dir)/$(<$(git-dir)/commondir)"
+    fi
+    if [[ -f "$(git-dir)/refs/stash" || ( -n "$commondir" && -f "$commondir/refs/stash" ) ]]; then
+      stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
+      if [[ -n "$stashed" ]]; then
+        zformat -f stashed_formatted "$stashed_format" "S:$stashed"
+      fi
     fi
   fi
 

--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -215,7 +215,8 @@ function git-info {
   if [[ -n "$stashed_format" ]]; then
     commondir=""
     if [[ -f "$(git-dir)/commondir" ]]; then
-      commondir="$(git-dir)/$(<$(git-dir)/commondir)"
+      commondir="$(<$(git-dir)/commondir)"
+      [[ "$commondir" =~ ^/ ]] || commondir="$(git-dir)/$commondir"
     fi
     if [[ -f "$(git-dir)/refs/stash" || ( -n "$commondir" && -f "$commondir/refs/stash" ) ]]; then
       stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"


### PR DESCRIPTION
In `git-info`, we check if there is git stash by looking for `.git/refs/stash` file.
But in git worktrees, there is a file named `commondir` under `$(git-dir)`, and it's usually `../..`, and `refs/stash` is not in `$(git-dir)` but in `$(git-dir)/../..` (the `../..` part comes from the content of `commondir`).

This patch checks there as well.