### PR TITLE
attempt to unbreak the TTY check

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -39,7 +39,7 @@ setopt RC_QUOTES            # Allow 'Henry''s Garage' instead of 'Henry'\''s Gar
 unsetopt MAIL_WARNING       # Don't print a warning message if a mail file has been accessed.
 
 # Allow mapping Ctrl+S and Ctrl+Q shortcuts
-[[ -n ${TTY:-} && $+commands[stty] == 1 ]] && stty -ixon <$TTY >$TTY
+[[ -r ${TTY:-} && -w ${TTY:-} && $+commands[stty] == 1 ]] && stty -ixon <$TTY >$TTY
 
 #
 # Jobs


### PR DESCRIPTION
Bug report from @qosmio: https://github.com/sorin-ionescu/prezto/pull/1771#issuecomment-575596417.

I'm unable to reproduce it and @qosmio hasn't yet confirmed or disconfirmed whether this fix works. It's a good idea to change the code this way in either case.

(As I mentioned in #1771, this `stty -ixon` call may have been added by mistake. It doesn't do what the comment suggest and is at least as likely to be harming users as helping them.)