### PR TITLE
Allow custom TMUX config path

### DIFF
--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -53,6 +53,16 @@ zstyle ':prezto:module:tmux:iterm' integrate 'yes'
 
 Read [iTerm2 and tmux Integration][7] for more information.
 
+#### Custom Config File Path
+
+By default this plugin will use tmux's default config path (`$HOME/.tmux.conf`).
+If your config is stored elsewhere (in `XDG_CONFIG_HOME` for example), you can
+set the path using:
+
+```sh
+zstyle ':prezto:module:tmux:config' path "$XDG_CONFIG_HOME/tmux.conf"
+```
+
 Aliases
 -------
 

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -23,27 +23,31 @@ if ([[ "$TERM_PROGRAM" = 'iTerm.app' ]] && \
   _tmux_iterm_integration='-CC'
 fi
 
+# Get tmux config path
+zstyle -s ':prezto:module:tmux:config' path _tmux_config || _tmux_config="$HOME/.tmux.conf"
+
+
 if [[ -z "$TMUX" && -z "$EMACS" && -z "$VIM" && -z "$INSIDE_EMACS" && "$TERM_PROGRAM" != "vscode" ]] && ( \
   ( [[ -n "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' remote ) ||
   ( [[ -z "$SSH_TTY" ]] && zstyle -t ':prezto:module:tmux:auto-start' local ) \
 ); then
-  tmux start-server
+  tmux -f "$_tmux_config" start-server
 
   # Create a 'prezto' session if no session has been defined in tmux.conf.
-  if ! tmux has-session 2> /dev/null; then
+  if ! tmux -f "$_tmux_config" has-session 2> /dev/null; then
     zstyle -s ':prezto:module:tmux:session' name tmux_session || tmux_session='prezto'
-    tmux \
+    tmux -f "$_tmux_config" \
       new-session -d -s "$tmux_session" \; \
       set-option -t "$tmux_session" destroy-unattached off &> /dev/null
   fi
 
   # Attach to the 'prezto' session or to the last session used. (detach first)
-  exec tmux $_tmux_iterm_integration attach-session -d
+  exec tmux -f "$_tmux_config" $_tmux_iterm_integration attach-session -d
 fi
 
 #
 # Aliases
 #
 
-alias tmuxa="tmux $_tmux_iterm_integration new-session -A"
-alias tmuxl='tmux list-sessions'
+alias tmuxa="tmux -f \"$_tmux_config\" $_tmux_iterm_integration new-session -A"
+alias tmuxl="tmux -f \"$_tmux_config\" list-sessions"


### PR DESCRIPTION
## Proposed Changes

  - Right now the TMUX plugin only makes use of the default TMUX config path (`~/.tmux.conf`)
  - This PR allows users to set the path to their tmux config.

Example:

```sh
zstyle ':prezto:module:tmux:config' path "$XDG_CONFIG_HOME/tmux.conf"
```