### PR TITLE
homebrew: Load standard Homebrew environment variables into shell session

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -1,7 +1,16 @@
 Homebrew
 ========
 
-Defines Homebrew aliases.
+Defines Homebrew specific shell environment variables and aliases.
+
+Environment Variables
+---------------------
+
+Execute the following to list the environment variables loaded in the shell:
+
+```sh
+brew shellenv
+```
 
 Aliases
 -------

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -11,6 +11,16 @@ if [[ "$OSTYPE" != (darwin|linux)* ]]; then
 fi
 
 #
+# Environmental Variables
+#
+
+# Load standard Homebrew shellenv into the shell session.
+# `brew shellenv` is relatively new, guard for legacy Homebrew.
+if (( $+commands[brew] )); then
+  eval "$(brew shellenv 2> /dev/null)"
+fi
+
+#
 # Aliases
 #
 


### PR DESCRIPTION
## Proposed Changes

Load standard Homebrew environment variables into shell session.
Since `brew shellenv` is relatively new, there is extra guard. This can be removed a few months later.