### PR TITLE
history: remove mutually exclusive option

### DIFF
--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -8,8 +8,9 @@ Options
 
   - `BANG_HIST` treats the **!** character specially during expansion.
   - `EXTENDED_HISTORY` writes the history file in the *:start:elapsed;command* format.
-  - `INC_APPEND_HISTORY` writes to the history file immediately, not when the shell exits.
-  - `SHARE_HISTORY` shares history between all sessions.
+  - `SHARE_HISTORY` shares history between all sessions. Note that
+    `SHARE_HISTORY`, `INC_APPEND_HISTORY`, and `INC_APPEND_HISTORY_TIME` are
+    mutually exclusive.
   - `HIST_EXPIRE_DUPS_FIRST` expires a duplicate event first when trimming history.
   - `HIST_IGNORE_DUPS` does not record an event that was just recorded again.
   - `HIST_IGNORE_ALL_DUPS` deletes an old recorded event if a new event is a duplicate.

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -12,7 +12,6 @@
 
 setopt BANG_HIST                 # Treat the '!' character specially during expansion.
 setopt EXTENDED_HISTORY          # Write the history file in the ':start:elapsed;command' format.
-setopt INC_APPEND_HISTORY        # Write to the history file immediately, not when the shell exits.
 setopt SHARE_HISTORY             # Share history between all sessions.
 setopt HIST_EXPIRE_DUPS_FIRST    # Expire a duplicate event first when trimming history.
 setopt HIST_IGNORE_DUPS          # Do not record an event that was just recorded again.


### PR DESCRIPTION
According to Zsh documentation http://zsh.sourceforge.net/Doc/Release/Options.html#History
INC_APPEND_HISTORY, INC_APPEND_HISTORY, and SHARE_HISTORY are mutually exclusive.
I didn't see any bug specifically, but just to be safe
I figured we want SHARE_HISTORY since it has the most features (and is what we actually use)