### PR TITLE
homebrew: load helper dependency

### DIFF
--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -5,6 +5,9 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
+# Load dependencies.
+pmodload 'helper'
+
 # Return if requirements are not found.
 if ! is-darwin && ! is-linux; then
   return 1


### PR DESCRIPTION
f4ca9ebfc913453f98ba6912a8c42684fd742cc1 introduced the `is-darwin` and `is-linux` helpers, but called them without first loading the module.

Updates #1815
