### PR TITLE
python: Make cached completion file mangling more reliable

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -150,7 +150,7 @@ fi
 
 # Load PIP completion.
 if (( $#commands[(i)pip(|[23])] )); then
-  cache_file="${TMPDIR:-/tmp}/prezto-python-cache.$UID.zsh"
+  cache_file="${TMPDIR:-/tmp}/prezto-pip-cache.$UID.zsh"
 
   # Detect and use one available from among 'pip', 'pip2', 'pip3' variants
   pip_command="$commands[(i)pip(|[23])]"

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -160,10 +160,11 @@ if (( $#commands[(i)pip(|[23])] )); then
         || ! -s "$cache_file" ]]; then
     # pip is slow; cache its output. And also support 'pip2', 'pip3' variants
     $pip_command completion --zsh \
-      | sed -e "s|compctl -K [-_[:alnum:]]* pip|& pip2 pip3|" >! "$cache_file" 2> /dev/null
+      | sed -e "s|\(compctl -K [-_[:alnum:]]*\) pip|\1 pip pip2 pip3|" >! "$cache_file" 2> /dev/null
   fi
 
   source "$cache_file"
+
   unset cache_file pip_command
 fi
 


### PR DESCRIPTION
## Proposed Changes

While mangling cached completion file, we cannot just assume that
`$pip_command` would resolve to `pip` -- it might be `pip2` or `pip3`
depending on the relative position in zsh `$commands` array.  Thus replace
the whole of 'pip*' with 'pip pip2 pip3' for compctl assignment.

Also, use more apropriate cache filename for pip completion.
