### PR TITLE
Allow mapping Ctrl+S and Ctrl+Q shortcuts

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -38,7 +38,8 @@ setopt INTERACTIVE_COMMENTS # Enable comments in interactive shell.
 setopt RC_QUOTES            # Allow 'Henry''s Garage' instead of 'Henry'\''s Garage'.
 unsetopt MAIL_WARNING       # Don't print a warning message if a mail file has been accessed.
 
-stty -ixon                  # Allow mapping Ctrl+S and Ctrl+Q shortcuts
+# Allow mapping Ctrl+S and Ctrl+Q shortcuts
+(( $+commands[stty] )) && stty -ixon
 
 #
 # Jobs

--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -38,6 +38,8 @@ setopt INTERACTIVE_COMMENTS # Enable comments in interactive shell.
 setopt RC_QUOTES            # Allow 'Henry''s Garage' instead of 'Henry'\''s Garage'.
 unsetopt MAIL_WARNING       # Don't print a warning message if a mail file has been accessed.
 
+stty -ixon                  # Allow mapping Ctrl+S and Ctrl+Q shortcuts
+
 #
 # Jobs
 #


### PR DESCRIPTION
Hi @belak, please treat this as a question and a proposal 🙂 

While looking at [this PR](https://github.com/jhawthorn/fzy/pull/124) I learned that `Ctrl+S` and `Ctrl+Q` are by default now allowed to be used by other apps.

Why don't we allow this by default? Is there a drawback in doing so?