### PR TITLE
Fix `pyenv: pip2: command not found` error when using pyenv

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -149,6 +149,10 @@ if (( $#commands[(i)pip(|[23])] )); then
 
   # Detect and use one available from among 'pip', 'pip2', 'pip3' variants
   pip_command="$commands[(i)pip(|[23])]"
+  # If the pip_command is a pyenv shim then ask pyenv for actual location
+  if [[ $+commands[pyenv] && "$pip_command" == *shims/pip* ]]; then
+    pip_command="$(pyenv which "${pip_command:t}" 2>/dev/null)"
+  fi
 
   if [[ "$pip_command" -nt "$cache_file" \
         || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \


### PR DESCRIPTION
When using the `python` module with pyenv, the pip autocompletion logic
blurts out following error (or something similar to it):

```
❯ #Ignore the warning from p10k's instant prompt feature

[WARNING]: Console output during zsh initialization detected.
...<snip>...
For details, see:
https://github.com/romkatv/powerlevel10k/blob/master/README.md#instant-prompt

-- console output produced during zsh initialization follows --

pyenv: pip2: command not found

The `pip2' command exists in these Python versions:
  2.7.17
  2.7.17/envs/neovim-2.7.17
  neovim-2.7.17
```

Currently, python-2.7.17 is installed but not set globally. A similar
error would occur if python-3 is installed but no system pip is installed
(which is the default case on macOS).

The issue arises in the pip completion logic where pyenv provides a path
to the pip shim in `$commands` array and can't figure out which pip to
use while generating the completion file for caching.

This commit fixes this error at startup by setting the `pip_command`
variable to actual location as determined by pyenv in case pyenv is in
use and the `pip_command` variable points to a shim.