### PR TITLE
apply `stty -ixon` only to tty

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -39,7 +39,7 @@ setopt RC_QUOTES            # Allow 'Henry''s Garage' instead of 'Henry'\''s Gar
 unsetopt MAIL_WARNING       # Don't print a warning message if a mail file has been accessed.
 
 # Allow mapping Ctrl+S and Ctrl+Q shortcuts
-(( $+commands[stty] )) && stty -ixon
+[[ -n ${TTY:-} && $+commands[stty] == 1 ]] && stty -ixon <$TTY >$TTY
 
 #
 # Jobs


### PR DESCRIPTION
Currently, prezto may call `stty -ixon` when stdin and/or stdout are not connected to a tty. This results in an error:

```text
stty: 'standard input': Inappropriate ioctl for device
```

This PR fixes it by explicitly redirecting `stty` to `$TTY`. `TTY` is a special parameter set by zsh. It points to the tty (if there is one) even if stdin and/or stdout are redirected.

I should also note that the comment above `stty -ixon` is a bit misleading:

```zsh
# Allow mapping Ctrl+S and Ctrl+Q shortcuts
```

`stty -ixon` disables Ctrl+S and Ctrl+Q terminal shortcuts which stop and resume terminal output respectively. It does allow you to bind these keys to zle widgets as a side effect. This is not a requirement, though. These same keys can be bound if `flow_control` option is unset. This option disables the default Ctrl+S and Ctrl+Q behavior only within zle without affecting everything else that you might run in the terminal.

My preferred setup is to **not* call `stty -ixon` (so that I can pause/resume console output when something is spewing out diagnostic messages very fast) and to unset `flow_control` (because freezing zle is never desired and being able to bind Ctrl+S and Ctrl+Q is nice).

Note that prezto unsets `flow_control` in `modules/completion/init.zsh`.