### PR TITLE
Delete prompt_powerlevel9k_setup

### DIFF
--- a/modules/prompt/functions/prompt_powerlevel9k_setup
+++ b/modules/prompt/functions/prompt_powerlevel9k_setup
@@ -1,1 +1,0 @@
-../external/powerlevel9k/powerlevel9k.zsh-theme


### PR DESCRIPTION
I think this should have been removed as part of https://github.com/sorin-ionescu/prezto/commit/0a07ba27a2f9582a37e7d1a5e08f33c2ad552000.

Currently I'm seeing this warning after updating to `master`:
```
Couldn't read file /Users/jeffwidman/.zprezto/modules/prompt/functions/prompt_powerlevel9k_setup containing theme powerlevel9k.
```

After removing this file, the warning goes away.