### PR TITLE
Add fixes for #1795 (prompt_sorin)

### DIFF
--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -54,6 +54,13 @@ function prompt_sorin_async_callback {
         zle && zle reset-prompt
       fi
       ;;
+    "[async]")
+      # If something happend to the worker, prompt_sorin_async_callback will be
+      # called one last time. In this case, we look out for `hup` or `err` and
+      # restart the worker
+      [[ $5 = *'returned error hup'* ]] || [[ $5 = *'returned error err'* ]] \
+        && prompt_sorin_initialize_worker
+      ;;
   esac
 }
 
@@ -65,14 +72,28 @@ function prompt_sorin_async_git {
   fi
 }
 
+function prompt_sorin_initialize_worker {
+  # This function is idempotent - see comments below
+
+  # It is ok to call async_start_worker many times, since async.zsh ensures that no
+  # such worker exists before proceeding
+  async_start_worker prompt_sorin -n
+
+  # It is ok to call async_register_callback many times. In version
+  # 1.7.2 of async.zsh, all actions in async_register_callback are idempotent
+  # (setting ASYNC_CALLBACKS, trap)
+  async_register_callback prompt_sorin prompt_sorin_async_callback
+}
+
 function prompt_sorin_async_tasks {
   # Initialize async worker. This needs to be done here and not in
   # prompt_sorin_setup so the git formatting can be overridden by other prompts.
-  if (( !${prompt_prezto_async_init:-0} )); then
-    async_start_worker prompt_sorin -n
-    async_register_callback prompt_sorin prompt_sorin_async_callback
-    typeset -g prompt_prezto_async_init=1
-  fi
+
+  # Need to try and start workers all the time, in case something happened to
+  # the worker and it dies.
+  # If it dies, async_job will fail with "no such pty command: prompt_sorin"
+  # (See https://github.com/sorin-ionescu/prezto/issues/1736)
+  prompt_sorin_initialize_worker
 
   # Kill the old process of slow commands if it is still running.
   async_flush_jobs prompt_sorin

--- a/modules/prompt/functions/prompt_sorin_setup
+++ b/modules/prompt/functions/prompt_sorin_setup
@@ -55,11 +55,11 @@ function prompt_sorin_async_callback {
       fi
       ;;
     "[async]")
-      # If something happend to the worker, prompt_sorin_async_callback will be
-      # called one last time. In this case, we look out for `hup` or `err` and
-      # restart the worker
-      [[ $5 = *'returned error hup'* ]] || [[ $5 = *'returned error err'* ]] \
-        && prompt_sorin_initialize_worker
+      # Code is 1 for corrupted worker output and 2 for dead worker.
+      if [[ $2 -eq 2 ]]; then
+	  # Our worker died unexpectedly.
+          typeset -g prompt_prezto_async_init=0
+      fi
       ;;
   esac
 }
@@ -72,28 +72,14 @@ function prompt_sorin_async_git {
   fi
 }
 
-function prompt_sorin_initialize_worker {
-  # This function is idempotent - see comments below
-
-  # It is ok to call async_start_worker many times, since async.zsh ensures that no
-  # such worker exists before proceeding
-  async_start_worker prompt_sorin -n
-
-  # It is ok to call async_register_callback many times. In version
-  # 1.7.2 of async.zsh, all actions in async_register_callback are idempotent
-  # (setting ASYNC_CALLBACKS, trap)
-  async_register_callback prompt_sorin prompt_sorin_async_callback
-}
-
 function prompt_sorin_async_tasks {
   # Initialize async worker. This needs to be done here and not in
   # prompt_sorin_setup so the git formatting can be overridden by other prompts.
-
-  # Need to try and start workers all the time, in case something happened to
-  # the worker and it dies.
-  # If it dies, async_job will fail with "no such pty command: prompt_sorin"
-  # (See https://github.com/sorin-ionescu/prezto/issues/1736)
-  prompt_sorin_initialize_worker
+  if (( !${prompt_prezto_async_init:-0} )); then
+    async_start_worker prompt_sorin -n
+    async_register_callback prompt_sorin prompt_sorin_async_callback
+    typeset -g prompt_prezto_async_init=1
+  fi
 
   # Kill the old process of slow commands if it is still running.
   async_flush_jobs prompt_sorin


### PR DESCRIPTION
Fixes #1795 

A similar fix will work for #1723 

The issue here is that when the async worker dies for whatever reason, `prompt_sorin_async_tasks` doesn't know about it and calls `async_job` on a worker that is not existent.

Between zsh-async v1.1.0 and v1.7.0, the change that made this difference is that in the newest version v1.7.2, zsh-async (I believe, correctly) checks for an error message (`hup`, `nval` or `err`) and stops the worker. In v1.1.0, it did not stop the worker, so `_async_zle_watcher` ends up calling `async_process_results` many, many times in an infinite loop, causing zsh to take up 100% CPU.

## Proposed Changes

  - Reinitialize the worker on the last callback from `_async_zle_watcher`
  - Also always start the worker in `prompt_sorin_async_tasks` (Initializing the worker is handled idempotently by zsh-async)
