### PR TITLE
Make .zcomp* location configurable

### DIFF
--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -21,7 +21,7 @@ elif (( $+commands[brew] )); then
     "$(brew --repository 2> /dev/null)"/Library/Taps/*/*/cmd/brew-command-not-found-init(|.rb)(.N)
   )
   if (( $#cnf_command )); then
-    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-brew-command-not-found-cache.zsh"
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/brew-command-not-found-cache.zsh"
 
     if [[ "${${(@o)cnf_command}[1]}" -nt "$cache_file" \
           || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \

--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -21,11 +21,12 @@ elif (( $+commands[brew] )); then
     "$(brew --repository 2> /dev/null)"/Library/Taps/*/*/cmd/brew-command-not-found-init(|.rb)(.N)
   )
   if (( $#cnf_command )); then
-    cache_file="${TMPDIR:-/tmp}/prezto-brew-command-not-found-cache.$UID.zsh"
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-brew-command-not-found-cache.zsh"
 
     if [[ "${${(@o)cnf_command}[1]}" -nt "$cache_file" \
           || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
           || ! -s "$cache_file" ]]; then
+      mkdir -p "$cache_file:h"
       # brew command-not-found-init is slow; cache its output.
       brew command-not-found-init >! "$cache_file" 2> /dev/null
     fi

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -33,15 +33,15 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 # shell is opened each day.
 autoload -Uz compinit
 _comp_path="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
-_comp_files=($_comp_path(Nm-20))
-if (( $#_comp_files )); then
+# #q expands globs in conditional expressions
+if [[ $_comp_path(#qNmh-20) ]]; then
   # -C (skip function check) implies -i (skip security check).
   compinit -C -d "$_comp_path"
 else
   mkdir -p "$_comp_path:h"
   compinit -i -d "$_comp_path"
 fi
-unset _comp_path _comp_files
+unset _comp_path
 
 #
 # Styles

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -32,8 +32,7 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 # cache time of 20 hours, so it should almost always regenerate the first time a
 # shell is opened each day.
 autoload -Uz compinit
-# Respect XDG_CACHE_HOME if set, otherwise use zsh default.
-_comp_path="${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompdump}:-${ZDOTDIR:-$HOME}/.zcompdump}"
+_comp_path="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
 _comp_files=($_comp_path(Nm-20))
 if (( $#_comp_files )); then
   # -C (skip function check) implies -i (skip security check).
@@ -50,8 +49,7 @@ unset _comp_path _comp_files
 
 # Use caching to make completion for commands such as dpkg and apt usable.
 zstyle ':completion::complete:*' use-cache on
-# Respect XDG_CACHE_HOME if set, otherwise use zsh default.
-zstyle ':completion::complete:*' cache-path "${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompcache}:-${ZDOTDIR:-$HOME}/.zcompcache}"
+zstyle ':completion::complete:*' cache-path "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompcache"
 
 # Case-insensitive (all), partial-word, and then substring completion.
 if zstyle -t ':prezto:module:completion:*' case-sensitive; then

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -32,13 +32,17 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 # cache time of 20 hours, so it should almost always regenerate the first time a
 # shell is opened each day.
 autoload -Uz compinit
-_comp_files=(${ZDOTDIR:-$HOME}/.zcompdump(Nm-20))
+# Respect XDG_CACHE_HOME if set, otherwise use zsh default.
+_comp_path="${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompdump}:-${ZDOTDIR:-$HOME}/.zcompdump}"
+_comp_files=($_comp_path(Nm-20))
 if (( $#_comp_files )); then
-  compinit -i -C
+  # -C (skip function check) implies -i (skip security check).
+  compinit -C -d "$_comp_path"
 else
-  compinit -i
+  mkdir -p "$_comp_path:h"
+  compinit -i -d "$_comp_path"
 fi
-unset _comp_files
+unset _comp_path _comp_files
 
 #
 # Styles
@@ -46,7 +50,8 @@ unset _comp_files
 
 # Use caching to make completion for commands such as dpkg and apt usable.
 zstyle ':completion::complete:*' use-cache on
-zstyle ':completion::complete:*' cache-path "${ZDOTDIR:-$HOME}/.zcompcache"
+# Respect XDG_CACHE_HOME if set, otherwise use zsh default.
+zstyle ':completion::complete:*' cache-path "${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompcache}:-${ZDOTDIR:-$HOME}/.zcompcache}"
 
 # Case-insensitive (all), partial-word, and then substring completion.
 if zstyle -t ':prezto:module:completion:*' case-sensitive; then

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -32,7 +32,7 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 # cache time of 20 hours, so it should almost always regenerate the first time a
 # shell is opened each day.
 autoload -Uz compinit
-_comp_path="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
+_comp_path="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/zcompdump"
 # #q expands globs in conditional expressions
 if [[ $_comp_path(#qNmh-20) ]]; then
   # -C (skip function check) implies -i (skip security check).
@@ -49,7 +49,7 @@ unset _comp_path
 
 # Use caching to make completion for commands such as dpkg and apt usable.
 zstyle ':completion::complete:*' use-cache on
-zstyle ':completion::complete:*' cache-path "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompcache"
+zstyle ':completion::complete:*' cache-path "${XDG_CACHE_HOME:-$HOME/.cache}/prezto/zcompcache"
 
 # Case-insensitive (all), partial-word, and then substring completion.
 if zstyle -t ':prezto:module:completion:*' case-sensitive; then

--- a/modules/fasd/init.zsh
+++ b/modules/fasd/init.zsh
@@ -19,7 +19,7 @@ fi
 # Initialization
 #
 
-cache_file="${TMPDIR:-/tmp}/prezto-fasd-cache.$UID.zsh"
+cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-fasd-cache.zsh"
 if [[ "${commands[fasd]}" -nt "$cache_file" \
       || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
       || ! -s "$cache_file"  ]]; then
@@ -31,6 +31,7 @@ if [[ "${commands[fasd]}" -nt "$cache_file" \
     init_args+=(zsh-ccomp zsh-ccomp-install zsh-wcomp zsh-wcomp-install)
   fi
 
+  mkdir -p "$cache_file:h"
   # Cache init code.
   fasd --init "$init_args[@]" >! "$cache_file" 2> /dev/null
 fi

--- a/modules/fasd/init.zsh
+++ b/modules/fasd/init.zsh
@@ -19,7 +19,7 @@ fi
 # Initialization
 #
 
-cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-fasd-cache.zsh"
+cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/fasd-cache.zsh"
 if [[ "${commands[fasd]}" -nt "$cache_file" \
       || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
       || ! -s "$cache_file"  ]]; then

--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -12,7 +12,7 @@ fi
 
 # Set the default paths to gpg-agent files.
 _gpg_agent_conf="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.conf"
-_gpg_agent_env="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/gpg-agent.env"
+_gpg_agent_env="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/gpg-agent.env"
 
 # Load environment variables from previous run
 source "$_gpg_agent_env" 2> /dev/null

--- a/modules/gpg/init.zsh
+++ b/modules/gpg/init.zsh
@@ -12,7 +12,7 @@ fi
 
 # Set the default paths to gpg-agent files.
 _gpg_agent_conf="${GNUPGHOME:-$HOME/.gnupg}/gpg-agent.conf"
-_gpg_agent_env="${TMPDIR:-/tmp}/gpg-agent.env.$UID"
+_gpg_agent_env="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/gpg-agent.env"
 
 # Load environment variables from previous run
 source "$_gpg_agent_env" 2> /dev/null
@@ -21,6 +21,7 @@ source "$_gpg_agent_env" 2> /dev/null
 if [[ -z "$GPG_AGENT_INFO" && ! -S "${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent" ]]; then
   # Start gpg-agent if not started.
   if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "${${${(s.:.)GPG_AGENT_INFO}[2]}:--1} gpg-agent"; then
+    mkdir -p "$_gpg_agent_env:h"
     eval "$(gpg-agent --daemon | tee "$_gpg_agent_env")"
   fi
 fi

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -39,7 +39,7 @@ typeset -A compl_commands=(
 
 for compl_command in "${(k)compl_commands[@]}"; do
   if (( $+commands[$compl_command] )); then
-    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-$compl_command-cache.zsh"
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/$compl_command-cache.zsh"
 
     # Completion commands are slow; cache their output if old or missing.
     if [[ "$commands[$compl_command]" -nt "$cache_file" \

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -39,12 +39,13 @@ typeset -A compl_commands=(
 
 for compl_command in "${(k)compl_commands[@]}"; do
   if (( $+commands[$compl_command] )); then
-    cache_file="${TMPDIR:-/tmp}/prezto-$compl_command-cache.$UID.zsh"
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-$compl_command-cache.zsh"
 
     # Completion commands are slow; cache their output if old or missing.
     if [[ "$commands[$compl_command]" -nt "$cache_file" \
           || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
           || ! -s "$cache_file" ]]; then
+      mkdir -p "$cache_file:h"
       command ${=compl_commands[$compl_command]} >! "$cache_file" 2> /dev/null
     fi
 

--- a/modules/pacman/functions/pacman-list-disowned
+++ b/modules/pacman/functions/pacman-list-disowned
@@ -8,11 +8,11 @@
 
 # function pacman-list-disowned {
 
-local tmp="${TMPDIR:-/tmp}/pacman-disowned-$UID-$$"
+local tmp="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/pacman-disowned-$$"
 local db="$tmp/db"
 local fs="$tmp/fs"
 
-mkdir "$tmp"
+mkdir -p "$tmp"
 trap  'rm -rf "$tmp"' EXIT
 
 pacman --quiet --query --list | sort --unique > "$db"

--- a/modules/pacman/functions/pacman-list-disowned
+++ b/modules/pacman/functions/pacman-list-disowned
@@ -8,7 +8,7 @@
 
 # function pacman-list-disowned {
 
-local tmp="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/pacman-disowned-$$"
+local tmp="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/pacman-disowned-$$"
 local db="$tmp/db"
 local fs="$tmp/fs"
 

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -42,11 +42,12 @@ fi
 
 if is-darwin; then
   # Perl is slow; cache its output.
-  cache_file="${TMPDIR:-/tmp}/prezto-perl-cache.$UID.zsh"
+  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-perl-cache.zsh"
   perl_path="$HOME/Library/Perl/5.12"
 
   if [[ -f "$perl_path/lib/perl5/local/lib.pm" ]]; then
     if [[ "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" || ! -s "$cache_file" ]]; then
+      mkdir -p "$cache_file:h"
       perl -I$perl_path/lib/perl5 -Mlocal::lib=$perl_path >! "$cache_file"
     fi
 

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -42,7 +42,7 @@ fi
 
 if is-darwin; then
   # Perl is slow; cache its output.
-  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-perl-cache.zsh"
+  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/perl-cache.zsh"
   perl_path="$HOME/Library/Perl/5.12"
 
   if [[ -f "$perl_path/lib/perl5/local/lib.pm" ]]; then

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -148,7 +148,7 @@ fi
 
 # Load PIP completion.
 if (( $#commands[(i)pip(|[23])] )); then
-  cache_file="${TMPDIR:-/tmp}/prezto-pip-cache.$UID.zsh"
+  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-pip-cache.zsh"
 
   # Detect and use one available from among 'pip', 'pip2', 'pip3' variants
   pip_command="$commands[(i)pip(|[23])]"
@@ -156,6 +156,7 @@ if (( $#commands[(i)pip(|[23])] )); then
   if [[ "$pip_command" -nt "$cache_file" \
         || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
         || ! -s "$cache_file" ]]; then
+    mkdir -p "$cache_file:h"
     # pip is slow; cache its output. And also support 'pip2', 'pip3' variants
     $pip_command completion --zsh \
       | sed -e "s/\(compctl -K [-_[:alnum:]]* pip\).*/\1{,2,3}{,.{0..9}}/" \

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -148,7 +148,7 @@ fi
 
 # Load PIP completion.
 if (( $#commands[(i)pip(|[23])] )); then
-  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/prezto-pip-cache.zsh"
+  cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/pip-cache.zsh"
 
   # Detect and use one available from among 'pip', 'pip2', 'pip3' variants
   pip_command="$commands[(i)pip(|[23])]"

--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -14,10 +14,10 @@ fi
 _ssh_dir="$HOME/.ssh"
 
 # Set the path to the environment file if not set by another module.
-_ssh_agent_env="${_ssh_agent_env:-${TMPDIR:-/tmp}/ssh-agent.env.$UID}"
+_ssh_agent_env="${_ssh_agent_env:-${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ssh-agent.env}"
 
 # Set the path to the persistent authentication socket.
-_ssh_agent_sock="${TMPDIR:-/tmp}/ssh-agent.sock.$UID"
+_ssh_agent_sock="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ssh-agent.sock"
 
 # Start ssh-agent if not started.
 if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
@@ -26,12 +26,14 @@ if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
 
   # Start ssh-agent if not started.
   if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "${SSH_AGENT_PID:--1} ssh-agent"; then
+    mkdir -p "$_ssh_agent_env:h"
     eval "$(ssh-agent | sed '/^echo /d' | tee "$_ssh_agent_env")"
   fi
 fi
 
 # Create a persistent SSH authentication socket.
 if [[ -S "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$_ssh_agent_sock" ]]; then
+  mkdir -p "$_ssh_agent_sock:h"
   ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
   export SSH_AUTH_SOCK="$_ssh_agent_sock"
 fi

--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -14,10 +14,10 @@ fi
 _ssh_dir="$HOME/.ssh"
 
 # Set the path to the environment file if not set by another module.
-_ssh_agent_env="${_ssh_agent_env:-${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ssh-agent.env}"
+_ssh_agent_env="${_ssh_agent_env:-${XDG_CACHE_HOME:-$HOME/.cache}/prezto/ssh-agent.env}"
 
 # Set the path to the persistent authentication socket.
-_ssh_agent_sock="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ssh-agent.sock"
+_ssh_agent_sock="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/ssh-agent.sock"
 
 # Start ssh-agent if not started.
 if [[ ! -S "$SSH_AUTH_SOCK" ]]; then

--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -8,7 +8,7 @@
 # Execute code that does not affect the current session in the background.
 {
   # Compile the completion dump to increase startup speed.
-  zcompdump="${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompdump}:-${ZDOTDIR:-$HOME}/.zcompdump}"
+  zcompdump="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
     zcompile "$zcompdump"
   fi

--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -8,7 +8,7 @@
 # Execute code that does not affect the current session in the background.
 {
   # Compile the completion dump to increase startup speed.
-  zcompdump="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
+  zcompdump="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
     zcompile "$zcompdump"
   fi

--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -8,7 +8,7 @@
 # Execute code that does not affect the current session in the background.
 {
   # Compile the completion dump to increase startup speed.
-  zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
+  zcompdump="${${XDG_CACHE_HOME:+$XDG_CACHE_HOME/zcompdump}:-${ZDOTDIR:-$HOME}/.zcompdump}"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
     zcompile "$zcompdump"
   fi


### PR DESCRIPTION
Closes #1841

## Proposed Changes

Look up `zcompdump` and `zcompcache` <ins>and all other cache files</ins> in `XDG_CACHE_HOME` ~if set, otherwise use the zsh default~. I provided additional detail in the linked issue and have tested as thoroughly as I can locally.