### PR TITLE
Fix typo: gupl --> gulp

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -34,7 +34,7 @@ fi
 typeset -A compl_commands=(
   npm   'npm completion'
   grunt 'grunt --completion=zsh'
-  gupl  'gulp --completion=zsh'
+  gulp  'gulp --completion=zsh'
 )
 
 for compl_command in "${(k)compl_commands[@]}"; do


### PR DESCRIPTION
I _think_ this is a typo, but not sure as I don't actually use `gulp`... just spotted while reviewing the diff of latest changes.