### PR TITLE
alias.zsh: add glgc alias to show git log graph in compact form.

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -219,6 +219,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
   - `gld` displays the diff log.
   - `glo` displays the one line log.
   - `glg` displays the graph log.
+  - `glgc` displays the graph log in compact form.
   - `glb` displays the brief commit log.
   - `glc` displays the commit count for each contributor in descending order.
   - `glS` displays the log and checks the validity of signed commits.

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -189,6 +189,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gld='git log --topo-order --stat --patch --full-diff --pretty=format:"${_git_log_medium_format}"'
   alias glo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
   alias glg='git log --topo-order --all --graph --pretty=format:"${_git_log_oneline_format}"'
+  alias glgc='git log --graph --oneline --decorate --all'
   alias glb='git log --topo-order --pretty=format:"${_git_log_brief_format}"'
   alias glc='git shortlog --summary --numbered'
   alias glS='git log --show-signature'


### PR DESCRIPTION
Add alias for pretty git log output without extra whitespace between lines.  Useful for smaller laptop screens.