### PR TITLE
Add the ability to set locale environment variables

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -62,3 +62,14 @@ if zstyle -t ':prezto:environment:termcap' color; then
   export LESS_TERMCAP_ue=$'\E[0m'          # Ends underline.
   export LESS_TERMCAP_us=$'\E[01;32m'      # Begins underline.
 fi
+
+#
+# Locale
+#
+
+zstyle -s ':prezto:environment' language 'LANGUAGE'
+if [[ ! -z $LANGUAGE ]]
+then
+  export LC_ALL="$LANGUAGE"
+  export LANG="$LANGUAGE"
+fi

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -66,6 +66,13 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 #zstyle ':prezto:module:editor' ps-context 'yes'
 
 #
+# Environment
+#
+
+# You may need to manually set your language environment
+zstyle ':prezto:environment' language 'en_US.UTF-8'
+
+#
 # Git
 #
 


### PR DESCRIPTION
Allow setting locale environment variables `$LC_ALL` and `$LANG` from prezto runcom.