### PR TITLE
Add ^_ mapping to undo in viins mode

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -318,6 +318,7 @@ bindkey -M vicmd "$key_info[Control]X$key_info[Control]E" edit-command-line
 
 # Undo/Redo
 bindkey -M vicmd "u" undo
+bindkey -M viins "$key_info[Control]_" undo
 bindkey -M vicmd "$key_info[Control]R" redo
 
 if (( $+widgets[history-incremental-pattern-search-backward] )); then


### PR DESCRIPTION
My initial PR wasn't good. So I closed it. So, this is the good version.

This one line addition allows to cancel a tab completion in viins as ^_ in emacs mode.
That's all.

This mapping is essential for a vi mapping. Thank you for considering it.