### PR TITLE
Resolves 1641 - Checks whether the prompt is set to be managed or not.

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -91,28 +91,32 @@ function bindkey-all {
 # Exposes information about the Zsh Line Editor via the $editor_info associative
 # array.
 function editor-info {
-  # Clean up previous $editor_info.
-  unset editor_info
-  typeset -gA editor_info
+  # Ensure that we're going to set the editor-info for prompts that
+  # are prezto managed and/or compatible.
+  if zstyle -t ':prezto:module:prompt' managed; then
+    # Clean up previous $editor_info.
+    unset editor_info
+    typeset -gA editor_info
 
-  if [[ "$KEYMAP" == 'vicmd' ]]; then
-    zstyle -s ':prezto:module:editor:info:keymap:alternate' format 'REPLY'
-    editor_info[keymap]="$REPLY"
-  else
-    zstyle -s ':prezto:module:editor:info:keymap:primary' format 'REPLY'
-    editor_info[keymap]="$REPLY"
-
-    if [[ "$ZLE_STATE" == *overwrite* ]]; then
-      zstyle -s ':prezto:module:editor:info:keymap:primary:overwrite' format 'REPLY'
-      editor_info[overwrite]="$REPLY"
+    if [[ "$KEYMAP" == 'vicmd' ]]; then
+      zstyle -s ':prezto:module:editor:info:keymap:alternate' format 'REPLY'
+      editor_info[keymap]="$REPLY"
     else
-      zstyle -s ':prezto:module:editor:info:keymap:primary:insert' format 'REPLY'
-      editor_info[overwrite]="$REPLY"
-    fi
-  fi
+      zstyle -s ':prezto:module:editor:info:keymap:primary' format 'REPLY'
+      editor_info[keymap]="$REPLY"
 
-  unset REPLY
-  zle zle-reset-prompt
+      if [[ "$ZLE_STATE" == *overwrite* ]]; then
+        zstyle -s ':prezto:module:editor:info:keymap:primary:overwrite' format 'REPLY'
+        editor_info[overwrite]="$REPLY"
+      else
+        zstyle -s ':prezto:module:editor:info:keymap:primary:insert' format 'REPLY'
+        editor_info[overwrite]="$REPLY"
+      fi
+    fi
+
+    unset REPLY
+    zle zle-reset-prompt
+  fi
 }
 zle -N editor-info
 

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -43,6 +43,22 @@ A prompt theme is an autoloadable function file with a special name,
 project, themes **should** be placed in the *modules/prompt/functions*
 directory.
 
+### Required Variables
+
+To ensure that your function works with the editor-info module you'll need to
+set the following variable:
+
+```
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+```
+
+This is to ensure compatibility with outside prompts, while allowing prezto
+and prezto-compatible prompts to take full advantage of the editor module.
+This should be set in the `prompt_name_setup` function after you've added
+any additional hooks with `add-zsh-hook precmd prompt_name_precmd`. See below
+for additional information about functions and hooks.
+
 ### Theme Functions
 
 There are three theme functions, a setup function, a help function, and

--- a/modules/prompt/functions/prompt-pwd
+++ b/modules/prompt/functions/prompt-pwd
@@ -28,3 +28,4 @@ unset current_pwd
 print "$ret_directory"
 
 # }
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_cloud_setup
+++ b/modules/prompt/functions/prompt_cloud_setup
@@ -104,6 +104,9 @@ function prompt_cloud_setup {
   # Add hook for calling git-info before each command.
   add-zsh-hook precmd prompt_cloud_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set git-info parameters.
   zstyle ':prezto:module:git:info' verbose 'yes'
   zstyle ':prezto:module:git:info:dirty' format "%%B%F{$secondary_color}]%f%%b %F{yellow}⚡%f"
@@ -119,3 +122,4 @@ function prompt_cloud_setup {
 }
 
 prompt_cloud_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_damoekri_setup
+++ b/modules/prompt/functions/prompt_damoekri_setup
@@ -40,6 +40,9 @@ function prompt_damoekri_setup {
   # Add hook for calling git-info and ruby-info before each command.
   add-zsh-hook precmd prompt_damoekri_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:keymap:primary' format ' %F{green}»%f'
 
@@ -63,3 +66,4 @@ function prompt_damoekri_setup {
 }
 
 prompt_damoekri_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_giddie_setup
+++ b/modules/prompt/functions/prompt_giddie_setup
@@ -47,6 +47,9 @@ function prompt_giddie_setup {
   # Add hook to set up prompt parameters before each command.
   add-zsh-hook precmd prompt_giddie_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:completing' format '%F{green}...%f'
   zstyle ':prezto:module:editor:info:keymap:alternate' format '%F{yellow}--- COMMAND ---%f'
@@ -74,3 +77,4 @@ function prompt_giddie_setup {
 }
 
 prompt_giddie_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_kylewest_setup
+++ b/modules/prompt/functions/prompt_kylewest_setup
@@ -40,6 +40,9 @@ function prompt_kylewest_setup {
   # Add hook for calling git-info before each command.
   add-zsh-hook precmd prompt_kylewest_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:completing' format '%B%F{red}...%f%b'
   zstyle ':prezto:module:editor:info:keymap:primary' format "%B%F{green}❯%f%b"
@@ -63,3 +66,4 @@ function prompt_kylewest_setup {
 }
 
 prompt_kylewest_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_minimal_setup
+++ b/modules/prompt/functions/prompt_minimal_setup
@@ -32,6 +32,9 @@ function prompt_minimal_setup {
   # Add hook for calling vcs_info before each command.
   add-zsh-hook precmd prompt_minimal_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set vcs_info parameters.
   zstyle ':vcs_info:*' enable bzr git hg svn
   zstyle ':vcs_info:*' check-for-changes true
@@ -57,3 +60,4 @@ function prompt_minimal_preview {
 }
 
 prompt_minimal_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_nicoulaj_setup
+++ b/modules/prompt/functions/prompt_nicoulaj_setup
@@ -35,6 +35,9 @@ function prompt_nicoulaj_setup {
   # Add hook for calling vcs_info before each command.
   add-zsh-hook precmd prompt_nicoulaj_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Customizable parameters.
   local max_path_chars=30
   local user_char='❯'
@@ -58,3 +61,4 @@ function prompt_nicoulaj_setup {
 }
 
 prompt_nicoulaj_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -116,6 +116,9 @@ function prompt_paradox_setup {
   add-zsh-hook preexec prompt_paradox_preexec
   add-zsh-hook precmd prompt_paradox_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:completing' format '%B%F{red}...%f%b'
   zstyle ':prezto:module:editor:info:keymap:primary' format '%B%F{blue}❯%f%b'
@@ -154,3 +157,4 @@ ${(e)$(prompt_paradox_build_prompt)}
 }
 
 prompt_paradox_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_peepcode_setup
+++ b/modules/prompt/functions/prompt_peepcode_setup
@@ -34,6 +34,9 @@ function prompt_peepcode_setup {
   # Add a hook for calling info functions before each command.
   add-zsh-hook precmd prompt_peepcode_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set git-info parameters.
   zstyle ':prezto:module:git:info' verbose 'no'
   zstyle ':prezto:module:git:info:action' format ' +%s'
@@ -83,3 +86,4 @@ function prompt_peepcode_preview {
 }
 
 prompt_peepcode_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_skwp_setup
+++ b/modules/prompt/functions/prompt_skwp_setup
@@ -36,6 +36,9 @@ function prompt_skwp_setup {
   # Add hook to set up prompt parameters before each command.
   add-zsh-hook precmd prompt_skwp_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Use extended color pallete if available.
   if [[ $TERM = *256color* || $TERM = *rxvt* ]]; then
     _prompt_skwp_colors=(
@@ -73,3 +76,4 @@ function prompt_skwp_setup {
 }
 
 prompt_skwp_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_smiley_setup
+++ b/modules/prompt/functions/prompt_smiley_setup
@@ -41,6 +41,9 @@ function prompt_smiley_setup {
   # Add hook for calling git-info before each command.
   add-zsh-hook precmd prompt_smiley_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:completing' format '%B%F{red}...%f%b'
 
@@ -63,3 +66,4 @@ function prompt_smiley_setup {
 }
 
 prompt_smiley_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -118,6 +118,9 @@ function prompt_sorin_setup {
   # Add hook for calling git-info before each command.
   add-zsh-hook precmd prompt_sorin_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Set editor-info parameters.
   zstyle ':prezto:module:editor:info:completing' format '%B%F{7}...%f%b'
   zstyle ':prezto:module:editor:info:keymap:primary' format ' %B%F{1}❯%F{3}❯%F{2}❯%f%b'
@@ -176,3 +179,4 @@ function prompt_sorin_preview {
 }
 
 prompt_sorin_setup "$@"
+# vim: ft=zsh

--- a/modules/prompt/functions/prompt_steeef_setup
+++ b/modules/prompt/functions/prompt_steeef_setup
@@ -41,6 +41,9 @@ function prompt_steeef_setup {
   # Add hook for calling vcs_info before each command.
   add-zsh-hook precmd prompt_steeef_precmd
 
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
+
   # Use extended color pallete if available.
   if [[ $TERM = *256color* || $TERM = *rxvt* ]]; then
     _prompt_steeef_colors=(
@@ -104,3 +107,4 @@ function prompt_steeef_preview {
 }
 
 prompt_steeef_setup "$@"
+# vim: ft=zsh


### PR DESCRIPTION
This is a new variable that will need to be set on all new prompts and
is not backwards compatible with custom prompts that are not prezto
managed, but use prezto's editor-info functionality. Updated the
README.md with additional information for themes.

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #1641 

## Proposed Changes

  - Adds new backwards incompatible flag to use the editor-info
  - Updates the prompt Readme to talk about the required changes 

This will affect prompts that users have created which I don't love but I could not find an elegant way of preserving backwards functionality. I tried using every zstyle option, but this was the best I could come up with. 
