### PR TITLE
history: Permit use of previously set HISTFILE

### DIFF
--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -26,7 +26,7 @@ setopt HIST_BEEP                 # Beep when accessing non-existent history.
 # Variables
 #
 
-HISTFILE="${ZDOTDIR:-$HOME}/.zhistory"  # The path to the history file.
+HISTFILE="${HISTFILE:-${ZDOTDIR:-$HOME}/.zhistory}"  # The path to the history file.
 HISTSIZE=10000                   # The maximum number of events to save in the internal history.
 SAVEHIST=10000                   # The maximum number of events to save in the history file.
 


### PR DESCRIPTION
## Proposed Changes

  - Honor the use of the HISTFILE environment variable, if it's already set.
