### PR TITLE
don't raise an error in zlogin when stderr is not a TTY

### DIFF
--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -15,7 +15,7 @@
 } &!
 
 # Execute code only if STDERR is bound to a TTY.
-[[ -o INTERACTIVE && -t 2 ]] && {
+if [[ -o INTERACTIVE && -t 2 ]]; then
 
   # Print a random, hopefully interesting, adage.
   if (( $+commands[fortune] )); then
@@ -23,4 +23,4 @@
     print
   fi
 
-} >&2
+fi >&2


### PR DESCRIPTION
The existing code in runcoms/zlogin results in `$?` being equal to `1` when starting a login shell if stderr is not a TTY. For example:

```zsh
zsh -l 2>/dev/null
```

When using a theme that displays error/success status of the last command, the first prompt will show an error.

This commit fixes it so that error code is zero after sourcing zlogin (unless something unexpected and bad happens).