### PR TITLE
sorin-prompt: Remove old prompt tempfile and pid variable

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -110,8 +110,6 @@ function prompt_sorin_setup {
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
   prompt_opts=(cr percent sp subst)
-  _prompt_sorin_precmd_async_pid=0
-  _prompt_sorin_precmd_async_data=$(mktemp "${TMPDIR:-/tmp}/sorin-prompt-async-XXXXXXXXXX")
 
   # Load required functions.
   autoload -Uz add-zsh-hook


### PR DESCRIPTION

## Proposed Changes

  - Remove the tempfile and PID variable for the sorin prompt, it's not needed any more. Probably a leftover from #1385 

CC @belak 

