### PR TITLE
use $TTY instead of $(tty); it's faster and more reliable

### DIFF
--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -26,7 +26,7 @@ if [[ -z "$GPG_AGENT_INFO" && ! -S "${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent" ]]; 
 fi
 
 # Inform gpg-agent of the current TTY for user prompts.
-export GPG_TTY="$(tty)"
+export GPG_TTY=$TTY
 
 # Integrate with the SSH module.
 if grep '^enable-ssh-support' "$_gpg_agent_conf" &> /dev/null; then


### PR DESCRIPTION
`tty` command infers the current TTY from file descriptor 0. `$TTY` gives current TTY directly. The latter works even when file descriptor 0 is redirected. It's also over 1000 times faster.