### PR TITLE
node: Fixup nvm path detection for Homebrew based nvm

### DIFF
--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -12,8 +12,8 @@ if [[ -s "${NVM_DIR:=$HOME/.nvm}/nvm.sh" ]]; then
 
 # Load package manager installed NVM into the shell session.
 elif (( $+commands[brew] )) && \
-  [[ -d "${nvm_prefix::="$(brew --prefix 2> /dev/null)"/opt/nvm}" ]]; then
-  source "$(brew --prefix nvm)/nvm.sh"
+      [[ -d "${nvm_prefix::="$(brew --prefix nvm 2> /dev/null)"}" ]]; then
+  source "${nvm_prefix}/nvm.sh"
   unset nvm_prefix
 
 # Load manually installed nodenv into the shell session.


### PR DESCRIPTION
Prefer using `brew --prefix nvm` instead of just `brew --prefix` and actually use the variable `nvm_prefix` once detected and set up.
