### PR TITLE
Add alias `z` provided by `fasd`, which makes `z` users happy without ditching `fasd`.

### DIFF
--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -22,6 +22,7 @@ Aliases
 -------
 
   - `j` changes the current working directory interactively.
+  - `z` changes the current working directory, same functionality as `j` in [autojump][2].
 
 Completion
 ----------

--- a/modules/fasd/init.zsh
+++ b/modules/fasd/init.zsh
@@ -54,3 +54,6 @@ function fasd_cd {
 
 # Changes the current working directory interactively.
 alias j='fasd_cd -i'
+
+# Changes the current working directory, same functionality as j in autojump.
+alias z='fasd_cd'


### PR DESCRIPTION
Fixes #656 (hopefully)

## Proposed Changes

  - Add an alias `z` for non-interactive directory changing.