### PR TITLE
Ability to set a custom PROMPT_EDGE 

### DIFF
--- a/modules/prompt/functions/prompt_steeef_setup
+++ b/modules/prompt/functions/prompt_steeef_setup
@@ -85,9 +85,10 @@ function prompt_steeef_setup {
   zstyle ':prezto:module:python:info:virtualenv' format '(%v)'
 
   # Define prompts.
+  PROMPT_EDGE=${PROMPT_EDGE:=\$}
   PROMPT="
 ${_prompt_steeef_colors[3]}%n%f at ${_prompt_steeef_colors[2]}%m%f in ${_prompt_steeef_colors[5]}%~%f "'${vcs_info_msg_0_}'"
-"'$python_info[virtualenv]'"$ "
+"'$python_info[virtualenv]'"${PROMPT_EDGE} "
   RPROMPT=''
 }
 


### PR DESCRIPTION
Using variable PROMPT_EDGE to set the desired prompt character

ex: 
```
export PROMPT_EDGE="λ"
```