### PR TITLE
Add option to disable pip cache generation

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -22,6 +22,12 @@ zstyle ':prezto:module:python' conda-init 'on'
 
 Caution: using conda and virtualenvwrapper at the same time may cause conflicts.
 
+Pip autocompletion cache is automatically generated. To disable, add the following.
+
+```sh
+zstyle ':prezto:module:python' pip-cache 'no'
+```
+
 Local Python Installation
 -------------------------
 

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -149,7 +149,7 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) && \
 fi
 
 # Load PIP completion.
-if (( $#commands[(i)pip(|[23])] )); then
+if zstyle -T ':prezto:module:python' pip-cache && (( $#commands[(i)pip(|[23])] )); then
   cache_file="${TMPDIR:-/tmp}/prezto-pip-cache.$UID.zsh"
 
   # Detect and use one available from among 'pip', 'pip2', 'pip3' variants


### PR DESCRIPTION
On my computer, this process takes seconds. And as I ssh onto a lot of "fresh" hosts, it's very annoying as the initial logon is very slow.

Adding this option so user could disable. But by default it's on, as before