### PR TITLE
fix(alias): ls alias lx is an illegal option on darwin bsd style ls

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -118,12 +118,16 @@ alias ll='ls -lh'        # Lists human readable sizes.
 alias lr='ll -R'         # Lists human readable sizes, recursively.
 alias la='ll -A'         # Lists human readable sizes, hidden files.
 alias lm='la | "$PAGER"' # Lists human readable sizes, hidden files through pager.
-alias lx='ll -XB'        # Lists sorted by extension (GNU only).
 alias lk='ll -Sr'        # Lists sorted by size, largest last.
 alias lt='ll -tr'        # Lists sorted by date, most recent last.
 alias lc='lt -c'         # Lists sorted by date, most recent last, shows change time.
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
 alias sl='ls'            # I often screw this up.
+
+# Only make alias if ls supports -XB (darwins BSD style ls doesn't)
+if ls -XB &> /dev/null; then
+  alias lx='ll -XB'        # Lists sorted by extension (GNU only).
+fi
 
 # Grep
 if zstyle -t ':prezto:module:utility:grep' color; then


### PR DESCRIPTION
### Fixes illegal option `-X` on MacOS

The option `-X` gets MacOS' `ls` (and probably also other BSD-ish OS) to complain about an illegal option:

```sh
user@host ~ $ ls -lhXB
ls: illegal option -- X
usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]
```

### Proposed Changes

  - only define the alias `lx` with option `-X` on machines that are not Darwin

I would also exclude other BSD like OS but since I do not have such a host at hand I cannot verify if that is even really needed for them.
