### PR TITLE
Allow module functions directory to be a symlink

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -109,7 +109,7 @@ function pmodload {
       pmodule_location=${locations[1]}
 
       # Add functions to $fpath.
-      fpath=(${pmodule_location}/functions(/FN) $fpath)
+      fpath=(${pmodule_location}/functions(-/FN) $fpath)
 
       function {
         local pfunction


### PR DESCRIPTION
I am converting the [nix-zsh-completions](https://github.com/spwhitt/nix-zsh-completions) plugin to a module. It comes with completions. It makes sense to link the `functions` directory into `external`, otherwise I would have to create individual symlinks. (There are about 20.)

## Proposed Changes

Replace the expansion that locates the functions directory from  `functions(/FN)` to `functions(-/FN)`, so it matche symlinks to directories.