### PR TITLE
completion: Add completion for keg-only brewed curl when available

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -14,6 +14,13 @@ fi
 # Add zsh-completions to $fpath.
 fpath=("${0:h}/external/src" $fpath)
 
+# Add completion for keg-only brewed curl when available.
+if (( $+commands[brew] && ! $+functions[_curl] )) && \
+      [[ -d "${curl_prefix::="$(brew --prefix curl 2> /dev/null)"}" ]]; then
+  fpath=("${curl_prefix}/share/zsh/site-functions" $fpath)
+  unset curl_prefix
+fi
+
 #
 # Options
 #


### PR DESCRIPTION
As curl bundled with macOS does not include `_curl` definitions, one way to make `_curl` available is to install curl from Homebrew.

However, since curl from Hombrew is _keg-only_, its function path needs to be explicitly included.
