### PR TITLE
Allow loading more specific 'run-help' function

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -182,6 +182,9 @@ zstyle -a ':prezto:load' zmodule 'zmodules'
 for zmodule ("$zmodules[@]") zmodload "zsh/${(z)zmodule}"
 unset zmodule{s,}
 
+# Load more specific 'run-help' function from $fpath.
+unalias run-help && autoload -Uz run-help
+
 # Autoload Zsh functions.
 zstyle -a ':prezto:load' zfunction 'zfunctions'
 for zfunction ("$zfunctions[@]") autoload -Uz "$zfunction"

--- a/modules/git/init.zsh
+++ b/modules/git/init.zsh
@@ -13,5 +13,8 @@ fi
 # Load dependencies.
 pmodload 'helper'
 
+# Load 'run-help' function.
+autoload -Uz run-help-git
+
 # Source module files.
 source "${0:h}/alias.zsh"

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -15,6 +15,9 @@ if zstyle -T ':prezto:module:utility' correct; then
   setopt CORRECT
 fi
 
+# Load 'run-help' function.
+autoload -Uz run-help-{ip,openssl,sudo}
+
 #
 # Aliases
 #


### PR DESCRIPTION
Allow loading more specific 'run-help' function from $fpath. This allows automatically looking up specific sub-command helper if available instead of the static default ('man').

See: 
- https://github.com/zsh-users/zsh/blob/ccc9cff9e244725ed604fd1ac20e4958339e3885/Functions/Misc/run-help#L3-L8
- https://stackoverflow.com/a/32293317