### PR TITLE
osx module mand fix

### DIFF
--- a/modules/osx/functions/mand
+++ b/modules/osx/functions/mand
@@ -8,7 +8,7 @@
 function mand {
   if (( $# > 0 )); then
     zstyle -s ':prezto:module:osx:man' dash-keyword 'dashkw' || dashkw='manpages'
-    open "dash://$dashkw:$1" 2> /dev/null
+    open "dash://$dashkw%3A$1" 2> /dev/null
     if (( $? != 0 )); then
       print "$0: Dash is not installed" >&2
       break


### PR DESCRIPTION
> The {query} has to be percent-escaped in macOS 11.

Just replace `:` to `%3A` work fine.

But add function like this one I find on stackoverflow to encode the entire query string would be more robust.
```bash
urldecode() {
    # urldecode <string>

    local url_encoded="${1//+/ }"
    printf '%b' "${url_encoded//%/\\x}"
}
```