### PR TITLE
Remove alias for invalid `brew cleanup --force`

### DIFF
--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -27,7 +27,6 @@ fi
 
 # Homebrew
 alias brewc='brew cleanup'
-alias brewC='brew cleanup --force'
 alias brewi='brew install'
 alias brewl='brew list'
 alias brewo='brew outdated'


### PR DESCRIPTION
## Proposed Changes

  - remove `alias brewC='brew cleanup --force'`

`brew cleanup --force` produces the following error message:

```
❯ brewC              
Usage: brew cleanup [options] [formula|cask]

Remove stale lock files and outdated downloads for all formulae and casks, and
remove old versions of installed formulae. If arguments are specified, only do
this for the given formulae and casks.

        --prune                      Remove all cache files older than specified
                                     days.
    -n, --dry-run                    Show what would be removed, but do not
                                     actually remove anything.
    -s                               Scrub the cache, including downloads for
                                     even the latest versions. Note downloads
                                     for any installed formula or cask will
                                     still not be deleted. If you want to delete
                                     those too: rm -rf "$(brew --cache)"
        --prune-prefix               Only prune the symlinks and directories
                                     from the prefix and remove no other files.
    -v, --verbose                    Make some output more verbose.
    -d, --debug                      Display any debugging information.
    -h, --help                       Show this message.
Error: invalid option: --force
```

I can't seem to find any record of this being a valid option for the cleanup command, so either it was deprecated in the stone age or it was a simple mistake. However, there is a `--force` option available for `brew uninstall`, but that's a dicey thing to alias.