### PR TITLE
Ensure compinit updates its modified date

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -40,6 +40,7 @@ if [[ $_comp_path(#qNmh-20) ]]; then
 else
   mkdir -p "$_comp_path:h"
   compinit -i -d "$_comp_path"
+  touch "$_comp_path"
 fi
 unset _comp_path
 


### PR DESCRIPTION
`compinit -i` doesn't always change zcompdump, which means that the `compinit -C` condition fails to run until the completions change. When we `compinit -i`, we should touch the file too to solve this.

See: https://github.com/sorin-ionescu/prezto/issues/1880