### PR TITLE
history: Move HISTFILE path to more conventional one

### DIFF
--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -3,10 +3,13 @@ History
 
 Sets [history][1] options and defines history aliases.
 
-**Note:** If you are migrating from [Oh My Zsh][2] and are not on a recent
-version of macOS and want to keep your history, you will either need to set
-`HISTFILE` manually to `$HOME/.zsh_history` or rename `~/.zsh_history` to
-`~/.zhistory`.
+**Note:** Default path of `HISTFILE` has changed from `${ZDOTDIR:-$HOME}/.zhistory`
+to `${ZDOTDIR:-$HOME}/.zsh_history`. The file will be automatically renamed if
+possible (when the new one doesn't exist). Otherwise, if you want to preserve
+previous history, you will need to move them from `${ZDOTDIR:-$HOME}/.zhistory`
+to `${ZDOTDIR:-$HOME}/.zsh_history`.
+
+Alternately, you can set `HISTFILE` manually to `${ZDOTDIR:-$HOME}/.zhistory`.
 
 Options
 -------
@@ -40,11 +43,11 @@ Aliases
 Authors
 -------
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+*The authors of this module should be contacted via the [issue tracker][2].*
 
   - [Robby Russell](https://github.com/robbyrussell)
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
+  - [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
 [1]: http://zsh.sourceforge.net/Guide/zshguide02.html#l16
-[2]: https://github.com/ohmyzsh/ohmyzsh
-[3]: https://github.com/sorin-ionescu/prezto/issues
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -26,7 +26,7 @@ setopt HIST_BEEP                 # Beep when accessing non-existent history.
 # Variables
 #
 
-HISTFILE="${HISTFILE:-${ZDOTDIR:-$HOME}/.zhistory}"  # The path to the history file.
+HISTFILE="${HISTFILE:-${ZDOTDIR:-$HOME}/.zsh_history}"  # The path to the history file.
 HISTSIZE=10000                   # The maximum number of events to save in the internal history.
 SAVEHIST=10000                   # The maximum number of events to save in the history file.
 
@@ -36,3 +36,28 @@ SAVEHIST=10000                   # The maximum number of events to save in the h
 
 # Lists the ten most used commands.
 alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
+
+if [[ -s "${OLD_HISTFILE::=${HISTFILE:h}/.zhistory}" ]]; then
+
+  # New 'HISTFILE' doesn't exist yet, rename legacy one if available and notify.
+  if [[ ! -s "$HISTFILE" ]]; then
+    <<EON
+NOTICE: Default path of 'HISTFILE' has changed from '${OLD_HISTFILE/#$HOME/~}'
+        to '${HISTFILE/#$HOME/~}'.
+        Attempting to rename the existing 'HISTFILE' ...
+EON
+    mv -v "$OLD_HISTFILE" "$HISTFILE"
+
+  # New 'HISTFILE' does exist and is older than legacy one, just warn.
+  elif [[ "$OLD_HISTFILE" -nt "$HISTFILE" ]]; then
+    <<EOW
+WARNING: Default path of 'HISTFILE' has changed from '${OLD_HISTFILE/#$HOME/~}'
+         to '${HISTFILE/#$HOME/~}'.
+         Either set 'HISTFILE' in '${${0:h}/#$HOME/~}'
+         or move previous history from '${OLD_HISTFILE/#$HOME/~}' to
+         '${HISTFILE/#$HOME/~}'.
+EOW
+  fi
+
+  unset OLD_HISTFILE
+fi


### PR DESCRIPTION
Change default `HISTFILE` path from `~/.zhistory` to more conventional `~/.zsh_history`. This aligns better with Debian variants, macOS and Oh My Zsh.
 
This would provide an easier onboarding experience to users coming to Prezto from standard (framework free) zsh or from Oh My Zsh.

For existing Prezto users, we attempt to automatically rename old `HISTFILE` to new one iff the old one exists and the new one doesn't. However, if both old and new `HISTFILE` exist and the old one is more recent, we just alert the user about what changed with a suggested way to accommodate the change.

Closes #1766.