### PR TITLE
rsync: Remove broken HFS+ specific compression flag

### DIFF
--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -24,10 +24,10 @@ if grep -q 'xattrs' <(rsync --help 2>&1); then
   _rsync_cmd="${_rsync_cmd} --acls --xattrs"
 fi
 
-# macOS and HFS+ Enhancements
+# macOS Enhancements
 # https://bombich.com/kb/ccc5/credits
 if is-darwin && grep -q 'file-flags' <(rsync --help 2>&1); then
-  _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --protect-decmpfs --force-change"
+  _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --force-change"
 fi
 
 alias rsync-copy="${_rsync_cmd}"


### PR DESCRIPTION
Remove `--protect-decmpfs` by default since hfs-compression specific changes have been marked by upstream as broken since 3.1.3 and there is little likelihood of that changing.

See: WayneD/rsync-patches#1