### PR TITLE
Resolves 1641 - Checks whether the prompt uses editor-info (keymap) a…

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -92,27 +92,29 @@ function bindkey-all {
 # array.
 function editor-info {
   # Clean up previous $editor_info.
-  unset editor_info
-  typeset -gA editor_info
+  if zstyle -m ':prezto:module:editor:info:keymap:primary' format '*'; then
+    unset editor_info
+    typeset -gA editor_info
 
-  if [[ "$KEYMAP" == 'vicmd' ]]; then
-    zstyle -s ':prezto:module:editor:info:keymap:alternate' format 'REPLY'
-    editor_info[keymap]="$REPLY"
-  else
-    zstyle -s ':prezto:module:editor:info:keymap:primary' format 'REPLY'
-    editor_info[keymap]="$REPLY"
-
-    if [[ "$ZLE_STATE" == *overwrite* ]]; then
-      zstyle -s ':prezto:module:editor:info:keymap:primary:overwrite' format 'REPLY'
-      editor_info[overwrite]="$REPLY"
+    if [[ "$KEYMAP" == 'vicmd' ]]; then
+      zstyle -s ':prezto:module:editor:info:keymap:alternate' format 'REPLY'
+      editor_info[keymap]="$REPLY"
     else
-      zstyle -s ':prezto:module:editor:info:keymap:primary:insert' format 'REPLY'
-      editor_info[overwrite]="$REPLY"
-    fi
-  fi
+      zstyle -s ':prezto:module:editor:info:keymap:primary' format 'REPLY'
+      editor_info[keymap]="$REPLY"
 
-  unset REPLY
-  zle zle-reset-prompt
+      if [[ "$ZLE_STATE" == *overwrite* ]]; then
+        zstyle -s ':prezto:module:editor:info:keymap:primary:overwrite' format 'REPLY'
+        editor_info[overwrite]="$REPLY"
+      else
+        zstyle -s ':prezto:module:editor:info:keymap:primary:insert' format 'REPLY'
+        editor_info[overwrite]="$REPLY"
+      fi
+    fi
+
+    unset REPLY
+    zle zle-reset-prompt
+  fi
 }
 zle -N editor-info
 

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -130,6 +130,17 @@ function prompt_name_precmd {
 }
 ```
 
+### Keymap
+
+
+One of the defining features of a prompt is having it look different. To take full advantage of the features that prezto provides, you'll need to define at least the primary keymap format. E.g. (from the sorin prompt):
+
+```sh
+zstyle ':prezto:module:editor:info:keymap:primary' format ' %B%F{1}❯%F{3}❯%F{2}❯%f%b'
+```
+
+If you do not do so, then the editor module will not be able to pick up and determine when it should update the prompt.
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Checks whether the prompt uses editor-info (keymap) and an update to the prompt readme to ensure requirements for adding a prompt is clear

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #1641 

## Proposed Changes

  - Check whether or not a prompt has the primary keymap format set before using the editor-info
  - Updates the readme to call out that you need to set a primary keymap to allow for us to actually manage your prompt

## Additional Information

I timed whether using `zstyle -t` with a custom flag over `zstyle -m` with a generic pattern was faster and found that while `zstyle -t` was faster by around double, we were dealing nanoseconds, so it really didn't matter. 

This change allows us to enable prompt developers to utilize our way of doing things, without cluttering up everything else with additional options that need to be set (like I did with the ps-context - it was necessary, but I still hate it). When you're creating a new prompt, you're generally going to create a primary keymap format, so utilizing what we already have makes the most sense.