### PR TITLE
archive: Enhance 'archive' helper to support multi file archive

### DIFF
--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -8,11 +8,11 @@
 
 # function archive {
 
-local archive_name dir_to_archive _gzip_bin _bzip2_bin
+local archive_name path_to_archive _gzip_bin _bzip2_bin
 
-if (( $# != 2 )); then
+if (( $# < 2 )); then
   cat >&2 <<EOF
-usage: $0 [archive_name.zip] [/path/to/include/into/archive]
+usage: $0 [archive_name.zip] [/path/to/include/into/archive ...]
 
 Where 'archive.zip' uses any of the following extensions:
 
@@ -28,14 +28,8 @@ fi
 
 # strip the path, just in case one is provided for some reason
 archive_name="${1:t}"
-# use absolute paths, and follow symlinks
-dir_to_archive="${2}"
-
-# if the directory doesn't exist, quit. Nothing to archive
-if [[ ! -e "${dir_to_archive}" ]]; then
-  print "$0: file or directory not valid: ${dir_to_archive}" >&2
-  return 1
-fi
+# let paths be handled by actual archive helper
+path_to_archive="${@:2}"
 
 # here, we check for dropin/multi-threaded replacements
 # this should eventually be moved to modules/archive/init.zsh
@@ -53,14 +47,14 @@ else
 fi
 
 case "${archive_name}" in
-  (*.tar.gz|*.tgz) tar -cvf "${archive_name}" --use-compress-program="${_gzip_bin}" "${dir_to_archive}" ;;
-  (*.tar.bz2|*.tbz|*.tbz2) tar -cvf "${archive_name}" --use-compress-program="${_bzip2_bin}" "${dir_to_archive}" ;;
-  (*.tar.xz|*.txz) tar -cvJf "${archive_name}" "${dir_to_archive}" ;;
-  (*.tar.lzma|*.tlz) tar -cvf "${archive_name}" --lzma "${dir_to_archive}" ;;
-  (*.tar) tar -cvf "${archive_name}" "${dir_to_archive}" ;;
-  (*.zip|*.jar) zip -r "${archive_name}" "${dir_to_archive}" ;;
-  (*.rar) rar a "${archive_name}" "${dir_to_archive}" ;;
-  (*.7z) 7za a "${archive_name}" "${dir_to_archive}" ;;
+  (*.tar.gz|*.tgz) tar -cvf "${archive_name}" --use-compress-program="${_gzip_bin}" "${=path_to_archive}" ;;
+  (*.tar.bz2|*.tbz|*.tbz2) tar -cvf "${archive_name}" --use-compress-program="${_bzip2_bin}" "${=path_to_archive}" ;;
+  (*.tar.xz|*.txz) tar -cvJf "${archive_name}" "${=path_to_archive}" ;;
+  (*.tar.lzma|*.tlz) tar -cvf "${archive_name}" --lzma "${=path_to_archive}" ;;
+  (*.tar) tar -cvf "${archive_name}" "${=path_to_archive}" ;;
+  (*.zip|*.jar) zip -r "${archive_name}" "${=path_to_archive}" ;;
+  (*.rar) rar a "${archive_name}" "${=path_to_archive}" ;;
+  (*.7z) 7za a "${archive_name}" "${=path_to_archive}" ;;
   (*.gz) print "\n.gz is only useful for single files, and does not capture permissions. Use .tar.gz" ;;
   (*.bz2) print "\n.bzip2 is only useful for single files, and does not capture permissions. Use .tar.bz2" ;;
   (*.xz) print "\n.xz is only useful for single files, and does not capture permissions. Use .tar.xz" ;;


### PR DESCRIPTION
## Proposed Changes

We now allow multiple paths (files/directories) to be archived in one shot. Validation of the target path(s) is now delegated to the actual archive helper.

Fixes #1618