### PR TITLE
don't dowload whole history of powerlevel9k and powerlevel10k submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,8 @@
 [submodule "modules/prompt/external/powerlevel9k"]
 	path = modules/prompt/external/powerlevel9k
 	url = https://github.com/bhilburn/powerlevel9k.git
+	shallow = true
 [submodule "modules/prompt/external/powerlevel10k"]
 	path = modules/prompt/external/powerlevel10k
 	url = https://github.com/romkatv/powerlevel10k.git
+	shallow = true


### PR DESCRIPTION
Cloning prezto's submodules takes considerable amount of time. This is especially noticeable when setting up environment on remote host over SSH with slow connection. Moreover it's really annoying as you realize that time spent for stuff that you never use.
With this PR git will fetch only required shallow commit, as described [here](https://stackoverflow.com/questions/30129920/git-submodule-without-extra-weight/38895397#38895397), thus saving time over SSH with slow connection.
I selected only `powerlevel` submodules because they're pretty fat.