### PR TITLE
general: Remove redundant usage of `cat`

### DIFF
--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -11,7 +11,7 @@
 local archive_name path_to_archive _gzip_bin _bzip2_bin _xz_bin
 
 if (( $# < 2 )); then
-  cat >&2 <<EOF
+  >&2 <<EOF
 usage: $0 [archive_name.zip] [/path/to/include/into/archive ...]
 
 Where 'archive.zip' uses any of the following extensions:

--- a/modules/archive/functions/lsarchive
+++ b/modules/archive/functions/lsarchive
@@ -10,7 +10,7 @@
 local verbose
 
 if (( $# == 0 )); then
-  cat >&2 <<EOF
+  >&2 <<EOF
 usage: $0 [-option] [file ...]
 
 options:

--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -15,7 +15,7 @@ local extract_dir
 local _gzip_bin _bzip2_bin _xz_bin
 
 if (( $# == 0 )); then
-  cat >&2 <<EOF
+  >&2 <<EOF
 usage: $0 [-option] [file ...]
 
 options:

--- a/modules/dpkg/functions/deb-history
+++ b/modules/dpkg/functions/deb-history
@@ -26,7 +26,7 @@ case "$1" in
     zcat $(ls -rt /var/log/dpkg*)
   ;;
   (*)
-    cat >&2 <<EOF
+    >&2 <<EOF
 Commands:
     install - List installed packages
     upgrade - List upgraded packages

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -57,7 +57,7 @@ function _python-workon-cwd {
   # Check for virtualenv name override
   local ENV_NAME=""
   if [[ -f "$PROJECT_ROOT/.venv" ]]; then
-    ENV_NAME="$(cat "$PROJECT_ROOT/.venv")"
+    ENV_NAME="$(<"$PROJECT_ROOT/.venv")"
   elif [[ -f "$PROJECT_ROOT/.venv/bin/activate" ]]; then
     ENV_NAME="$PROJECT_ROOT/.venv"
   elif [[ "$PROJECT_ROOT" != "." ]]; then

--- a/modules/utility/functions/prep
+++ b/modules/utility/functions/prep
@@ -9,8 +9,7 @@
 
 local usage pattern modifiers invert
 
-usage="$(
-cat <<EOF
+usage="$(<<EOF
 usage: $0 [-option ...] [--] pattern [file ...]
 
 options:

--- a/modules/utility/functions/psub
+++ b/modules/utility/functions/psub
@@ -9,8 +9,7 @@
 
 local usage pattern replacement modifiers
 
-usage="$(
-cat <<EOF
+usage="$(<<EOF
 usage: $0 [-option ...] [--] pattern replacement [file ...]
 
 options:

--- a/modules/utility/functions/zsh-help
+++ b/modules/utility/functions/zsh-help
@@ -9,8 +9,7 @@
 
 # function zsh-help {
 
-local usage="$(
-cat <<EOF
+local usage="$(<<EOF
 usage: $0 [--help] [--zsh-help-debug] [--all] search term(s)
 Options:
     --all - search for the term anywhere, not just at the start of a line.


### PR DESCRIPTION
In general, the substitution ‘$(cat foo)’ may be replaced by the
equivalent but faster ‘$(<foo)’.

