### PR TITLE
prompt: Remove Powerlevel9k

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,10 +25,6 @@
 [submodule "modules/prompt/external/async"]
 	path = modules/prompt/external/async
 	url = https://github.com/mafredri/zsh-async.git
-[submodule "modules/prompt/external/powerlevel9k"]
-	path = modules/prompt/external/powerlevel9k
-	url = https://github.com/bhilburn/powerlevel9k.git
-	shallow = true
 [submodule "modules/prompt/external/powerlevel10k"]
 	path = modules/prompt/external/powerlevel10k
 	url = https://github.com/romkatv/powerlevel10k.git

--- a/modules/prompt/init.zsh
+++ b/modules/prompt/init.zsh
@@ -12,6 +12,11 @@ autoload -Uz promptinit && promptinit
 zstyle -a ':prezto:module:prompt' theme 'prompt_argv'
 if [[ "$TERM" == (dumb|linux|*bsd*) ]] || (( $#prompt_argv < 1 )); then
   prompt 'off'
+elif [[ "$prompt_argv[1]" == 'powerlevel9k' ]] ; then
+  printf "'powerlevel9k' has been deprecated and unsupported by its author, "
+  printf "consider migrating to 'powerlevel10k' instead.\n"
+  printf "Switching to prezto default prompt...\n"
+  prompt 'sorin'
 else
   prompt "$prompt_argv[@]"
 fi


### PR DESCRIPTION
## Remove Powerlevel9k

Powerlevel9k has been marked deprecated and unmaintained by the author.
Powerlevel10k is now the recommended replacement.

See: https://github.com/Powerlevel9k/powerlevel9k#powerlevel9k-is-deprecated-and-now-unmaintained-please-use-powerlevel10k
