### PR TITLE
homebrew: Replace deprecated casks with their brew counterpart

### DIFF
--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -20,12 +20,9 @@ Aliases
 ### Homebrew Cask
 
   - `cask` is aliased to `brew cask`.
-  - `caskc` cleans up old cached downloads.
-  - `caskC` cleans up all cached downloads.
   - `caski` installs a cask.
   - `caskl` lists installed casks.
   - `casko` lists casks which have an update available.
-  - `casks` searches for a cask.
   - `caskx` uninstalls a cask.
 
 Authors

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -26,10 +26,21 @@ alias brewx='brew remove'
 
 # Homebrew Cask
 alias cask='brew cask'
-alias caskc='brew cask cleanup --outdated'
-alias caskC='brew cask cleanup'
+alias caskc='hb_deprecated brew cask cleanup'
+alias caskC='hb_deprecated brew cask cleanup'
 alias caski='brew cask install'
 alias caskl='brew cask list'
 alias casko='brew cask outdated'
-alias casks='brew cask search'
+alias casks='hb_deprecated brew cask search'
 alias caskx='brew cask uninstall'
+
+function hb_deprecated {
+  local cmd="${argv[3]}"
+  local cmd_args=( ${(@)argv:4} )
+
+  printf "'brew cask %s' has been deprecated, " "${cmd}"
+  printf "using 'brew %s' instead\n" "${cmd}"
+
+  cmd_args=( ${(@)argv:4} )
+  command brew "${cmd}" ${(@)cmd_args}
+}

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -21,8 +21,8 @@ alias brewi='brew install'
 alias brewl='brew list'
 alias brewo='brew outdated'
 alias brews='brew search'
-alias brewu='brew update && brew upgrade'
-alias brewx='brew remove'
+alias brewu='brew upgrade'
+alias brewx='brew uninstall'
 
 # Homebrew Cask
 alias cask='brew cask'


### PR DESCRIPTION
## Proposed Changes

Homebrew has deprecated `brew cask cleanup` and `brew cask search` in favor
of `brew cleanup` and `brew search` respectively. They will stop working on
2018-09-30.

We should eventually remove the related aliases, but for a while we keep
supporting them gracefully with a deprecation warning.

Further, cleanup `brew` aliases as well.

Replaces: #1597
Reference: Homebrew/brew#4661