### PR TITLE
Fix issue #1635. Option to disable GNU ls to group directories first.

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -18,6 +18,12 @@ disabled, type indicators (\*, /, =>, @, =, |, %) will be appended to entries.
 zstyle ':prezto:module:utility:ls' color 'no'
 ```
 
+To disable GNU coreutils `ls` to list directories grouped first, add the following line to *zpreztorc*:
+
+```sh
+zstyle ':prezto:module:utility:ls' dirs-first 'no'
+```
+
 To disable `diff` highlighting, add the following line to *zpreztorc*:
 
 ```sh

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -73,7 +73,10 @@ fi
 # ls
 if is-callable 'dircolors'; then
   # GNU Core Utilities
-  alias ls='ls --group-directories-first'
+
+  if zstyle -T ':prezto:module:utility:ls' dirs-first; then
+    alias ls="${aliases[ls]:-ls} --group-directories-first"
+  fi
 
   if zstyle -t ':prezto:module:utility:ls' color; then
     # Call dircolors to define colors if they're missing


### PR DESCRIPTION
Fixes #1635. Add option to disable group directories first in GNU `ls`.

## Proposed Changes

  - Added a option `':prezto:module:utility:ls' dirs-first`
  - Default value is enabled, no breaking change
