### PR TITLE
command-not-found: Update docs for Homebrew

### DIFF
--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -7,8 +7,9 @@ the proper install command.
 
 Debian and Arch Linux based distributions use the [`command-not-found`][1] tool.
 
-macOS uses Homebrew's [`command-not-found` clone][2]. Note that you also need to
-[follow the instructions][3] to tap the `command-not-found` homebrew repository.
+macOS uses Homebrew's [`command-not-found` clone][2]. Note that unless you have
+a recent version of Homebrew installed, you might also need to tap the
+`command-not-found` Homebrew repository [following the instructions][3].
 
 
 Authors
@@ -17,6 +18,7 @@ Authors
 *The authors of this module should be contacted via the [issue tracker][4].*
 
   - [Joseph Booker](https://github.com/sargas)
+  - [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
 [1]: https://code.launchpad.net/command-not-found
 [2]: https://github.com/Homebrew/homebrew-command-not-found


### PR DESCRIPTION
Update documentation for Homebrew to indicate that a recent version of 
Homebrew does not need to tap `command-not-found` Homebrew repository.

See: Homebrew/brew#11137