### PR TITLE
Nixos gpg module fix

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -11,9 +11,9 @@ if (( ! $+commands[gpg-agent] )); then
 fi
 
 # Set the default paths to gpg-agent files.
-_gpg_agent_conf="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.conf"
+_gpg_agent_conf="$(gpgconf --list-dir homedir)/gpg-agent.conf"
 _gpg_agent_env="${TMPDIR:-/tmp}/gpg-agent.env.$UID"
-_gpg_agent_socket="$(gpgconf --list-dir | grep "agent-socket:.*" | sed "s/agent-socket://")"
+_gpg_agent_socket="$(gpgconf --list-dir agent-socket)"
 
 # Load environment variables from previous run
 source "$_gpg_agent_env" 2> /dev/null

--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -20,7 +20,7 @@ source "$_gpg_agent_env" 2> /dev/null
 
 
 # Start gpg-agent if not started.
-if [[ -z "$GPG_AGENT_INFO" && ! -S ${_gpg_agent_socket}" ]]; then
+if [[ -z "$GPG_AGENT_INFO" && ! -S "${_gpg_agent_socket}" ]]; then
   # Start gpg-agent if not started.
   if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "^[0-9]* gpg-agent$"; then
     eval "$(gpg-agent --daemon | tee "$_gpg_agent_env")"
@@ -49,7 +49,7 @@ if grep '^enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then
 fi
 
 # Clean up.
-unset _gpg_agent_{conf,env}
+unset _gpg_agent_{conf,env,socket}
 
 # Disable GUI prompts inside SSH.
 if [[ -n "$SSH_CONNECTION" ]]; then

--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -22,7 +22,7 @@ source "$_gpg_agent_env" 2> /dev/null
 # Start gpg-agent if not started.
 if [[ -z "$GPG_AGENT_INFO" && ! -S "${_gpg_agent_socket}" ]]; then
   # Start gpg-agent if not started.
-  if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "^[0-9]* gpg-agent$"; then
+  if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "^ *[0-9]* gpg-agent$"; then
     eval "$(gpg-agent --daemon | tee "$_gpg_agent_env")"
   fi
 fi

--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -13,14 +13,16 @@ fi
 # Set the default paths to gpg-agent files.
 _gpg_agent_conf="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.conf"
 _gpg_agent_env="${TMPDIR:-/tmp}/gpg-agent.env.$UID"
+_gpg_agent_socket="$(gpgconf --list-dir | grep "agent-socket:.*" | sed "s/agent-socket://")"
 
 # Load environment variables from previous run
 source "$_gpg_agent_env" 2> /dev/null
 
+
 # Start gpg-agent if not started.
-if [[ -z "$GPG_AGENT_INFO" && ! -S "${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent" ]]; then
+if [[ -z "$GPG_AGENT_INFO" && ! -S ${_gpg_agent_socket}" ]]; then
   # Start gpg-agent if not started.
-  if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "${${${(s.:.)GPG_AGENT_INFO}[2]}:--1} gpg-agent"; then
+  if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "^[0-9]* gpg-agent$"; then
     eval "$(gpg-agent --daemon | tee "$_gpg_agent_env")"
   fi
 fi

--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -33,7 +33,6 @@ fi
 # Create a persistent SSH authentication socket.
 if [[ -S "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$_ssh_agent_sock" ]]; then
   ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
-  export SSH_AUTH_SOCK="$_ssh_agent_sock"
 fi
 
 # Load identities.


### PR DESCRIPTION
Fixes #1681

Proposed Changes
- gpg module: if-condition ( grep expression and find socket file) in modules/gpg/init.zsh between line 16 to 25.
- remove re-export SSH_AUTH_SOCK in ssh module. Becasue some tools such as pam ssh auth will check socket file permission. A link to this socket is useful but re-export the variable will break some tools.

This pr is the same as #1682 but switching into a new branch(not master).
