### PR TITLE
Support pmodule-allow-overrides feature

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -98,10 +98,7 @@ function pmodload {
     else
       locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(-/FN)})
       if (( ${#locations} > 1 )); then
-        if zstyle -t ':prezto:load' pmodule-allow-overrides 'yes'; then
-          # Use the final location as an override when there are module name conflicts
-          locations=($locations[-1])
-        else
+        if ! zstyle -t ':prezto:load' pmodule-allow-overrides 'yes'; then
           print "$0: conflicting module locations: $locations"
           continue
         fi
@@ -111,7 +108,7 @@ function pmodload {
       fi
 
       # Grab the full path to this module
-      pmodule_location=${locations[1]}
+      pmodule_location=${locations[-1]}
 
       # Add functions to $fpath.
       fpath=(${pmodule_location}/functions(/FN) $fpath)

--- a/init.zsh
+++ b/init.zsh
@@ -98,8 +98,13 @@ function pmodload {
     else
       locations=(${pmodule_dirs:+${^pmodule_dirs}/$pmodule(-/FN)})
       if (( ${#locations} > 1 )); then
-        print "$0: conflicting module locations: $locations"
-        continue
+        if zstyle -t ':prezto:load' pmodule-allow-overrides 'yes'; then
+          # Use the final location as an override when there are module name conflicts
+          locations=($locations[-1])
+        else
+          print "$0: conflicting module locations: $locations"
+          continue
+        fi
       elif (( ${#locations} < 1 )); then
         print "$0: no such module: $pmodule"
         continue

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -18,6 +18,9 @@ zstyle ':prezto:*:*' color 'yes'
 # Add additional directories to load prezto modules from
 # zstyle ':prezto:load' pmodule-dirs $HOME/.zprezto-contrib
 
+# Allow module overrides when pmodule-dirs causes module name collisions
+# zstyle ':prezto:load' pmodule-allow-overrides 'yes'
+
 # Set the Zsh modules to load (man zshmodules).
 # zstyle ':prezto:load' zmodule 'attr' 'stat'
 


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #1779

## Proposed Changes
 
 - Adds a new optional zstyle setting (defaulted to 'no' or not-existing): `zstyle ':prezto:load' pmodule-allow-overrides`
  - Adds support in init.zsh for overriding modules with the same name based on whether `zstyle ':prezto:load' pmodule-allow-overrides 'yes'` is set in .zpreztorc
