### PR TITLE
rsync: Check for new rsync before applying newer options

### DIFF
--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -3,8 +3,8 @@ Rsync
 
 Defines [rsync][1] aliases.
 
-macOS users are encouraged to use [Bombich's rsync][2], which has HFS+
-enhancements.
+macOS users are encouraged to use *rsync* from [Homebrew][2] or [MacPorts][3],
+which has additional enhancements including patches from [Bombich][4].
 
 Aliases
 -------
@@ -18,10 +18,12 @@ Aliases
 Authors
 -------
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+*The authors of this module should be contacted via the [issue tracker][5].*
 
   - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://rsync.samba.org
-[2]: https://bombich.com/kb/ccc5/credits#rsync
-[3]: https://github.com/sorin-ionescu/prezto/issues
+[1]: https://rsync.samba.org
+[2]: https://github.com/Homebrew/homebrew-core
+[3]: https://ports.macports.org/port/rsync
+[4]: https://bombich.com/kb/ccc5/credits#rsync
+[5]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/rsync/init.zsh
+++ b/modules/rsync/init.zsh
@@ -20,14 +20,19 @@ pmodload 'helper'
 _rsync_cmd='rsync --verbose --progress --human-readable --compress --archive \
   --hard-links --one-file-system'
 
-if grep -q 'xattrs' <(rsync --help 2>&1); then
-  _rsync_cmd="${_rsync_cmd} --acls --xattrs"
-fi
+autoload -Uz is-at-least
+if is-at-least 3.1 ${"$(rsync --version 2>&1)"[(w)3]}; then
 
-# macOS Enhancements
-# https://bombich.com/kb/ccc5/credits
-if is-darwin && grep -q 'file-flags' <(rsync --help 2>&1); then
-  _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --force-change"
+  # ACL and extended attributes support
+  if grep -q 'xattrs' <(rsync --help 2>&1); then
+    _rsync_cmd="${_rsync_cmd} --acls --xattrs"
+  fi
+
+  # macOS Enhancements
+  # https://bombich.com/kb/ccc5/credits
+  if is-darwin && grep -q 'file-flags' <(rsync --help 2>&1); then
+    _rsync_cmd="${_rsync_cmd} --crtimes --fileflags --force-change"
+  fi
 fi
 
 alias rsync-copy="${_rsync_cmd}"


### PR DESCRIPTION
The newer options for extended attributes or file-flags got reliable only after rsync v3.1.
Also, recommend Homebrew or MacPorts rsync for macOS.