### PR TITLE
archive: Remove unnecessary interpreter directive

### DIFF
--- a/modules/archive/functions/archive
+++ b/modules/archive/functions/archive
@@ -1,4 +1,3 @@
-#!/usr/bin/env zsh
 #
 # Creates archive file
 #


### PR DESCRIPTION
These files are expected to be `source`d in and not executed standalone.

