### PR TITLE
archive: enhance parallel operations

### DIFF
--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -8,7 +8,7 @@
 
 # function archive {
 
-local archive_name path_to_archive _gzip_bin _bzip2_bin
+local archive_name path_to_archive _gzip_bin _bzip2_bin _xz_bin
 
 if (( $# < 2 )); then
   cat >&2 <<EOF
@@ -40,7 +40,15 @@ else
   _gzip_bin='gzip'
 fi
 
-if (( $+commands[pbzip2] )); then
+if (( $+commands[pixz] )); then
+  _xz_bin='pixz'
+else
+  _xz_bin='xz'
+fi
+
+if (( $+commands[lbzip2] )); then
+  _bzip2_bin='lbzip2'
+elif (( $+commands[pbzip2] )); then
   _bzip2_bin='pbzip2'
 else
   _bzip2_bin='bzip2'
@@ -49,7 +57,7 @@ fi
 case "${archive_name}" in
   (*.tar.gz|*.tgz) tar -cvf "${archive_name}" --use-compress-program="${_gzip_bin}" "${=path_to_archive}" ;;
   (*.tar.bz2|*.tbz|*.tbz2) tar -cvf "${archive_name}" --use-compress-program="${_bzip2_bin}" "${=path_to_archive}" ;;
-  (*.tar.xz|*.txz) tar -cvJf "${archive_name}" "${=path_to_archive}" ;;
+  (*.tar.xz|*.txz) tar -cvf "${archive_name}" --use-compress-program="${_xz_bin}" "${=path_to_archive}" ;;
   (*.tar.lzma|*.tlz) tar -cvf "${archive_name}" --lzma "${=path_to_archive}" ;;
   (*.tar) tar -cvf "${archive_name}" "${=path_to_archive}" ;;
   (*.zip|*.jar) zip -r "${archive_name}" "${=path_to_archive}" ;;

--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -12,6 +12,7 @@ local success
 local file_name
 local file_path
 local extract_dir
+local _gzip_bin _bzip2_bin _xz_bin
 
 if (( $# == 0 )); then
   cat >&2 <<EOF
@@ -30,6 +31,29 @@ if [[ "$1" == "-r" || "$1" == "--remove" ]]; then
   shift
 fi
 
+# here, we check for dropin/multi-threaded replacements
+# this should eventually be moved to modules/archive/init.zsh
+# as a global alias
+if (( $+commands[pigz] )); then
+  _gzip_bin='pigz'
+else
+  _gzip_bin='gzip'
+fi
+
+if (( $+commands[pixz] )); then
+  _xz_bin='pixz'
+else
+  _xz_bin='xz'
+fi
+
+if (( $+commands[lbzip2] )); then
+  _bzip2_bin='lbzip2'
+elif (( $+commands[pbzip2] )); then
+  _bzip2_bin='pbzip2'
+else
+  _bzip2_bin='bzip2'
+fi
+
 while (( $# > 0 )); do
   if [[ ! -s "$1" ]]; then
     print "$0: file not valid: $1" >&2
@@ -42,15 +66,13 @@ while (( $# > 0 )); do
   file_path="${1:A}"
   extract_dir="${file_name:r}"
   case "$1:l" in
-    (*.tar.gz|*.tgz) tar xvzf "$1" ;;
-    (*.tar.bz2|*.tbz|*.tbz2) tar xvjf "$1" ;;
-    (*.tar.xz|*.txz) tar --xz --help &> /dev/null \
-      && tar --xz -xvf "$1" \
-      || xzcat "$1" | tar xvf - ;;
+    (*.tar.gz|*.tgz) tar -xvf "$1" --use-compress-program="${_gzip_bin}" ;;
+    (*.tar.bz2|*.tbz|*.tbz2) tar -xvf "$1" --use-compress-program="${_bzip2_bin}" ;;
+    (*.tar.xz|*.txz) tar -xvf "$1" --use-compress-program="${_xz_bin}" ;;
     (*.tar.zma|*.tlz) tar --lzma --help &> /dev/null \
       && tar --lzma -xvf "$1" \
-      || lzcat "$1" | tar xvf - ;;
-    (*.tar) tar xvf "$1" ;;
+      || lzcat "$1" | tar -xvf - ;;
+    (*.tar) tar -xvf "$1" ;;
     (*.gz) gunzip "$1" ;;
     (*.bz2) bunzip2 "$1" ;;
     (*.xz) unxz "$1" ;;


### PR DESCRIPTION
This adds a few improvements to the way `archive` module works:

1. Support `pixz` as the parallel version of `xz` when creating an archive
1. Support `lbzip2` as a better alternative to `pbzip2` (`lbzip2` works twice as fast in my tests)
1. Make `unarchive` helper also use parallel alternatives, and make it behave exactly the opposite to `archive` helper in terms of how commands are executed.