### PR TITLE
feat(helper): add os-type helper functions

### DIFF
--- a/modules/haskell/init.zsh
+++ b/modules/haskell/init.zsh
@@ -11,7 +11,7 @@ if (( ! $+commands[ghc] )); then
 fi
 
 # Prepend Cabal per user directories to PATH.
-if [[ "$OSTYPE" == darwin* && -d $HOME/Library/Haskell ]]; then
+if is-darwin && [[  -d $HOME/Library/Haskell ]]; then
   path=($HOME/Library/Haskell/bin(/N) $path)
 else
   path=($HOME/.cabal/bin(/N) $path)

--- a/modules/helper/init.zsh
+++ b/modules/helper/init.zsh
@@ -29,3 +29,23 @@ function coalesce {
   done
   return 1
 }
+
+# is true on MacOS Darwin
+function is-darwin {
+  [[ "$OSTYPE" == darwin* ]]
+}
+
+# is true on Linux's
+function is-linux {
+  [[ "$OSTYPE" == linux* ]]
+}
+
+# is true on BSD's
+function is-bsd {
+  [[ "$OSTYPE" == *bsd* ]]
+}
+
+# is true on Cygwin (Windows)
+function is-cygwin {
+  [[ "$OSTYPE" == cygwin* ]]
+}

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$OSTYPE" != (darwin|linux)* ]]; then
+if ! is-darwin || ! is-linux; then
   return 1
 fi
 

--- a/modules/macports/init.zsh
+++ b/modules/macports/init.zsh
@@ -7,7 +7,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$OSTYPE" != darwin* ]]; then
+if ! is-darwin; then
   return 1
 fi
 

--- a/modules/osx/init.zsh
+++ b/modules/osx/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$OSTYPE" != darwin* ]]; then
+if ! is-darwin; then
   return 1
 fi
 

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -37,7 +37,7 @@ fi
 # Local Module Installation
 #
 
-if [[ "$OSTYPE" == darwin* ]]; then
+if is-darwin; then
   # Perl is slow; cache its output.
   cache_file="${TMPDIR:-/tmp}/prezto-perl-cache.$UID.zsh"
   perl_path="$HOME/Library/Perl/5.12"

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -22,7 +22,7 @@ elif (( $+commands[pyenv] )); then
 else
   if [[ -n "$PYTHONUSERBASE" ]]; then
     path=($PYTHONUSERBASE/bin $path)
-  elif [[ "$OSTYPE" == darwin* ]]; then
+  elif is-darwin; then
     path=($HOME/Library/Python/*/bin(N) $path)
   else
     # This is subject to change.

--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -23,7 +23,7 @@ fi
 
 # macOS and HFS+ Enhancements
 # https://bombich.com/kb/ccc5/credits
-if [[ "$OSTYPE" == darwin* ]] && grep -q 'file-flags' <(rsync --help 2>&1); then
+if is-darwin && grep -q 'file-flags' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --protect-decmpfs --force-change"
 fi
 

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -134,9 +134,9 @@ if zstyle -t ':prezto:module:utility:grep' color; then
 fi
 
 # macOS Everywhere
-if [[ "$OSTYPE" == darwin* ]]; then
+if is-darwin; then
   alias o='open'
-elif [[ "$OSTYPE" == cygwin* ]]; then
+elif is-cygwin; then
   alias o='cygstart'
   alias pbcopy='tee > /dev/clipboard'
   alias pbpaste='cat /dev/clipboard'
@@ -166,7 +166,7 @@ fi
 alias df='df -kh'
 alias du='du -kh'
 
-if [[ "$OSTYPE" == (darwin*|*bsd*) ]]; then
+if is-darwin || is-bsd; then
   alias topc='top -o cpu'
   alias topm='top -o vsize'
 else


### PR DESCRIPTION
## Add `$OSTYPE` functions

Add the following functions checking for the `$OSTYPE`:

- is-bsd
- is-cygwin
- is-darwin
- is-linux

And apply them everywhere in prezto I found code doing that.

Everywhere but in [zprofile](runcoms/zprofile), because I presume zprofile will not have helpers available.  
Is that correct?

## Reasons

1. I personally find functions like this just more readable in code.
1. If a test for OSTYPE xy proves to not cover some edge case one day, there will be only one place to fix it.
1. I just use Prezto for quite some time, and if I want to start contributing, I ought to be with small helper utilities like these.

## Questions

1. I'm not sure if that kind of thing is wanted in prezto?
1. Is [helper](modules/helper/init.zsh) the right place for this?
1. Will [helper](modules/helper/init.zsh) be available to all those places I applied my helpers? (will it work there)