### PR TITLE
Enable `history-substring-search` as a default module

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -38,6 +38,7 @@ zstyle ':prezto:load' pmodule \
   'spectrum' \
   'utility' \
   'completion' \
+  'history-substring-search' \
   'prompt'
 
 #


### PR DESCRIPTION
Enable `history-substring-search` as a default module

Resolves #1868

## Proposed Changes

  - Enable `history-substring-search` as a default module

## The motivation

I love `prezto` at least this 4 or 5 years. Thanks for this so useful project!

This time, I have casual updated to my own local `prezto`.
Then all dotfiles around zsh has been removed with my careless operation... 😇  

All of them are completely my mistaken.

Then I have tried to get back my loving environment again.
Honestly, It taken no short time.

And I noticed, I mostly loving the feature is the `history-substring-search`.
And I noticed again, making it is a default is suggested in https://github.com/sorin-ionescu/prezto/issues/1868.

I believe it makes happy for new users of `prezto`. So I have created this PR.

## I'm afraid...

I think 2 consideration points exist.

https://github.com/sorin-ionescu/prezto/blob/704fc46c3f83ca1055becce65fb513a533f48982/README.md#usage

>Prezto has many features disabled by default.

I guess it is an important philosophy of this project. It makes light and fast this `prezto` behaviors.

Actually, the default loading modules looks not changed this 9 years!

https://github.com/sorin-ionescu/prezto/blob/704fc46c3f83ca1055becce65fb513a533f48982/runcoms/zpreztorc#L30-L42

https://github.com/sorin-ionescu/prezto/commit/cc7e43b2422d044c98da2b5c5a1ebf6e8b2ac40d

It sounds this suggestion might not fit for `prezto` philosophy, but I couldn't keep to stop sending this PR from my motivation. :bow:
But I think this change does not make much slower behaviors, I have checked with below.

Before

```console
$ for i in $(seq 1 10); do time zsh -i -c exit; done
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.166 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.159 total
zsh -i -c exit  0.11s user 0.04s system 98% cpu 0.155 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.159 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.160 total
zsh -i -c exit  0.12s user 0.04s system 87% cpu 0.186 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.159 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.163 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.161 total
zsh -i -c exit  0.12s user 0.05s system 98% cpu 0.166 total
```

After

```console
$ for i in $(seq 1 10); do time zsh -i -c exit; done
zsh -i -c exit  0.11s user 0.04s system 98% cpu 0.153 total
zsh -i -c exit  0.11s user 0.04s system 98% cpu 0.152 total
zsh -i -c exit  0.12s user 0.05s system 98% cpu 0.167 total
zsh -i -c exit  0.12s user 0.04s system 97% cpu 0.167 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.162 total
zsh -i -c exit  0.11s user 0.04s system 98% cpu 0.162 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.164 total
zsh -i -c exit  0.11s user 0.04s system 98% cpu 0.158 total
zsh -i -c exit  0.12s user 0.05s system 98% cpu 0.166 total
zsh -i -c exit  0.12s user 0.04s system 98% cpu 0.166 total
```

Another consideration is an implementation issue.

https://github.com/sorin-ionescu/prezto/blob/704fc46c3f83ca1055becce65fb513a533f48982/runcoms/zpreztorc#L31

The description made hesitate to adding this change. But this ordering works fine in my machine.
If this has any problem, please pointing out. 🙏 