### PR TITLE
fix several missing dependencies on the helper module

### DIFF
--- a/modules/haskell/init.zsh
+++ b/modules/haskell/init.zsh
@@ -10,6 +10,9 @@ if (( ! $+commands[ghc] )); then
   return 1
 fi
 
+# Load dependencies.
+pmodload 'helper'
+
 # Prepend Cabal per user directories to PATH.
 if is-darwin && [[  -d $HOME/Library/Haskell ]]; then
   path=($HOME/Library/Haskell/bin(/N) $path)

--- a/modules/macports/init.zsh
+++ b/modules/macports/init.zsh
@@ -6,6 +6,9 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# Load dependencies.
+pmodload 'helper'
+
 # Return if requirements are not found.
 if ! is-darwin; then
   return 1

--- a/modules/osx/init.zsh
+++ b/modules/osx/init.zsh
@@ -5,6 +5,9 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# Load dependencies.
+pmodload 'helper'
+
 # Return if requirements are not found.
 if ! is-darwin; then
   return 1

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -10,6 +10,9 @@ if (( ! $+commands[perl] )); then
   return 1
 fi
 
+# Load dependencies.
+pmodload 'helper'
+
 #
 # Load Perlbrew or plenv
 #

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -7,6 +7,9 @@
 #   Patrick Bos <egpbos@gmail.com>
 #
 
+# Load dependencies
+pmodload 'helper'
+
 # Load manually installed pyenv into the path
 if [[ -s "${PYENV_ROOT:=$HOME/.pyenv}/bin/pyenv" ]]; then
   path=("${PYENV_ROOT}/bin" $path)

--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -10,6 +10,9 @@ if (( ! $+commands[rsync] )); then
   return 1
 fi
 
+# Load dependencies.
+pmodload 'helper'
+
 #
 # Aliases
 #


### PR DESCRIPTION
## Fixes several missing dependencies on `helper` module

Fixes #1812 

#1793 added the `is-darwin`, `is-linux`, `is-bsd`, `is-cygwin` functions to the `helper` module and referenced them in a few modules. However, these modules don't appear to declare a dependency on the `helper` module, so you may end up getting a 'command not found error' at module load for one of the above functions.

```
/home/char8/.zprezto/modules/python/init.zsh:25: command not found: is-darwin
```

I tried to work out if `helper` wasn't being loaded because I was missing a specific module load order. But looking at the `git` and `utility`  modules it appears that it needs to be specified as a dependency by the module?

I've only tested this fix to work when loading the `python` and `homebrew` modules.

## Proposed Changes
  - add `pmodload 'helper'` declarations to modules that were missing them
