### PR TITLE
Add check for empty WORKON_HOME

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -71,7 +71,7 @@ function _python-workon-cwd {
   if [[ "$ENV_NAME" != "" ]]; then
     # Activate the environment only if it is not already active
     if [[ "$VIRTUAL_ENV" != "$WORKON_HOME/$ENV_NAME" ]]; then
-      if [[ -e "$WORKON_HOME/$ENV_NAME/bin/activate" ]]; then
+      if [[ -n "$WORKON_HOME" && -e "$WORKON_HOME/$ENV_NAME/bin/activate" ]]; then
         workon "$ENV_NAME" && export CD_VIRTUAL_ENV="$ENV_NAME"
       elif [[ -e "$ENV_NAME/bin/activate" ]]; then
         source $ENV_NAME/bin/activate && export CD_VIRTUAL_ENV="$ENV_NAME"


### PR DESCRIPTION
## Proposed Changes
When $WORKON_HOME is not set and $ENV_NAME is equal to
$PROJECT_ROOT/.venv which contains bin/activate then
the code wrongly assumes workon is available.

It should execute the second branch to source bin/activate.