### PR TITLE
rsync: use --inplace for rsync base cmd by default

### DIFF
--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -22,7 +22,7 @@ if grep -q 'xattrs' <(rsync --help 2>&1); then
 fi
 
 # macOS and HFS+ Enhancements
-# http://help.bombich.com/kb/overview/credits#opensource
+# https://bombich.com/kb/ccc5/credits
 if [[ "$OSTYPE" == darwin* ]] && grep -q 'file-flags' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --protect-decmpfs --force-change"
 fi

--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -15,7 +15,7 @@ fi
 #
 
 _rsync_cmd='rsync --verbose --progress --human-readable --compress --archive \
-  --hard-links --one-file-system'
+  --hard-links --inplace --one-file-system'
 
 if grep -q 'xattrs' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --acls --xattrs"


### PR DESCRIPTION
## Proposed Changes

  - Use `--inplace` flag by default. Updating detination file 'inplace' is almo st alway what we want. This is also a recommended option on COW filesystems (like BTRFS). @Eriner suggested this [few years ago](https://github.com/Eriner/prezto/commit/2c3e9209726652fe32e6c82e1fd167517f13476f) and I have been using it since quite successfully.
  - Update link to Bombich rsync page again
