### PR TITLE
Ensure compinit updates its modified date

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -24,7 +24,7 @@ setopt PATH_DIRS           # Perform path search even on command names with slas
 setopt AUTO_MENU           # Show completion menu on a successive tab press.
 setopt AUTO_LIST           # Automatically list choices on ambiguous completion.
 setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a trailing slash.
-setopt EXTENDED_GLOB       # Needed for file modification glob modifiers with compinit
+setopt EXTENDED_GLOB       # Needed for file modification glob modifiers with compinit.
 unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
 unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 
@@ -40,6 +40,7 @@ if [[ $_comp_path(#qNmh-20) ]]; then
 else
   mkdir -p "$_comp_path:h"
   compinit -i -d "$_comp_path"
+  # Keep $_comp_path younger than cache time even if it isn't regenerated.
   touch "$_comp_path"
 fi
 unset _comp_path

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -40,6 +40,7 @@ if [[ $_comp_path(#qNmh-20) ]]; then
 else
   mkdir -p "$_comp_path:h"
   compinit -i -d "$_comp_path"
+  touch "$_comp_path"
 fi
 unset _comp_path
 


### PR DESCRIPTION
`compinit -i` doesn't always change zcompdump, which means that the
`compinit -C` condition fails to run until the completions change.
When we `compinit -i`, we should touch the file too to solve this.

Superseded #1881
