### PR TITLE
Set key bindings alt + arrow keys to move between words

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -269,9 +269,11 @@ bindkey -d
 # Emacs Key Bindings
 #
 
-for key in "$key_info[Escape]"{B,b} "${(s: :)key_info[ControlLeft]}"
+for key in "$key_info[Escape]"{B,b} "${(s: :)key_info[ControlLeft]}" \
+  "${key_info[Escape]}${key_info[Left]}"
   bindkey -M emacs "$key" emacs-backward-word
-for key in "$key_info[Escape]"{F,f} "${(s: :)key_info[ControlRight]}"
+for key in "$key_info[Escape]"{F,f} "${(s: :)key_info[ControlRight]}" \
+  "${key_info[Escape]}${key_info[Right]}"
   bindkey -M emacs "$key" emacs-forward-word
 
 # Kill to the beginning of the line.


### PR DESCRIPTION
I use iTerm + tmux + prezto/zsh
I noticed this only recently: when I press alt + arrow keys in ZLE, it won't move cursor around words, instead it'll print out A/B/C/D (and an alarm).
I use iTerm's default settings, so alt + left will be translated to `^[^[[D`. This translation is actually hard-coded (irrelevant of normal/application mode), so with iTerm + prezto/zsh, things work as expected.
But as soon as I start using iTerm + **tmux** + prezto/zsh, and since prezto enable application mode by default (`echoti smkx`), tmux will try to be smart and interpret alt + left as `^[^[OD`. This is the correct behavior according to `terminfo` (capability `kcub1`)! But then prezto/zsh doesn't have a keybinding for this control sequence and outputs D on the screen.

At any rate, tldr, I'm adding the keybinding for this. I believe `key_info` will do the right thing so this will work for all terminals. Specifically under xterm, this maps `^[^[Ox` where `x=A/B/C/D`.
But I have no idea why this only happened recently to me. (Not being able to figure out this really bothers me :(
iTerm has been sending this control sequence for a long time. I tried `tmux` from last year but the problem still persists. I tried zsh 5.3.1 and 5.6.2, both have this problem... I'd greatly appreciate it if you know why this is the case