### PR TITLE
node: Make nvm lookup mechanism more efficient in homebrewed environment

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -11,8 +11,10 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   source "$HOME/.nvm/nvm.sh"
 
 # Load package manager installed NVM into the shell session.
-elif (( $+commands[brew] )) && [[ -d "$(brew --prefix nvm 2> /dev/null)" ]]; then
+elif (( $+commands[brew] )) && \
+  [[ -d "${nvm_prefix::="$(brew --prefix 2> /dev/null)"/opt/nvm}" ]]; then
   source "$(brew --prefix nvm)/nvm.sh"
+  unset nvm_prefix
 
 # Load manually installed nodenv into the shell session.
 elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then


### PR DESCRIPTION
## Proposed Changes

In homebrewed environment, avoid using `brew --prefix nvm` which is ruby based and is super slow. Instead, rely on homebrew standard behavior wherein all installed packages are available in canonical path `$(brew --prefix)/opt/<package>` (for nvm it would obviously be `$(brew --prefix)/opt/nvm`).

NB: `$(brew --prefix)` (without additional argument) is a simple shell shortcut and doesn't have the same performance impact.