### PR TITLE
Add module nvm-auto-use

### DIFF
--- a/modules/nvm-auto-use/README.md
+++ b/modules/nvm-auto-use/README.md
@@ -1,0 +1,16 @@
+`nvm` Auto Use
+==============
+
+This module integrates [`nvm` auto use][1] shell integration into Prezto. It will automatically call `nvm use` in a directory with a .nvmrc file. This recipe is **not** supported by the `nvm` development team, but they are accepting pull requests for more examples.
+
+This module must be loaded **after** the [node](../node) module.
+
+Author
+------
+
+*The author of this module should be contacted via the [issue tracker][2].*
+
+- [Jared Manning](https://github.com/lambdanerd)
+
+[1]: https://github.com/nvm-sh/nvm#zsh
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/nvm-auto-use/init.zsh
+++ b/modules/nvm-auto-use/init.zsh
@@ -1,5 +1,5 @@
 #
-# Integrates history-substring-search into Prezto.
+# Integrates `nvm` auto use shell integration into Prezto.
 #
 # Author:
 #   Jared Manning <hello.lambda.nerd@gmail.com>

--- a/modules/nvm-auto-use/init.zsh
+++ b/modules/nvm-auto-use/init.zsh
@@ -1,0 +1,27 @@
+#
+# Integrates history-substring-search into Prezto.
+#
+# Author:
+#   Jared Manning <hello.lambda.nerd@gmail.com>
+#
+
+autoload -U add-zsh-hook
+load-nvmrc() {
+  local node_version="$(nvm version)"
+  local nvmrc_path="$(nvm_find_nvmrc)"
+
+  if [ -n "$nvmrc_path" ]; then
+    local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+    if [ "$nvmrc_node_version" = "N/A" ]; then
+      nvm install
+    elif [ "$nvmrc_node_version" != "$node_version" ]; then
+      nvm use
+    fi
+  elif [ "$node_version" != "$(nvm version default)" ]; then
+    echo "Reverting to nvm default version"
+    nvm use default
+  fi
+}
+add-zsh-hook chpwd load-nvmrc
+load-nvmrc


### PR DESCRIPTION
`nvm` Auto Use
==============

This module integrates [`nvm` auto use](https://github.com/nvm-sh/nvm#zsh) shell integration into Prezto. It will automatically call `nvm use` in a directory with a .nvmrc file. This recipe is **not** supported by the `nvm` development team, but they are accepting pull requests for more examples.

<img width="682" alt="Screen Shot 2019-11-03 at 4 04 37 PM" src="https://user-images.githubusercontent.com/36175659/68092875-55670180-fe55-11e9-8cf2-88150ed34bb0.png">
<img width="682" alt="Screen Shot 2019-11-03 at 4 05 30 PM" src="https://user-images.githubusercontent.com/36175659/68092876-55670180-fe55-11e9-9bfd-076ac4af6e76.png">
