### PR TITLE
Support custom locations for version management tools

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -7,8 +7,8 @@
 #
 
 # Load manually installed NVM into the shell session.
-if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-  source "$HOME/.nvm/nvm.sh"
+if [[ -s "${NVM_DIR:=$HOME/.nvm}/nvm.sh" ]]; then
+  source "${NVM_DIR}/nvm.sh"
 
 # Load package manager installed NVM into the shell session.
 elif (( $+commands[brew] )) && \
@@ -17,8 +17,8 @@ elif (( $+commands[brew] )) && \
   unset nvm_prefix
 
 # Load manually installed nodenv into the shell session.
-elif [[ -s "$HOME/.nodenv/bin/nodenv" ]]; then
-  path=("$HOME/.nodenv/bin" $path)
+elif [[ -s "${NODENV_ROOT:=$HOME/.nodenv}/bin/nodenv" ]]; then
+  path=("${NODENV_ROOT}/bin" $path)
   eval "$(nodenv init - --no-rehash zsh)"
 
 # Load package manager installed nodenv into the shell session.

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -8,17 +8,12 @@
 #
 
 # Load manually installed pyenv into the path
-if [[ -n "$PYENV_ROOT" && -s "$PYENV_ROOT/bin/pyenv" ]]; then
-  path=("$PYENV_ROOT/bin" $path)
-elif [[ -s "$HOME/.pyenv/bin/pyenv" ]]; then
-  path=("$HOME/.pyenv/bin" $path)
-fi
+if [[ -s "${PYENV_ROOT:=$HOME/.pyenv}/bin/pyenv" ]]; then
+  path=("${PYENV_ROOT}/bin" $path)
+  eval "$(pyenv init - --no-rehash zsh)"
 
 # Load pyenv into the current python session
-if (( $+commands[pyenv] )); then
-  if [[ -z "$PYENV_ROOT" ]]; then
-    export PYENV_ROOT=$(pyenv root)
-  fi
+elif (( $+commands[pyenv] )); then
   eval "$(pyenv init - --no-rehash zsh)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to

--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -15,8 +15,8 @@ if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
   source "$HOME/.rvm/scripts/rvm"
 
 # Load manually installed rbenv into the shell session.
-elif [[ -s "$HOME/.rbenv/bin/rbenv" ]]; then
-  path=("$HOME/.rbenv/bin" $path)
+elif [[ -s "${RBENV_ROOT:=$HOME/.rbenv}/bin/rbenv" ]]; then
+  path=("${RBENV_ROOT}/bin" $path)
   eval "$(rbenv init - --no-rehash zsh)"
 
 # Load package manager installed rbenv into the shell session.


### PR DESCRIPTION
Support more custom locations for version management tools
- `NVM_DIR` for `nvm`
- `NODENV_ROOT` for `nodenv`
- `RBENV_ROOT` for `rbenv`
- `PYENV_ROOT` for `pyenv`

It seems there's no canonical environment for `rvm` yet.