### PR TITLE
python: Use brace expansion for pip compctl match

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -160,7 +160,9 @@ if (( $#commands[(i)pip(|[23])] )); then
         || ! -s "$cache_file" ]]; then
     # pip is slow; cache its output. And also support 'pip2', 'pip3' variants
     $pip_command completion --zsh \
-      | sed -e "s/\(compctl -K [-_[:alnum:]]*\) pip.*/\1 pip(|[23](|.[0-9]))/" >! "$cache_file" 2> /dev/null
+      | sed -e "s/\(compctl -K [-_[:alnum:]]* pip\).*/\1{,2,3}{,.{0..9}}/" \
+      >! "$cache_file" \
+      2> /dev/null
   fi
 
   source "$cache_file"


### PR DESCRIPTION
## Proposed Changes

Just use brace expansion only (and not a mix of brace expansion and 
path expansion) to expand `sed` match for more variants of 'pip*' (pip, 
pip2, pip3, pip2.7, pip3.7 etc.) in `compctl` assignment

Fixes: #1658