### PR TITLE
Matching submodule name with path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 [submodule "modules/prompt/external/agnoster"]
 	path = modules/prompt/external/agnoster
 	url = https://github.com/agnoster/agnoster-zsh-theme.git
-[submodule "modules/prompt/functions/pure"]
+[submodule "modules/prompt/external/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
 [submodule "modules/fasd/external"]


### PR DESCRIPTION
`pure` submodule name doesn't match its path in `.gitmodules`

`gSx` alias (`git-submodule-remove`) fails due to this unusual configuration.

## Proposed Changes

  - Rename submodule to match its path as all others
