### PR TITLE
Remove _ssh_agent_sock in module ssh

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -16,9 +16,6 @@ _ssh_dir="$HOME/.ssh"
 # Set the path to the environment file if not set by another module.
 _ssh_agent_env="${_ssh_agent_env:-${TMPDIR:-/tmp}/ssh-agent.env.$UID}"
 
-# Set the path to the persistent authentication socket.
-_ssh_agent_sock="${TMPDIR:-/tmp}/ssh-agent.sock.$UID"
-
 # Start ssh-agent if not started.
 if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
   # Export environment variables.
@@ -28,12 +25,6 @@ if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
   if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "${SSH_AGENT_PID:--1} ssh-agent"; then
     eval "$(ssh-agent | sed '/^echo /d' | tee "$_ssh_agent_env")"
   fi
-fi
-
-# Create a persistent SSH authentication socket.
-if [[ -S "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$_ssh_agent_sock" ]]; then
-  ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
-  export SSH_AUTH_SOCK="$_ssh_agent_sock"
 fi
 
 # Load identities.
@@ -57,4 +48,4 @@ if ssh-add -l 2>&1 | grep -q 'The agent has no identities'; then
 fi
 
 # Clean up.
-unset _ssh_{dir,identities} _ssh_agent_{env,sock}
+unset _ssh_{dir,identities} _ssh_agent_env


### PR DESCRIPTION
I'm proposing to remove `_ssh_agent_sock` variable in module ssh:
1. this variable is not used elsewhere, and serves no apparent purpose except making `SSH_AUTH_SOCK` more predictable. But I don't think anyone wants to predict that, as usually ssh sets up everything for you already.
2. this breaks when I recursively ssh onto localhost. For example, I set up ssh-agent on my laptop, and ssh onto `devbox1`, and then `ssh localhost`. It would look like `laptop` -> `devbox1_parent` -> `devbox1_child`.
Now I won't able to run `ssh-add -l` in `devbox1_child`. Because `devbox1_child` is trying to use the auth sock created by `devbox1_parent`, but now both the parent and the child are sharing the same `$SSH_AUTH_SOCK`, and the `ln -sf` line creates a loop out of the supposedly chain of ssh forwarding.

Well, I guess the original intention is for people who keeps long-lived tmux sessions on the remote host. So if you ssh a second time and do `tmux attach`, the ssh auth sock will get refreshed from the stale connection.