### PR TITLE
Fix TMUX module for Termux hosts

### DIFF
--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -38,7 +38,13 @@ if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" && -z "$INSIDE_EMACS" && "$TERM_PRO
   fi
 
   # Attach to the 'prezto' session or to the last session used. (detach first)
-  exec tmux $_tmux_iterm_integration attach-session -d
+  if (( $+commands[termux-info] )); then
+    # Simlate exec on Termux
+    tmux -f "$tmux_config" $_tmux_iterm_integration attach-session -d
+    exit "$?"
+  else
+    exec tmux $_tmux_iterm_integration attach-session -d
+  fi
 fi
 
 #


### PR DESCRIPTION
## Proposed Changes

  - On Termux, the current tmux plugin does not work as intended
  - The problematic part if the `exec` call, Termux's implementation is bogus and leads to the process exiting with RC 35 instead of starting/attaching tmux.

![Screenshot](https://user-images.githubusercontent.com/37886/83939538-1380ae00-a7de-11ea-888c-b07e167fca46.png)
