### PR TITLE
fix directory module docs: it doesn't really set AUTO_NAME_DIRS

### DIFF
--- a/modules/directory/README.md
+++ b/modules/directory/README.md
@@ -12,7 +12,6 @@ Options
   - `PUSHD_SILENT` does not print the directory stack after `pushd` or `popd`.
   - `PUSHD_TO_HOME` pushes to the home directory when no argument is given.
   - `CDABLE_VARS` changes directory to a path stored in a variable.
-  - `AUTO_NAME_DIRS` auto adds variable-stored paths to `~` list.
   - `MULTIOS` writes to multiple descriptors.
   - `EXTENDED_GLOB` uses extended globbing syntax.
   - `CLOBBER` does not overwrite existing files with `>` and `>>`. Use `>!` and


### PR DESCRIPTION
Module `directory` used to set `AUTO_NAME_DIRS`. This was changed in https://github.com/romkatv/prezto/commit/73e94b84bbe9bebfe612438507a53885485938cb but `README.md` hasn't been updated. This looks like an accidental omission that this PR fixes.
