### PR TITLE
Add aliases to use with termux terminal emulator (android)

### DIFF
--- a/modules/helper/init.zsh
+++ b/modules/helper/init.zsh
@@ -49,3 +49,8 @@ function is-bsd {
 function is-cygwin {
   [[ "$OSTYPE" == cygwin* ]]
 }
+
+# is true on termux (Android)
+function is-termux {
+  [[ "$OSTYPE" == linux-android ]]
+}

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -140,6 +140,10 @@ elif is-cygwin; then
   alias o='cygstart'
   alias pbcopy='tee > /dev/clipboard'
   alias pbpaste='cat /dev/clipboard'
+elif is-termux; then
+  alias o='termux-open'
+  alias pbcopy='termux-clipboard-set'
+  alias pbpaste='termux-clipboard-get'
 else
   alias o='xdg-open'
 


### PR DESCRIPTION
add is-termux function

add utility aliases

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

## Proposed Changes

  - add function to check if using termux (android) terminal emulator
  - add utility aliases
