### PR TITLE
general: Reformat documentation with better formatting and wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,42 +1,41 @@
-Contributing
-------------
+# Contributing
 
 This project would not exist without all of its users and [contributors][1].
 
 If you have ideas on how to make the configuration easier to maintain or
 improve its performance, do not hesitate to fork and send pull requests.
 
-### Issue Reporting
+## Issue Reporting
 
-   - Check that the issue has not already been reported.
-   - Check that the issue has not already been fixed in the latest code.
-   - Open an issue with a clear title and description in grammatically correct,
-     complete sentences.
+- Check that the issue has not already been reported.
+- Check that the issue has not already been fixed in the latest code.
+- Open an issue with a clear title and description in grammatically correct,
+  complete sentences.
 
-### Pull Request
+## Pull Request
 
-   - Read [how to properly contribute to open source projects on GitHub][2].
-   - Use a topic branch to easily amend a pull request later, if necessary.
-   - Write [good commit messages][3].
-   - Squash commits on the topic branch before opening a pull request.
-   - Use the same coding style and spacing.
-   - Open a [pull request][4] that relates to but one subject with a clear
-     title and description in grammatically correct, complete sentences.
+- Read [how to properly contribute to open source projects on GitHub][2].
+- Use a topic branch to easily amend a pull request later, if necessary.
+- Write [good commit messages][3].
+- Squash commits on the topic branch before opening a pull request.
+- Use the same coding style and spacing.
+- Open a [pull request][4] that relates to but one subject with a clear title
+  and description in grammatically correct, complete sentences.
 
-#### Code Style
+### Code Style
 
 This project follows the [Google Shell Style Guide][5] when possible. However,
 there are a number of additional things to keep in mind.
 
-   - Local variables should be used whenever possible.
-   - Prefer `zstyle` over environment variables for configuration.
-   - Prefer (( ... )) over [[ ... ]] for arithmetic expression.
-   - Use the function keyword to define functions.
-   - The 80 character hard limit can be waived for readability.
+- Local variables should be used whenever possible.
+- Prefer `zstyle` over environment variables for configuration.
+- Prefer (( ... )) over [[ ... ]] for arithmetic expression.
+- Use the function keyword to define functions.
+- The 80 character hard limit can be waived for readability.
 
-#### Using an Alternative zprezto Directory
+### Using an Alternative *zprezto* Directory
 
-To work on zprezto without messing with your current configuration:
+To work on Prezto without affecting your current configuration:
 
 ```sh
 mkdir devel-zprezto
@@ -52,24 +51,24 @@ done
 
 Then to start zsh in this development environment you will run:
 
-```sh
+```console
 ZDOTDIR=/path/to/devel-zprezto zsh
 ```
 
-#### Modules
+### Modules
 
-   - A *README.md* must be present.
-   - Large functions must be placed in a *functions* directory.
-   - Functions that take arguments must have completion.
+- A *README.md* must be present.
+- Large functions must be placed in a *functions* directory.
+- Functions that take arguments must have completion.
 
-#### Themes
+### Themes
 
-   - A screenshots section must be present in the file header.
-   - The pull request description must have [embedded screenshots][6].
+- A screenshots section must be present in the file header.
+- The pull request description must have [embedded screenshots][6].
 
 [1]: https://github.com/sorin-ionescu/prezto/contributors
-[2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
+[2]: https://gun.io/blog/how-to-github-fork-branch-and-pull-request
 [3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [4]: https://help.github.com/articles/using-pull-requests
 [5]: https://google.github.io/styleguide/shell.xml
-[6]: http://daringfireball.net/projects/markdown/syntax#img
+[6]: https://github.github.com/gfm/#images

--- a/README.md
+++ b/README.md
@@ -1,66 +1,64 @@
-Prezto — Instantly Awesome Zsh
-==============================
+# Prezto — Instantly Awesome Zsh
 
 Prezto is the configuration framework for [Zsh][1]; it enriches the command line
 interface environment with sane defaults, aliases, functions, auto completion,
 and prompt themes.
 
-Installation
-------------
+## Installation
 
 Prezto will work with any recent release of Zsh, but the minimum required
-version is 4.3.11.
+version is **4.3.11**.
 
-  1. Launch Zsh:
+01. Launch Zsh:
 
-     ```console
-     zsh
-     ```
+    ```console
+    zsh
+    ```
 
-  2. Clone the repository:
+02. Clone the repository:
 
-     ```console
-     git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
-     ```
+    ```console
+    git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
+    ```
 
-  3. Create a new Zsh configuration by copying the Zsh configuration files
-     provided:
+03. Create a new Zsh configuration by copying the Zsh configuration files
+    provided:
 
-     ```sh
-     setopt EXTENDED_GLOB
-     for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
-       ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
-     done
-     ```
+    ```console
+    setopt EXTENDED_GLOB
+    for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
+      ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+    done
+    ```
 
-     Note: If you already have any of the given configuration files, `ln` will
-     cause error. In simple cases you can load prezto by adding the line
-     `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"` to the bottom of your
-     `.zshrc` and keep the rest of your Zsh configuration intact. For more
-     complicated setups, it is recommended that you back up your original
-     configs and replace them with the provided prezto runcoms.
+    **Note:** If you already have any of the given configuration files, `ln` in
+    the above operation will cause an error. In simple cases, you can load
+    Prezto by adding the line `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"` to
+    the bottom of your *${ZDOTDIR:-$HOME}/.zshrc* and keep the rest of your Zsh
+    configuration intact. For more complicated setups, we recommend that you
+    back up your original configs and replace them with the provided Prezto
+    *runcoms*.
 
-  4. Set Zsh as your default shell:
+04. Set Zsh as your default shell:
 
-     ```console
-     chsh -s /bin/zsh
-     ```
+    ```console
+    chsh -s /bin/zsh
+    ```
 
-  5. Open a new Zsh terminal window or tab.
+05. Open a new Zsh terminal window or tab.
 
 ### Troubleshooting
 
-If you are not able to find certain commands after switching to *Prezto*,
-modify the `PATH` variable in *~/.zprofile* then open a new Zsh terminal
-window or tab.
+If you are not able to find certain commands after switching to Prezto, modify
+the `PATH` variable in *${ZDOTDIR:-$HOME}/.zprofile* then open a new Zsh
+terminal window or tab.
 
-Updating
---------
+## Updating
 
-Run `zprezto-update` to automatically check if there is an update to zprezto.
-If there are no file conflicts, zprezto and its submodules will be
-automatically updated. If there are conflicts you will be instructed to go into
-the `$ZPREZTODIR` directory and resolve them yourself.
+Run `zprezto-update` to automatically check if there is an update to Prezto.
+If there are no file conflicts, Prezto and its submodules will be automatically
+updated. If there are conflicts you will be instructed to go into the
+`$ZPREZTODIR` directory and resolve them yourself.
 
 To pull the latest changes and update submodules manually:
 
@@ -70,67 +68,63 @@ git pull
 git submodule update --init --recursive
 ```
 
-Usage
------
+## Usage
 
-Prezto has many features disabled by default. Read the source code and
-accompanying README files to learn of what is available.
+Prezto has many features disabled by default. Read the source code and the
+accompanying README files to learn about what is available.
 
 ### Modules
 
-  1. Browse */modules* to see what is available.
-  2. Load the modules you need in *~/.zpreztorc* then open a new Zsh terminal
-     window or tab.
+01. Browse */modules* to see what is available.
+02. Load the modules you need in *${ZDOTDIR:-$HOME}/.zpreztorc* then open a new
+    Zsh terminal window or tab.
 
 ### Themes
 
-  1. For a list of themes, type `prompt -l`.
-  2. To preview a theme, type `prompt -p name`.
-  3. Load the theme you like in *~/.zpreztorc* then open a new Zsh terminal
-     window or tab.
+01. For a list of themes, type `prompt -l`.
+02. To preview a theme, type `prompt -p name`.
+03. Load the theme you like in *${ZDOTDIR:-$HOME}/.zpreztorc* then open a new
+    Zsh terminal window or tab.
 
-     ![sorin theme][2]
-     Note that the 'git' module may be required for special symbols to appear,
-     such as those on the right of the above image. Add `'git'` to the `pmodule`
-     list (under `zstyle ':prezto:load' pmodule \` in your *~/.zpreztorc*) to
-     enable this module.
+    ![sorin theme][2]
+    Note that the *git* module may be required for special symbols to appear,
+    such as those on the right of the above image. Add `'git'` to the `pmodule`
+    list (under `zstyle ':prezto:load' pmodule \` in your
+    *${ZDOTDIR:-$HOME}/.zpreztorc*) to enable this module.
 
 ### External Modules
 
-  1. By default modules will be loaded from */modules* and */contrib*.
-  2. Additional module directories can be added to the
-     `:prezto:load:pmodule-dirs` setting in *~/.zpreztorc*.
+01. By default modules will be loaded from */modules* and */contrib*.
+02. Additional module directories can be added to the
+    `:prezto:load:pmodule-dirs` setting in *${ZDOTDIR:-$HOME}/.zpreztorc*.
 
-     Note that module names need to be unique or they will cause an error when
-     loading.
+    Note that module names need to be unique or they will cause an error when
+    loading.
 
-     ```sh
-     zstyle ':prezto:load' pmodule-dirs $HOME/.zprezto-contrib
-     ```
+    ```console
+    zstyle ':prezto:load' pmodule-dirs $HOME/.zprezto-contrib
+    ```
 
-Customization
--------------
+## Customization
 
-The project is managed via [Git][3]. It is highly recommended that you fork this
-project; so, that you can commit your changes and push them to [GitHub][4] to
-not lose them. If you do not know how to use Git, follow this [tutorial][5] and
-bookmark this [reference][6].
+The project is managed via [Git][3]. We highly recommend that you fork this
+project so that you can commit your changes and push them to your fork on
+[GitHub][4] to preserve them. If you do not know how to use Git, follow this
+[tutorial][5] and bookmark this [reference][6].
 
-Resources
----------
+## Resources
 
 The [Zsh Reference Card][7] and the [zsh-lovers][8] man page are indispensable.
 
-License
--------
+## License
 
 This project is licensed under the MIT License.
 
-[1]: http://www.zsh.org
-[2]: http://i.imgur.com/nrGV6pg.png "sorin theme"
-[3]: http://git-scm.com
+[1]: https://www.zsh.org
+[2]: https://i.imgur.com/nrGV6pg.png "sorin theme"
+[3]: https://git-scm.com
 [4]: https://github.com
-[5]: http://gitimmersion.com
+[5]: https://gitimmersion.com
 [6]: https://git.github.io/git-reference/
 [7]: http://www.bash2zsh.com/zsh_refcard/refcard.pdf
-[8]: http://grml.org/zsh/zsh-lovers.html
+[8]: https://grml.org/zsh/zsh-lovers.html

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,206 +1,166 @@
-Modules
-=======
+# Modules
 
-Load modules in *zpreztorc*. The order matters.
+Load modules in *~/.zpreztorc*. The order matters.
 
 ```sh
 zstyle ':prezto:load' pmodule 'environment' 'terminal'
 ```
 
-Archive
--------
+## Archive
 
 Provides functions to list and extract archives.
 
-Autosuggestions
----------------
+## Autosuggestions
 
 Integrates zsh-autosuggestions into Prezto.
 
-Command-Not-Found
------------------
+## Command-Not-Found
 
 Loads the command-not-found tool on macOS or Debian-based distributions.
 
-Completion
-----------
+## Completion
 
-Loads and configures tab completion and provides additional completions from
-the zsh-completions project.
+Loads and configures <kbd>TAB</kbd> completion and provides additional
+completions from the zsh-completions project.
 
-Directory
----------
+## Directory
 
 Sets directory options and defines directory aliases.
 
-DNF
----
+## DNF
 
-Defines dnf aliases.
+Defines *dnf* aliases.
 
-Dpkg
-----
+## Dpkg
 
-Defines dpkg aliases and functions.
+Defines *dpkg* aliases and functions.
 
-Editor
-------
+## Editor
 
 Sets key bindings.
 
-Emacs
------
+## Emacs
 
 Enables Emacs dependency management.
 
-Environment
------------
+## Environment
 
 Sets general shell options and defines environment variables.
 
-Fasd
-----
+## Fasd
 
 Maintains a frequently used file and directory list for fast access.
 
-Git
----
+## Git
 
 Enhances the Git distributed version control system by providing aliases,
 functions and by exposing repository status information to prompts.
 
-GNU Utility
------------
+## GNU Utility
 
 Provides for the interactive use of GNU utilities on non-GNU systems.
 
-GPG
----
+## GPG
 
 Provides for an easier use of GPG by setting up gpg-agent.
 
-Haskell
--------
+## Haskell
 
 Enables local Haskell package installation.
 
-Helper
-------
+## Helper
 
 Provides helper functions for developing modules.
 
-History
--------
+## History
 
 Sets history options and defines history aliases.
 
-History Substring Search
-------------------------
+## History Substring Search
 
 Integrates zsh-history-substring-search into Prezto.
 
-Homebrew
---------
+## Homebrew
 
 Defines Homebrew aliases.
 
-MacPorts
---------
+## MacPorts
 
 Defines MacPorts aliases and adds MacPorts directories to path variables.
 
-Node.js
--------
+## Node.js
 
 Provides utility functions for Node.js and loads npm completion.
 
-OCaml
------
+## OCaml
 
 Initializes OCaml package management.
 
-OSX
----
+## OSX
 
 Defines macOS aliases and functions.
 
-Pacman
-------
+## Pacman
 
 Provides aliases and functions for the Pacman package manager and frontends.
 
-Perl
-----
+## Perl
 
 Enables local Perl module installation on macOS and defines alises.
 
-Prompt
-------
+## Prompt
 
 Loads prompt themes.
 
-Python
-------
+## Python
 
 Enables local Python and local Python package installation.
 
-Ruby on Rails
--------------
+## Ruby on Rails
 
 Defines Ruby on Rails aliases.
 
-Rsync
------
+## Rsync
 
 Defines rsync aliases.
 
-Ruby
-----
+## Ruby
 
 Configures Ruby local gem installation, loads version managers, and defines
 aliases.
 
-GNU Screen
-----------
+## GNU Screen
 
 Defines GNU Screen aliases and provides for auto launching it at start-up.
 
-Spectrum
---------
+## Spectrum
 
 Provides for easier use of 256 colors and effects.
 
-SSH
----
+## SSH
 
 Provides for an easier use of SSH by setting up ssh-agent.
 
-Syntax Highlighting
--------------------
+## Syntax Highlighting
 
 Integrates zsh-syntax-highlighting into Prezto.
 
-Terminal
---------
+## Terminal
 
 Sets terminal window and tab titles.
 
-Tmux
-----
+## Tmux
 
 Defines tmux aliases and provides for auto launching it at start-up.
 
-Utility
--------
+## Utility
 
 Defines general aliases and functions.
 
-Wake-on-LAN
------------
+## Wake-on-LAN
 
 This module provides a wrapper around the wakeonlan tool.
 
-Yum
----
+## Yum
 
 Defines yum aliases.

--- a/modules/archive/README.md
+++ b/modules/archive/README.md
@@ -1,52 +1,47 @@
-Archive
-=======
+# Archive
 
 Provides functions to create, list, and extract archives.
 
-Functions
----------
+## Functions
 
-  - `archive` creates an archive based on the provided archive name.
-  - `lsarchive` lists the contents of one or more archives.
-  - `unarchive` extracts the contents of one or more archives.
+- `archive` creates an archive based on the provided archive name.
+- `lsarchive` lists the contents of one or more archives.
+- `unarchive` extracts the contents of one or more archives.
 
-Supported Formats
------------------
+## Supported Formats
 
 The following archive formats are supported when the required utilities are
 installed:
 
-  - *.tar.gz*, *.tgz* require `tar` (optionally `pigz`).
-  - *.tar.bz2*, *.tbz* require `tar` (optionally `pbzip2`).
-  - *.tar.xz*, *.txz* require `tar` with *xz* support.
-  - *.tar.zma*, *.tlz* require `tar` with *lzma* support.
-  - *.tar* requires `tar`.
-  - *.gz* requires `gunzip`.
-  - *.bz2* requires `bunzip2`.
-  - *.xz* requires `unxz`.
-  - *.lzma* requires `unlzma`.
-  - *.Z* requires `uncompress`.
-  - *.zip*, *.jar* requires `unzip`.
-  - *.rar* requires `rar` (needed for `archive` support), `unrar` or `lsar` and `unar`.
-  - *.7z* requires `7za`.
-  - *.deb* requires `ar`, `tar`.
+- *.tar.gz*, *.tgz* require `tar` (optionally `pigz`).
+- *.tar.bz2*, *.tbz* require `tar` (optionally `pbzip2`).
+- *.tar.xz*, *.txz* require `tar` with *xz* support.
+- *.tar.zma*, *.tlz* require `tar` with *lzma* support.
+- *.tar* requires `tar`.
+- *.gz* requires `gunzip`.
+- *.bz2* requires `bunzip2`.
+- *.xz* requires `unxz`.
+- *.lzma* requires `unlzma`.
+- *.Z* requires `uncompress`.
+- *.zip*, *.jar* requires `unzip`.
+- *.rar* requires `rar` (needed for `archive` support), `unrar` or `lsar` and `unar`.
+- *.7z* requires `7za`.
+- *.deb* requires `ar`, `tar`.
 
 Additionally, if `pigz` and/or `pbzip2` are installed, `archive` will use them
 over their traditional counterparts, `gzip` and `bzip2` respectively, to take
 full advantage of all available CPU cores for compression.
 
-Alternatives
-------------
+## Alternatives
 
 Specifically on macOS, [The Unarchiver][1] provides a similar command line tool
 which doesn't depend on a number of other programs being installed.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Matt Hamilton](https://github.com/Eriner)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Matt Hamilton](https://github.com/Eriner)
 
 [1]: https://theunarchiver.com/command-line

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -1,5 +1,4 @@
-Autosuggestions
-===============
+# Autosuggestions
 
 Integrates [zsh-autosuggestions][1] into Prezto, which implements the
 [Fish shell][2]'s autosuggestions feature, where the user can type in any part
@@ -13,15 +12,13 @@ If this module is used in conjunction with the *history-substring-search*
 module, this module must be loaded **after** the *history-substring-search*
 module.
 
-Contributors
-------------
+## Contributors
 
 New features and bug fixes should be submitted to the [zsh-autosuggestions][1]
 project according to its rules and regulations. This module will be synchronized
 against it.
 
-Settings
---------
+## Settings
 
 ### Highlighting
 
@@ -29,33 +26,31 @@ If colors are enabled, *autosuggestions* will automatically highlight
 positive results.
 
 To enable highlighting for this module only, add the following line to
-*zpreztorc*:
+*~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:autosuggestions' color 'yes'
 ```
 
-To set the query found color, add the following line to *zpreztorc*:
+To set the query found color, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:autosuggestions:color' found ''
 ```
 
-Troubleshooting
----------------
+## Troubleshooting
 
 ### Autosuggestions from previous sessions don't show up
 
 For autosuggestions from previous shell sessions to work, please make sure you
 also have the `history` module enabled.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/tarruda/zsh-autosuggestions
-[2]: http://fishshell.com
+[2]: https://fishshell.com
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -1,9 +1,8 @@
-Command-Not-Found
-=================
+# Command-Not-Found
 
-When you try to use a command that is not available locally, searches
-the package manager for a package offering that command and suggests
-the proper install command.
+When you try to use a command that is not available locally, searches the
+package manager for a package offering that command and suggests the proper
+install command.
 
 Debian and Arch Linux based distributions use the [`command-not-found`][1] tool.
 
@@ -11,14 +10,12 @@ macOS uses Homebrew's [`command-not-found` clone][2]. Note that unless you have
 a recent version of Homebrew installed, you might also need to tap the
 `command-not-found` Homebrew repository [following the instructions][3].
 
-
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][4].*
 
-  - [Joseph Booker](https://github.com/sargas)
-  - [Indrajit Raychaudhuri](https://github.com/indrajitr)
+- [Joseph Booker](https://github.com/sargas)
+- [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
 [1]: https://code.launchpad.net/command-not-found
 [2]: https://github.com/Homebrew/homebrew-command-not-found

--- a/modules/completion/README.md
+++ b/modules/completion/README.md
@@ -1,31 +1,29 @@
-Completion
-==========
+# Completion
 
-Loads and configures tab completion and provides additional completions from
-the [zsh-completions][1] project.
+Loads and configures <kbd>TAB</kbd> completion and provides additional
+completions from the [zsh-completions][1] project.
 
 This module must be loaded **after** the *utility* module.
 
-Options
--------
+## Options
 
-  - `COMPLETE_IN_WORD` complete from both ends of a word.
-  - `ALWAYS_TO_END` move cursor to the end of a completed word.
-  - `PATH_DIRS` perform path search even on command names with slashes.
-  - `AUTO_MENU` show completion menu on a successive tab press.
-  - `AUTO_LIST` automatically list choices on ambiguous completion.
-  - `AUTO_PARAM_SLASH` if completed parameter is a directory, add a trailing slash.
-  - `EXTENDED_GLOB` needed for file modification glob modifiers with compinit.
-  - `MENU_COMPLETE` do not autoselect the first completion entry.
-  - `FLOW_CONTROL` disable start/stop characters in shell editor.
+- `COMPLETE_IN_WORD` complete from both ends of a word.
+- `ALWAYS_TO_END` move cursor to the end of a completed word.
+- `PATH_DIRS` perform path search even on command names with slashes.
+- `AUTO_MENU` show completion menu on a successive <kbd>TAB</kbd> press.
+- `AUTO_LIST` automatically list choices on ambiguous completion.
+- `AUTO_PARAM_SLASH` if completed parameter is a directory, add a trailing
+  slash (`/`).
+- `EXTENDED_GLOB` needed for file modification glob modifiers with *compinit*.
+- `MENU_COMPLETE` do not autoselect the first completion entry.
+- `FLOW_CONTROL` disable start/stop characters in shell editor.
 
-Settings
---------
+## Settings
 
 ### Ignore */etc/hosts* Entries
 
 To ignore certain entries from static */etc/hosts* for host completion, add the
-following lines in *zpreztorc* with the IP addresses of the hosts as they
+following lines in *~/.zpreztorc* with the IP addresses of the hosts as they
 appear in */etc/hosts*. Both IP address and the corresponding hostname will be
 ignored during host completion. However, some of the entries ignored from
 */etc/hosts* still might appear during completion because of their presence in
@@ -36,18 +34,16 @@ zstyle ':prezto:module:completion:*:hosts' etc-host-ignores \
   '0.0.0.0' '127.0.0.1'
 ```
 
-Contributors
-------------
+## Contributors
 
-Completions should be submitted to the [zsh-completions][1] project according
-to its rules and regulations. This module will be synchronized against it.
+Completions should be submitted to the [zsh-completions][1] project according to
+its rules and regulations. This module will be synchronized against it.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-completions
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/directory/README.md
+++ b/modules/directory/README.md
@@ -1,34 +1,30 @@
-Directory
-=========
+# Directory
 
 Sets directory options and defines directory aliases.
 
-Options
--------
+## Options
 
-  - `AUTO_CD` auto changes to a directory without typing `cd`.
-  - `AUTO_PUSHD` pushes the old directory onto the stack on `cd`.
-  - `PUSHD_IGNORE_DUPS` does not store duplicates in the stack.
-  - `PUSHD_SILENT` does not print the directory stack after `pushd` or `popd`.
-  - `PUSHD_TO_HOME` pushes to the home directory when no argument is given.
-  - `CDABLE_VARS` changes directory to a path stored in a variable.
-  - `MULTIOS` writes to multiple descriptors.
-  - `EXTENDED_GLOB` uses extended globbing syntax.
-  - `CLOBBER` does not overwrite existing files with `>` and `>>`. Use `>!` and
-    `>>!` to bypass.
+- `AUTO_CD` auto changes to a directory without typing `cd`.
+- `AUTO_PUSHD` pushes the old directory onto the stack on `cd`.
+- `PUSHD_IGNORE_DUPS` does not store duplicates in the stack.
+- `PUSHD_SILENT` does not print the directory stack after `pushd` or `popd`.
+- `PUSHD_TO_HOME` pushes to the home directory when no argument is given.
+- `CDABLE_VARS` changes directory to a path stored in a variable.
+- `MULTIOS` writes to multiple descriptors.
+- `EXTENDED_GLOB` uses extended globbing syntax.
+- `CLOBBER` does not overwrite existing files with `>` and `>>`. Use `>!` and
+  `>>!` to bypass.
 
-Aliases
--------
+## Aliases
 
-  - `d` prints the contents of the directory stack.
-  - `1 ... 9` changes the directory to the **n** previous one.
+- `d` prints the contents of the directory stack.
+- `1 ... 9` changes the directory to the **n** previous one.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [James Cox](https://github.com/imajes)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [James Cox](https://github.com/imajes)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/dnf/README.md
+++ b/modules/dnf/README.md
@@ -1,29 +1,25 @@
-DNF
-===
+# DNF
 
 Defines [dnf][1] aliases.
 
-Aliases
--------
+## Aliases
 
-  - `dnfc` removes package(s) and leaves.
-  - `dnfi` installs package(s).
-  - `dnfh` displays history.
-  - `dnfl` lists packages.
-  - `dnfL` lists installed packages.
-  - `dnfq` displays package information.
-  - `dnfr` removes package(s).
-  - `dnfs` searches for a package.
-  - `dnfu` updates packages.
-  - `dnfU` upgrades packages.
+- `dnfc` removes package(s) and leaves.
+- `dnfi` installs package(s).
+- `dnfh` displays history.
+- `dnfl` lists packages.
+- `dnfL` lists installed packages.
+- `dnfq` displays package information.
+- `dnfr` removes package(s).
+- `dnfs` searches for a package.
+- `dnfu` updates packages.
+- `dnfU` upgrades packages.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://fedoraproject.org/wiki/Features/DNF
 [2]: https://github.com/sorin-ionescu/prezto/issues
-

--- a/modules/docker/README.md
+++ b/modules/docker/README.md
@@ -1,4 +1,4 @@
-# ZSH Docker Aliases
+# Docker
 
 Defines [Docker][1] aliases and functions.
 
@@ -21,14 +21,15 @@ Defines [Docker][1] aliases and functions.
 - `dkli` Log in to a Docker registry
 - `dklo` Log out from a Docker registry
 - `dkls` is alias for `dkps`
-- `dkp` Pause all processes within one or more containers<Paste>
+- `dkp` Pause all processes within one or more containers
 - `dkP` Unpause all processes within one or more containers
 - `dkpl` Pull an image or a repository from a registry
 - `dkph` Push an image or a repository to a registry
 - `dkps` List containers
 - `dkpsa` List all containers (default lists just running)
 - `dkr` Run a command in a new container
-- `dkR` Run an interactive command in a new container and automatically remove the container when it exits
+- `dkR` Run an interactive command in a new container and automatically remove
+  the container when it exits
 - `dkRe` like `dkR` and set entry point to `/bin/bash`
 - `dkrm` Remove one or more containers
 - `dkrmi` Remove one or more images
@@ -39,13 +40,14 @@ Defines [Docker][1] aliases and functions.
 - `dks` Start one or more stopped containers
 - `dkS` Restart a container
 - `dkss` Display a live stream of container(s) resource usage statistics
-- `dksv` Save one or more images to a tar archive (streamed to STDOUT by default)
+- `dksv` Save one or more images to a tar archive (streamed to STDOUT by
+  default)
 - `dkt` Tag an image into a repository
 - `dktop` Display the running processes of a container
 - `dkup` Update configuration of one or more containers
 - `dkV` Manage Docker volumes
 - `dkv` Show the Docker version information
-- `dkw` Block until a container stops, then print its exit code<Paste>
+- `dkw` Block until a container stops, then print its exit code
 - `dkx` Stop a running container
 
 #### container (C)
@@ -65,7 +67,8 @@ Defines [Docker][1] aliases and functions.
 - `dkCS` Restart one or more containers
 - `dkCrm` Remove one or more containers
 - `dkCr` Run a command in a new container
-- `dkCR` Run an interactive command in a new container and automatically remove the container when it exits
+- `dkCR` Run an interactive command in a new container and automatically remove
+  the container when it exits
 - `dkCRe` like `dkCR` and set entry point to `/bin/bash`
 - `dkCs` Start one or more stopped containers
 - `dkCss` Display a live stream of container(s) resource usage statistics
@@ -87,7 +90,8 @@ Defines [Docker][1] aliases and functions.
 - `dkIpl` Pull an image or a repository from a registry
 - `dkIph` Push an image or a repository to a registry
 - `dkIrm` Remove one or more images
-- `dkIsv` Save one or more images to a tar archive (streamed to STDOUT by default)
+- `dkIsv` Save one or more images to a tar archive (streamed to STDOUT by
+  default)
 - `dkIt` Tag an image into a repository
 
 #### volume (V)

--- a/modules/dpkg/README.md
+++ b/modules/dpkg/README.md
@@ -1,10 +1,8 @@
-Dpkg
-====
+# Dpkg
 
-Defines [dpkg][1] aliases and functions.
+Defines [*dpkg*][1] aliases and functions.
 
-Aliases
--------
+## Aliases
 
 - `debc` cleans the cache.
 - `debf` displays a file's package.
@@ -20,22 +18,20 @@ Aliases
 - `deb-kclean` removes all kernel images and headers, except for the ones in
   use.
 
-Functions
----------
+## Functions
 
-- `deb-clone` generates a script that can be used to duplicate a dpkg-based
+- `deb-clone` generates a script that can be used to duplicate a `dpkg`-based
   system.
-- `deb-history` displays dpkg history.
-- `deb-kbuild` makes a dpkg Linux kernel package.
+- `deb-history` displays `dpkg` history.
+- `deb-kbuild` makes a `dpkg` Linux kernel package.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Daniel Bolton](https://github.com/dbb)
-  - [Benjamin Boudreau](https://github.com/dreur)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Daniel Bolton](https://github.com/dbb)
+- [Benjamin Boudreau](https://github.com/dreur)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://wiki.debian.org/Teams/Dpkg
+[1]: https://wiki.debian.org/Teams/Dpkg
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -1,25 +1,21 @@
-Editor
-======
+# Editor
 
 Sets editor specific key bindings options and variables.
 
-Options
--------
+## Options
 
-  - `BEEP` beep on error in line editor.
+- `BEEP` beep on error in line editor.
 
-Variables
----------
+## Variables
 
-  - `WORDCHARS` treat a given set of characters as part of a word.
+- `WORDCHARS` treat a given set of characters as part of a word.
 
-Settings
---------
+## Settings
 
 ### Key bindings
 
-To enable key bindings, add the following to *zpreztorc*, and replace 'bindings'
-with 'emacs' or 'vi'.
+To enable key bindings, add the following to *~/.zpreztorc*, and replace
+'bindings' with 'emacs' or 'vi'.
 
 ```sh
 zstyle ':prezto:module:editor' key-bindings 'bindings'
@@ -28,7 +24,7 @@ zstyle ':prezto:module:editor' key-bindings 'bindings'
 ### Dot Expansion
 
 To enable the auto conversion of .... to ../.., add the following to
-*zpreztorc*.
+*~/.zpreztorc*.
 
 ```sh
 zstyle ':prezto:module:editor' dot-expansion 'yes'
@@ -37,14 +33,13 @@ zstyle ':prezto:module:editor' dot-expansion 'yes'
 ### PS Context
 
 To enable the prompt context to be set, add the following to your
-*zpreztorc*.
+*~/.zpreztorc*.
 
 ```sh
 zstyle ':prezto:module:editor' ps-context 'yes'
 ```
 
-Theming
--------
+## Theming
 
 To indicate when the editor is in the primary keymap (emacs or viins), add
 the following to your `theme_prompt_setup` function.
@@ -84,8 +79,7 @@ zstyle ':prezto:module:editor:info:completing' format '...'
 Then add `$editor_info[context]`, where context is *keymap*, *insert*, or
 *overwrite*, to `$PROMPT` or `$RPROMPT`.
 
-Convenience Functions
----------------------
+## Convenience Functions
 
 ### bindkey-all
 
@@ -99,11 +93,10 @@ It will also pass through arguments so you can use bindkey-all to set bindings
 for all keymaps at once. If provided arguments it will *not* print out the
 names of each of the keymaps, and just run the command for each keymap.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/emacs/README.md
+++ b/modules/emacs/README.md
@@ -1,10 +1,8 @@
-Emacs
-=====
+# Emacs
 
 Enables Emacs dependency management.
 
-Dependency management
----------------------
+## Dependency management
 
 [Carton][1] installs and manages Emacs packages for Emacs package development
 and Emacs configuration.
@@ -12,22 +10,20 @@ and Emacs configuration.
 This module prepends the Carton directory to the path variable to enable the
 execution of `carton`.
 
-Aliases
--------
+## Aliases
 
 ### Carton
 
-  - `cai` installs dependencies.
-  - `cau` updates dependencies.
-  - `caI` initializes the current directory for dependency management.
-  - `cae` executes a command which correct dependencies.
+- `cai` installs dependencies.
+- `cau` updates dependencies.
+- `caI` initializes the current directory for dependency management.
+- `cae` executes a command which correct dependencies.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sebastian Wiesner](https://github.com/lunaryorn)
+- [Sebastian Wiesner](https://github.com/lunaryorn)
 
 [1]: https://github.com/rejeep/carton
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/environment/README.md
+++ b/modules/environment/README.md
@@ -1,56 +1,51 @@
-Environment
-===========
+# Environment
 
 Sets general shell options and defines environment variables.
 
 This module must be loaded first.
 
-Contributors
-------------
+## Contributors
 
 This module **MUST NOT** rely on any command not built in Zsh.
 
 Non-interactive environment variables should be defined in [`zshenv`][1].
 
-Options
--------
+## Options
 
 ### General
 
-  - `COMBINING_CHARS` combine zero-length punctuation characters (accents) with
-    the base character.
-  - `INTERACTIVE_COMMENTS` enable comments in interactive shell.
-  - `RC_QUOTES` allow 'Henry''s Garage' instead of 'Henry'\''s Garage'.
-  - `MAIL_WARNING` don't print a warning message if a mail file has been accessed.
+- `COMBINING_CHARS` combine zero-length punctuation characters (accents) with
+  the base character.
+- `INTERACTIVE_COMMENTS` enable comments in interactive shell.
+- `RC_QUOTES` allow 'Henry''s Garage' instead of 'Henry'\''s Garage'.
+- `MAIL_WARNING` don't print a warning message if a mail file has been accessed.
 
 ### Jobs
 
-  - `LONG_LIST_JOBS` list jobs in the long format by default.
-  - `AUTO_RESUME` attempt to resume existing job before creating a new process.
-  - `NOTIFY` report status of background jobs immediately.
-  - `BG_NICE` don't run all background jobs at a lower priority.
-  - `HUP` don't kill jobs on shell exit.
-  - `CHECK_JOBS` don't report on jobs when shell exit.
+- `LONG_LIST_JOBS` list jobs in the long format by default.
+- `AUTO_RESUME` attempt to resume existing job before creating a new process.
+- `NOTIFY` report status of background jobs immediately.
+- `BG_NICE` don't run all background jobs at a lower priority.
+- `HUP` don't kill jobs on shell exit.
+- `CHECK_JOBS` don't report on jobs when shell exit.
 
-Variables
----------
+## Variables
 
 ### Termcap
 
-  - `LESS_TERMCAP_mb` begins blinking.
-  - `LESS_TERMCAP_md` begins bold.
-  - `LESS_TERMCAP_me` ends mode.
-  - `LESS_TERMCAP_se` ends standout-mode.
-  - `LESS_TERMCAP_so` begins standout-mode.
-  - `LESS_TERMCAP_ue` ends underline.
-  - `LESS_TERMCAP_us` begins underline.
+- `LESS_TERMCAP_mb` begins blinking.
+- `LESS_TERMCAP_md` begins bold.
+- `LESS_TERMCAP_me` ends mode.
+- `LESS_TERMCAP_se` ends standout-mode.
+- `LESS_TERMCAP_so` begins standout-mode.
+- `LESS_TERMCAP_ue` ends underline.
+- `LESS_TERMCAP_us` begins underline.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zshenv
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -1,5 +1,4 @@
-Fasd
-====
+# Fasd
 
 [Fasd][1] is a command-line productivity booster, inspired by tools like
 [autojump][2], [z][3] and [v][4], it offers quick access to files and
@@ -12,30 +11,27 @@ module.
 The Prezto Fasd configuration differs from the default. The default aliases have
 been disabled.
 
-Installation
-------------
+## Installation
 
-`fasd` is bundled with prezto as a git submodule. Alternatively, you can manually install `fasd`.
-If a manual install is found, it will be used instead of the bundled version.
+`fasd` is bundled with prezto as a git submodule. Alternatively, you can
+manually install `fasd`. If a manual installation is found, it will be used
+instead of the bundled version.
 
-Aliases
--------
+## Aliases
 
-  - `j` changes the current working directory interactively.
+- `j` changes the current working directory interactively.
 
-Completion
-----------
+## Completion
 
 Type `,`, `f,`, `d,` in front of a comma-separated query or type `,,`,  `,,f`,
-`,,d` at the end of a comma-separated query then hit <kbd>tab</kbd>.
+`,,d` at the end of a comma-separated query then hit <kbd>TAB</kbd>.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][5].*
 
-  - [Wei Dai](https://github.com/clvv)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Wei Dai](https://github.com/clvv)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/clvv/fasd
 [2]: https://github.com/joelthelion/autojump

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -1,13 +1,11 @@
-Git
-===
+# Git
 
 Enhances the [Git][1] distributed version control system by providing aliases,
 functions and by exposing repository status information to prompts.
 
 Git **1.7.2** is the [minimum required version][7].
 
-Settings
---------
+## Settings
 
 ### Log
 
@@ -30,8 +28,7 @@ zstyle ':prezto:module:git:status:ignore' submodules 'all'
 
 This setting affects all aliases and functions that call `git-status`.
 
-Aliases
--------
+## Aliases
 
 Aliases are enabled by default. You can disable them with:
 
@@ -41,288 +38,290 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 
 ### Git
 
-  - `g` is short for `git`.
+- `g` is short for `git`.
 
-### Branch
+### Branch (b)
 
-  - `gb` lists, creates, renames, and deletes branches.
-  - `gbc` creates a new branch.
-  - `gbl` lists branches and their commits. (also `gbv`)
-  - `gbL` lists all local and remote branches and their commits.
-  - `gbr` renames a branch. (also `gbm`)
-  - `gbR` renames a branch even if the new branch name already exists. (also
-    `gbM`)
-  - `gbs` lists branches and their commits with ancestry graphs.
-  - `gbS` lists local and remote branches and their commits with ancestry
-    graphs.
-  - `gbV` lists branches with more verbose information about their commits.
-  - `gbx` deletes a branch. (also `gbd`)
-  - `gbX` deletes a branch irrespective of its merged status. (also `gbD`)
+- `gb` lists, creates, renames, and deletes branches.
+- `gbc` creates a new branch.
+- `gbl` lists branches and their commits. (also `gbv`)
+- `gbL` lists all local and remote branches and their commits.
+- `gbr` renames a branch. (also `gbm`)
+- `gbR` renames a branch even if the new branch name already exists. (also
+  `gbM`)
+- `gbs` lists branches and their commits with ancestry graphs.
+- `gbS` lists local and remote branches and their commits with ancestry graphs.
+- `gbV` lists branches with more verbose information about their commits.
+- `gbx` deletes a branch. (also `gbd`)
+- `gbX` deletes a branch irrespective of its merged status. (also `gbD`)
 
+### Commit (c)
 
-### Commit
+- `gc` records changes to the repository.
+- `gca` stages all modified and deleted files.
+- `gcm` records changes to the repository with the given message.
+- `gcS` records changes to the repository. (Signed)
+- `gcSa` stages all modified and deleted files. (Signed)
+- `gcSm` records changes to the repository with the given message. (Signed)
+- `gcam` stages all modified and deleted files, and records changes to the
+  repository with the given message.
+- `gco` checks out a branch or paths to work tree.
+- `gcO` checks out hunks from the index or the tree interactively.
+- `gcf` amends the tip of the current branch using the same log message as
+  *HEAD*.
+- `gcSf` amends the tip of the current branch using the same log message as
+  *HEAD*. (Signed)
+- `gcF` amends the tip of the current branch.
+- `gcSF` amends the tip of the current branch. (Signed)
+- `gcp` applies changes introduced by existing commits.
+- `gcP` applies changes introduced by existing commits without committing.
+- `gcr` reverts existing commits by reverting patches and recording new commits.
+- `gcR` removes the *HEAD* commit.
+- `gcs` displays various types of objects.
+- `gcsS` displays commits with GPG signature.
+- `gcl` lists lost commits.
+- `gcy` displays commits yet to be applied to upstream in the short format.
+- `gcY` displays commits yet to be applied to upstream.
 
-  - `gc` records changes to the repository.
-  - `gca` stages all modified and deleted files.
-  - `gcm` records changes to the repository with the given message.
-  - `gcS` records changes to the repository. (Signed)
-  - `gcSa` stages all modified and deleted files. (Signed)
-  - `gcSm` records changes to the repository with the given message. (Signed)
-  - `gcam` stages all modified and deleted files, and records changes to the repository with the given message.
-  - `gco` checks out a branch or paths to work tree.
-  - `gcO` checks out hunks from the index or the tree interactively.
-  - `gcf` amends the tip of the current branch using the same log message as *HEAD*.
-  - `gcSf` amends the tip of the current branch using the same log message as *HEAD*. (Signed)
-  - `gcF` amends the tip of the current branch.
-  - `gcSF` amends the tip of the current branch. (Signed)
-  - `gcp` applies changes introduced by existing commits.
-  - `gcP` applies changes introduced by existing commits without committing.
-  - `gcr` reverts existing commits by reverting patches and recording new
-     commits.
-  - `gcR` removes the *HEAD* commit.
-  - `gcs` displays various types of objects.
-  - `gcsS` displays commits with GPG signature.
-  - `gcl` lists lost commits.
-  - `gcy` displays commits yet to be applied to upstream in the short format.
-  - `gcY` displays commits yet to be applied to upstream.
+### Conflict (C)
 
-### Conflict
+- `gCl` lists unmerged files.
+- `gCa` adds unmerged file contents to the index.
+- `gCe` executes merge-tool on all unmerged file.
+- `gCo` checks out our changes for unmerged paths.
+- `gCO` checks out our changes for all unmerged paths.
+- `gCt` checks out their changes for unmerged paths.
+- `gCT` checks out their changes for all unmerged paths.
 
-  - `gCl` lists unmerged files.
-  - `gCa` adds unmerged file contents to the index.
-  - `gCe` executes merge-tool on all unmerged file.
-  - `gCo` checks out our changes for unmerged paths.
-  - `gCO` checks out our changes for all unmerged paths.
-  - `gCt` checks out their changes for unmerged paths.
-  - `gCT` checks out their changes for all unmerged paths.
+### Data (d)
 
-### Data
+- `gd` displays information about files in the index and the work tree.
+- `gdc` lists cached files.
+- `gdx` lists deleted files.
+- `gdm` lists modified files.
+- `gdu` lists untracked files.
+- `gdk` lists killed files.
+- `gdi` lists ignored files.
 
-  - `gd` displays information about files in the index and the work tree.
-  - `gdc` lists cached files.
-  - `gdx` lists deleted files.
-  - `gdm` lists modified files.
-  - `gdu` lists untracked files.
-  - `gdk` lists killed files.
-  - `gdi` lists ignored files.
+### Fetch (f)
 
-### Fetch
+- `gf` downloads objects and references from another repository.
+- `gfa` downloads objects and references from all remote repositories.
+- `gfc` clones a repository into a new directory.
+- `gfcr` clones a repository into a new directory including all submodules.
+- `gfm` fetches from and merges with another repository or local branch.
+- `gfr` fetches from and rebases on another repository or local branch.
 
-  - `gf` downloads objects and references from another repository.
-  - `gfa` downloads objects and references from all remote repositories.
-  - `gfc` clones a repository into a new directory.
-  - `gfcr` clones a repository into a new directory including all submodules.
-  - `gfm` fetches from and merges with another repository or local branch.
-  - `gfr` fetches from and rebases on another repository or local branch.
+### Flow (F)
 
-### Flow
+- `gFi` is short for `git flow init`
 
-  - `gFi` is short for `git flow init`
+#### Feature (Ff)
 
-#### Feature
+- `gFf` is short for `git flow feature`
+- `gFfl` is short for `git flow feature list`
+- `gFfs` is short for `git flow feature start`
+- `gFff` is short for `git flow feature finish`
+- `gFfp` is short for `git flow feature publish`
+- `gFft` is short for `git flow feature track`
+- `gFfd` is short for `git flow feature diff`
+- `gFfr` is short for `git flow feature rebase`
+- `gFfc` is short for `git flow feature checkout`
+- `gFfm` is short for `git flow feature pull`
+- `gFfx` is short for `git flow feature delete`
 
-  - `gFf` is short for `git flow feature`
-  - `gFfl` is short for `git flow feature list`
-  - `gFfs` is short for `git flow feature start`
-  - `gFff` is short for `git flow feature finish`
-  - `gFfp` is short for `git flow feature publish`
-  - `gFft` is short for `git flow feature track`
-  - `gFfd` is short for `git flow feature diff`
-  - `gFfr` is short for `git flow feature rebase`
-  - `gFfc` is short for `git flow feature checkout`
-  - `gFfm` is short for `git flow feature pull`
-  - `gFfx` is short for `git flow feature delete`
+#### Bugfix (Fb)
 
-#### Bugfix
+- `gFb` is short for `git flow bugfix`
+- `gFbl` is short for `git flow bugfix list`
+- `gFbs` is short for `git flow bugfix start`
+- `gFbf` is short for `git flow bugfix finish`
+- `gFbp` is short for `git flow bugfix publish`
+- `gFbt` is short for `git flow bugfix track`
+- `gFbd` is short for `git flow bugfix diff`
+- `gFbr` is short for `git flow bugfix rebase`
+- `gFbc` is short for `git flow bugfix checkout`
+- `gFbm` is short for `git flow bugfix pull`
+- `gFbx` is short for `git flow bugfix delete`
 
-  - `gFb` is short for `git flow bugfix`
-  - `gFbl` is short for `git flow bugfix list`
-  - `gFbs` is short for `git flow bugfix start`
-  - `gFbf` is short for `git flow bugfix finish`
-  - `gFbp` is short for `git flow bugfix publish`
-  - `gFbt` is short for `git flow bugfix track`
-  - `gFbd` is short for `git flow bugfix diff`
-  - `gFbr` is short for `git flow bugfix rebase`
-  - `gFbc` is short for `git flow bugfix checkout`
-  - `gFbm` is short for `git flow bugfix pull`
-  - `gFbx` is short for `git flow bugfix delete`
+#### Release (Fl)
 
-#### Release
+- `gFl` is short for `git flow release`
+- `gFll` is short for `git flow release list`
+- `gFls` is short for `git flow release start`
+- `gFlf` is short for `git flow release finish`
+- `gFlp` is short for `git flow release publish`
+- `gFlt` is short for `git flow release track`
+- `gFld` is short for `git flow release diff`
+- `gFlr` is short for `git flow release rebase`
+- `gFlc` is short for `git flow release checkout`
+- `gFlm` is short for `git flow release pull`
+- `gFlx` is short for `git flow release delete`
 
-  - `gFl` is short for `git flow release`
-  - `gFll` is short for `git flow release list`
-  - `gFls` is short for `git flow release start`
-  - `gFlf` is short for `git flow release finish`
-  - `gFlp` is short for `git flow release publish`
-  - `gFlt` is short for `git flow release track`
-  - `gFld` is short for `git flow release diff`
-  - `gFlr` is short for `git flow release rebase`
-  - `gFlc` is short for `git flow release checkout`
-  - `gFlm` is short for `git flow release pull`
-  - `gFlx` is short for `git flow release delete`
+#### Hotfix (Fh)
 
-#### Hotfix
+- `gFh` is short for `git flow hotfix`
+- `gFhl` is short for `git flow hotfix list`
+- `gFhs` is short for `git flow hotfix start`
+- `gFhf` is short for `git flow hotfix finish`
+- `gFhp` is short for `git flow hotfix publish`
+- `gFht` is short for `git flow hotfix track`
+- `gFhd` is short for `git flow hotfix diff`
+- `gFhr` is short for `git flow hotfix rebase`
+- `gFhc` is short for `git flow hotfix checkout`
+- `gFhm` is short for `git flow hotfix pull`
+- `gFhx` is short for `git flow hotfix delete`
 
-  - `gFh` is short for `git flow hotfix`
-  - `gFhl` is short for `git flow hotfix list`
-  - `gFhs` is short for `git flow hotfix start`
-  - `gFhf` is short for `git flow hotfix finish`
-  - `gFhp` is short for `git flow hotfix publish`
-  - `gFht` is short for `git flow hotfix track`
-  - `gFhd` is short for `git flow hotfix diff`
-  - `gFhr` is short for `git flow hotfix rebase`
-  - `gFhc` is short for `git flow hotfix checkout`
-  - `gFhm` is short for `git flow hotfix pull`
-  - `gFhx` is short for `git flow hotfix delete`
+#### Support (Fs)
 
-#### Support
+- `gFs` is short for `git flow support`
+- `gFsl` is short for `git flow support list`
+- `gFss` is short for `git flow support start`
+- `gFsf` is short for `git flow support finish`
+- `gFsp` is short for `git flow support publish`
+- `gFst` is short for `git flow support track`
+- `gFsd` is short for `git flow support diff`
+- `gFsr` is short for `git flow support rebase`
+- `gFsc` is short for `git flow support checkout`
+- `gFsm` is short for `git flow support pull`
+- `gFsx` is short for `git flow support delete`
 
-  - `gFs` is short for `git flow support`
-  - `gFsl` is short for `git flow support list`
-  - `gFss` is short for `git flow support start`
-  - `gFsf` is short for `git flow support finish`
-  - `gFsp` is short for `git flow support publish`
-  - `gFst` is short for `git flow support track`
-  - `gFsd` is short for `git flow support diff`
-  - `gFsr` is short for `git flow support rebase`
-  - `gFsc` is short for `git flow support checkout`
-  - `gFsm` is short for `git flow support pull`
-  - `gFsx` is short for `git flow support delete`
+### Grep (g)
 
-### Grep
+- `gg` displays lines matching a pattern.
+- `ggi` displays lines matching a pattern ignoring case.
+- `ggl` lists files matching a pattern.
+- `ggL` lists files that are not matching a pattern.
+- `ggv` displays lines not matching a pattern.
+- `ggw` displays lines matching a pattern at word boundary.
 
-  - `gg` displays lines matching a pattern.
-  - `ggi` displays lines matching a pattern ignoring case.
-  - `ggl` lists files matching a pattern.
-  - `ggL` lists files that are not matching a pattern.
-  - `ggv` displays lines not matching a pattern.
-  - `ggw` displays lines matching a pattern at word boundary.
+### Index (i)
 
-### Index
+- `gia` adds file contents to the index.
+- `giA` adds file contents to the index interactively.
+- `giu` adds file contents to the index (updates only known files).
+- `gid` displays changes between the index and a named commit (diff).
+- `giD` displays changes between the index and a named commit (word diff).
+- `gii` temporarily ignore differences in a given file.
+- `giI` unignore differences in a given file.
+- `gir` resets the current HEAD to the specified state.
+- `giR` resets the current index interactively.
+- `gix` removes files/directories from the index (recursively).
+- `giX` removes files/directories from the index (recursively and forced).
 
-  - `gia` adds file contents to the index.
-  - `giA` adds file contents to the index interactively.
-  - `giu` adds file contents to the index (updates only known files).
-  - `gid` displays changes between the index and a named commit (diff).
-  - `giD` displays changes between the index and a named commit (word diff).
-  - `gii` temporarily ignore differences in a given file.
-  - `giI` unignore differences in a given file.
-  - `gir` resets the current HEAD to the specified state.
-  - `giR` resets the current index interactively.
-  - `gix` removes files/directories from the index (recursively).
-  - `giX` removes files/directories from the index (recursively and forced).
+### Log (l)
 
-### Log
+- `gl` displays the log.
+- `gls` displays the stats log.
+- `gld` displays the diff log.
+- `glo` displays the one line log.
+- `glg` displays the graph log.
+- `glb` displays the brief commit log.
+- `glc` displays the commit count for each contributor in descending order.
+- `glS` displays the log and checks the validity of signed commits.
 
-  - `gl` displays the log.
-  - `gls` displays the stats log.
-  - `gld` displays the diff log.
-  - `glo` displays the one line log.
-  - `glg` displays the graph log.
-  - `glb` displays the brief commit log.
-  - `glc` displays the commit count for each contributor in descending order.
-  - `glS` displays the log and checks the validity of signed commits.
+### Merge (m)
 
-### Merge
+- `gm` joins two or more development histories together.
+- `gmC` joins two or more development histories together but does not commit.
+- `gmF` joins two or more development histories together but does not commit
+  generating a merge commit even if the merge resolved as a fast-forward.
+- `gma` aborts the conflict resolution, and reconstructs the pre-merge state.
+- `gmt` runs the merge conflict resolution tools to resolve conflicts.
 
-  - `gm` joins two or more development histories together.
-  - `gmC` joins two or more development histories together but does not commit.
-  - `gmF` joins two or more development histories together but does not commit
-     generating a merge commit even if the merge resolved as a fast-forward.
-  - `gma` aborts the conflict resolution, and reconstructs the pre-merge state.
-  - `gmt` runs the merge conflict resolution tools to resolve conflicts.
+### Push (p)
 
-### Push
+- `gp` updates remote refs along with associated objects.
+- `gpf` forcefully updates remote refs along with associated objects using the
+  safer `--force-with-lease` option.
+- `gpF` forcefully updates remote refs along with associated objects using the
+  riskier `--force` option.
+- `gpa` updates remote branches along with associated objects.
+- `gpA` updates remote branches and tags along with associated objects.
+- `gpt` updates remote tags along with associated objects.
+- `gpc` updates remote refs along with associated objects and adds *origin* as
+  an upstream reference for the current branch.
+- `gpp` pulls and pushes from origin to origin.
 
-  - `gp` updates remote refs along with associated objects.
-  - `gpf` forcefully updates remote refs along with associated objects using the safer `--force-with-lease` option.
-  - `gpF` forcefully updates remote refs along with associated objects using the riskier `--force` option.
-  - `gpa` updates remote branches along with associated objects.
-  - `gpA` updates remote branches and tags along with associated objects.
-  - `gpt` updates remote tags along with associated objects.
-  - `gpc` updates remote refs along with associated objects and adds *origin*
-     as an upstream reference for the current branch.
-  - `gpp` pulls and pushes from origin to origin.
+### Rebase (r)
 
-### Rebase
+- `gr` forward-ports local commits to the updated upstream head.
+- `gra` aborts the rebase.
+- `grc` continues the rebase after merge conflicts are resolved.
+- `gri` makes a list of commits to be rebased and opens the editor.
+- `grs` skips the current patch.
 
-  - `gr` forward-ports local commits to the updated upstream head.
-  - `gra` aborts the rebase.
-  - `grc` continues the rebase after merge conflicts are resolved.
-  - `gri` makes a list of commits to be rebased and opens the editor.
-  - `grs` skips the current patch.
+### Remote (R)
 
-### Remote
+- `gR` manages tracked repositories.
+- `gRl` lists remote names and their URLs.
+- `gRa` adds a new remote.
+- `gRx` removes a remote.
+- `gRm` renames a remote.
+- `gRu` fetches remotes updates.
+- `gRp` prunes all stale remote tracking branches.
+- `gRs` displays information about a given remote.
+- `gRb` opens a remote on [GitHub][3] in the default browser.
 
-  - `gR` manages tracked repositories.
-  - `gRl` lists remote names and their URLs.
-  - `gRa` adds a new remote.
-  - `gRx` removes a remote.
-  - `gRm` renames a remote.
-  - `gRu` fetches remotes updates.
-  - `gRp` prunes all stale remote tracking branches.
-  - `gRs` displays information about a given remote.
-  - `gRb` opens a remote on [GitHub][3] in the default browser.
+### Stash (s)
 
-### Stash
+- `gs` stashes the changes of the dirty working directory.
+- `gsa` applies the changes recorded in a stash to the working directory.
+- `gsx` drops a stashed state.
+- `gsX` drops all the stashed states.
+- `gsl` lists stashed states.
+- `gsL` lists dropped stashed states.
+- `gsd` displays changes between the stash and its original parent.
+- `gsp` removes and applies a single stashed state from the stash list.
+- `gsr` recovers a given stashed state.
+- `gss` stashes the changes of the dirty working directory, including untracked.
+- `gsS` stashes the changes of the dirty working directory interactively.
+- `gsw` stashes the changes of the dirty working directory retaining the index.
 
-  - `gs` stashes the changes of the dirty working directory.
-  - `gsa` applies the changes recorded in a stash to the working directory.
-  - `gsx` drops a stashed state.
-  - `gsX` drops all the stashed states.
-  - `gsl` lists stashed states.
-  - `gsL` lists dropped stashed states.
-  - `gsd` displays changes between the stash and its original parent.
-  - `gsp` removes and applies a single stashed state from the stash list.
-  - `gsr` recovers a given stashed state.
-  - `gss` stashes the changes of the dirty working directory, including untracked.
-  - `gsS` stashes the changes of the dirty working directory interactively.
-  - `gsw` stashes the changes of the dirty working directory retaining the index.
+### Submodule (S)
 
-### Submodule
+- `gS` initializes, updates, or inspects submodules.
+- `gSa` adds given a repository as a submodule.
+- `gSf` evaluates a shell command in each of checked out submodules.
+- `gSi` initializes submodules.
+- `gSI` initializes and clones submodules recursively.
+- `gSl` lists the commits of all submodules.
+- `gSm` moves a submodule.
+- `gSs` synchronizes submodules' remote URL to the value specified in
+  *.gitmodules*.
+- `gSu` fetches and merges the latest changes for all submodule.
+- `gSx` removes a submodule.
 
-  - `gS` initializes, updates, or inspects submodules.
-  - `gSa` adds given a repository as a submodule.
-  - `gSf` evaluates a shell command in each of checked out submodules.
-  - `gSi` initializes submodules.
-  - `gSI` initializes and clones submodules recursively.
-  - `gSl` lists the commits of all submodules.
-  - `gSm` moves a submodule.
-  - `gSs` synchronizes submodules' remote URL to the value specified in
-    .gitmodules.
-  - `gSu` fetches and merges the latest changes for all submodule.
-  - `gSx` removes a submodule.
+### Tag (t)
 
-### Tag
+- `gt` lists tags or creates tag.
+- `gtl` lists tags matching pattern.
+- `gts` creates a signed tag.
+- `gtv` validate a signed tag.
 
-  - `gt` lists tags or creates tag.
-  - `gtl` lists tags matching pattern.
-  - `gts` creates a signed tag.
-  - `gtv` validate a signed tag.
+### Working directory (w)
 
-### Working directory
-
-  - `gws` displays working-tree status in the short format.
-  - `gwS` displays working-tree status.
-  - `gwd` displays changes between the working tree and the index (diff).
-  - `gwD` displays changes between the working tree and the index (word diff).
-  - `gwr` resets the current HEAD to the specified state, does not touch the
-     index nor the working tree.
-  - `gwR` resets the current HEAD, index and working tree to the specified state.
-  - `gwc` removes untracked files from the working tree (dry-run).
-  - `gwC` removes untracked files from the working tree.
-  - `gwx` removes files from the working tree and from the index recursively.
-  - `gwX` removes files from the working tree and from the index recursively and
-    forcefully.
+- `gws` displays working-tree status in the short format.
+- `gwS` displays working-tree status.
+- `gwd` displays changes between the working tree and the index (diff).
+- `gwD` displays changes between the working tree and the index (word diff).
+- `gwr` resets the current HEAD to the specified state, does not touch the
+  index nor the working tree.
+- `gwR` resets the current HEAD, index and working tree to the specified state.
+- `gwc` removes untracked files from the working tree (dry-run).
+- `gwC` removes untracked files from the working tree.
+- `gwx` removes files from the working tree and from the index recursively.
+- `gwX` removes files from the working tree and from the index recursively and
+  forcefully.
 
 ### Shadows
 
 The following aliases may shadow system commands:
 
-  - `gb` shadows the [GB][9].
-  - `gm` shadows the [Graphics Magick image processor][11].
-  - `gpt` shadows the [GUID partition table maintenance utility][4].
-  - `gs` shadows the [Ghostscript interpreter and previewer][5].
+- `gb` shadows the [GB][9].
+- `gm` shadows the [GraphicsMagick image processor][11].
+- `gpt` shadows the [GUID partition table maintenance utility][4].
+- `gs` shadows the [Ghostscript interpreter and previewer][5].
 
 If you frequently use the above commands, you may wish to remove said aliases
 from this module or to disable them at the bottom of the zshrc with `unalias`.
@@ -330,25 +329,23 @@ from this module or to disable them at the bottom of the zshrc with `unalias`.
 You can temporarily bypass an alias by prefixing it with a backward slash:
 `\gpt`.
 
-Functions
----------
+## Functions
 
-  - `git-branch-current` displays the current branch.
-  - `git-commit-lost` lists lost commits.
-  - `git-dir` displays the path to the Git directory.
-  - `git-hub-browse` opens the [GitHub][3] repository in the default browser.
-  - `git-hub-shorten-url` shortens [GitHub URLs][10].
-  - `git-info` exposes repository information via the `$git_info` associative
-    array.
-  - `git-root` displays the path to the working tree root.
-  - `git-stash-clear-interactive` asks for confirmation before clearing the stash.
-  - `git-stash-dropped` lists dropped stashed states.
-  - `git-stash-recover` recovers given dropped stashed states.
-  - `git-submodule-move` moves a submodule.
-  - `git-submodule-remove` removes a submodule.
+- `git-branch-current` displays the current branch.
+- `git-commit-lost` lists lost commits.
+- `git-dir` displays the path to the Git directory.
+- `git-hub-browse` opens the [GitHub][3] repository in the default browser.
+- `git-hub-shorten-url` shortens [GitHub URLs][10].
+- `git-info` exposes repository information via the `$git_info` associative
+  array.
+- `git-root` displays the path to the working tree root.
+- `git-stash-clear-interactive` asks for confirmation before clearing the stash.
+- `git-stash-dropped` lists dropped stashed states.
+- `git-stash-recover` recovers given dropped stashed states.
+- `git-submodule-move` moves a submodule.
+- `git-submodule-remove` removes a submodule.
 
-Theming
--------
+## Theming
 
 To display information about the current repository in a prompt, define the
 following styles in the `prompt_name_setup` function, where the syntax for
@@ -361,7 +358,7 @@ zstyle ':prezto:module:git:info:context:subcontext' format 'string'
 ### Main Contexts
 
 | Name      | Format Code | Description
-| --------- | :---------: | ---------------------------------------------------
+| --------- | :---------: | ----------------------------------------------------
 | action    |     %s      | Special action name
 | ahead     |     %A      | Commits ahead of remote count
 | behind    |     %B      | Commits behind of remote count
@@ -374,7 +371,7 @@ zstyle ':prezto:module:git:info:context:subcontext' format 'string'
 ### Concise Contexts
 
 | Name      | Format Code | Description
-| --------- | :---------: | ---------------------------------------------------
+| --------- | :---------: | ----------------------------------------------------
 | clean     |     %C      | Clean state
 | dirty     |     %D      | Dirty files count
 | indexed   |     %i      | Indexed files count
@@ -390,7 +387,7 @@ zstyle ':prezto:module:git:info' verbose 'yes'
 ### Verbose Contexts
 
 | Name      | Format Code | Description
-| --------- | :---------: | ---------------------------------------------------
+| --------- | :---------: | ----------------------------------------------------
 | added     |     %a      | Added files count
 | clean     |     %C      | Clean state
 | deleted   |     %d      | Deleted files count
@@ -435,22 +432,21 @@ Last, add `$git_info[prompt]` to `$PROMPT` and `$git_info[rprompt]` to
 `$RPROMPT` respectively and call `git-info` in the `prompt_name_preexec` hook
 function.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][6].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Colin Hebert](https://github.com/ColinHebert)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Colin Hebert](https://github.com/ColinHebert)
 
-[1]: http://www.git-scm.com
+[1]: https://www.git-scm.com
 [2]: https://github.com/defunkt/hub
 [3]: https://www.github.com
-[4]: http://www.manpagez.com/man/8/gpt/
-[5]: http://www.manpagez.com/man/1/gs/
+[4]: https://www.manpagez.com/man/8/gpt/
+[5]: https://www.manpagez.com/man/1/gs/
 [6]: https://github.com/sorin-ionescu/prezto/issues
 [7]: https://github.com/sorin-ionescu/prezto/issues/219
-[8]: http://www.kernel.org/pub/software/scm/git/docs/git-log.html
+[8]: https://www.kernel.org/pub/software/scm/git/docs/git-log.html
 [9]: https://getgb.io/
 [10]: https://github.com/blog/985-git-io-github-url-shortener
-[11]: http://www.manpagez.com/man/1/gm/
+[11]: https://www.manpagez.com/man/1/gm/

--- a/modules/gnu-utility/README.md
+++ b/modules/gnu-utility/README.md
@@ -1,9 +1,8 @@
-GNU Utility
-===========
+# GNU Utility
 
 Provides for the interactive use of GNU utilities on BSD systems.
 
-Installing GNU utilities on non-GNU systems in `$PATH` without a prefix, i.e.
+Installing GNU utilities on non-GNU systems in `$PATH` without a prefix, i.e.,
 `ls` instead of `gls`, is not recommended since scripts that target other
 utilities will be broken.
 
@@ -12,23 +11,21 @@ use.
 
 This module must be loaded **before** the *utility* module.
 
-Settings
---------
+## Settings
 
 ### Prefix
 
-To use a different prefix, add the following to *zpreztorc*, and replace 'g' with
-the desired prefix:
+To use a different prefix, add the following to *~/.zpreztorc*, and replace 'g'
+with the desired prefix:
 
 ```sh
 zstyle ':prezto:module:gnu-utility' prefix 'g'
 ```
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/gpg/README.md
+++ b/modules/gpg/README.md
@@ -1,13 +1,14 @@
-GPG
-===
+# GPG
 
 Provides for an easier use of [GPG][1] by setting up [gpg-agent][2].
+
+## Settings
 
 ### SSH
 
 To enable OpenSSH Agent protocol emulation, and make `gpg-agent` a drop-in
 replacement for `ssh-agent`, add the following line to
-*~/.gnupg/gpg-agent.conf*:
+*`~/.gnupg/gpg-agent.conf`*:
 
 ```conf
 enable-ssh-support
@@ -16,13 +17,12 @@ enable-ssh-support
 When OpenSSH Agent protocol emulation is enabled, this module will load the SSH
 module for additional processing.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.gnupg.org
-[2]: http://linux.die.net/man/1/gpg-agent
+[1]: https://www.gnupg.org
+[2]: https://linux.die.net/man/1/gpg-agent
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/haskell/README.md
+++ b/modules/haskell/README.md
@@ -1,10 +1,8 @@
-Haskell
-=======
+# Haskell
 
 Enables local Haskell package installation.
 
-Per-user Package Installation
------------------------------
+## Per-user Package Installation
 
 [Cabal][1], the Haskell package manager, can install packages into per user
 directories.
@@ -17,12 +15,11 @@ documentation.
 
 Install packages into per user directories with `cabal install --user`.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sebastian Wiesner](https://github.com/lunaryorn)
+- [Sebastian Wiesner](https://github.com/lunaryorn)
 
-[1]: http://www.haskell.org/cabal/
+[1]: https://www.haskell.org/cabal/
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/helper/README.md
+++ b/modules/helper/README.md
@@ -1,29 +1,26 @@
-Helper
-======
+# Helper
 
 Provides helper functions for developing modules.
 
-Functions
----------
+## Functions
 
-  - `add-zsh-trap` adds a function name to a list to be called when a trap is
-    triggered.
-  - `is-autoloadable` checks if a file can be autoloaded by trying to load it
-    in a subshell.
-  - `is-callable` checks if a name is a command, function, or alias.
-  - `is-true` checks a boolean variable for "true".
-  - `coalesce` prints the first non-empty string in the arguments array.
-  - `is-darwin` checks if running on macOS Darwin.
-  - `is-linux` checks if running on Linux.
-  - `is-bsd` checks if running on BSD.
-  - `is-cygwin` checks if running on Cygwin (Windows).
-  - `is-termux` checks if running on Termux (Android).
+- `add-zsh-trap` adds a function name to a list to be called when a trap is
+  triggered.
+- `is-autoloadable` checks if a file can be autoloaded by trying to load it in
+  a subshell.
+- `is-callable` checks if a name is a command, function, or alias.
+- `is-true` checks a boolean variable for "true".
+- `coalesce` prints the first non-empty string in the arguments array.
+- `is-darwin` checks if running on macOS Darwin.
+- `is-linux` checks if running on Linux.
+- `is-bsd` checks if running on BSD.
+- `is-cygwin` checks if running on Cygwin (Windows).
+- `is-termux` checks if running on Termux (Android).
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -1,28 +1,25 @@
-History Substring Search
-========================
+# History Substring Search
 
-Integrates [zsh-history-substring-search][1] into Prezto, which implements
-the [Fish shell][2]'s history search feature, where the user can type in any
-part of a previously entered command and press up and down to cycle through
-matching commands.
+Integrates [`zsh-history-substring-search`][1] into Prezto, which implements the
+[Fish shell][2]'s history search feature, where the user can type in any part of
+a previously entered command and press up and down to cycle through matching
+commands.
 
 If this module is used in conjunction with the *syntax-highlighting* module,
 this module must be loaded **after** the *syntax-highlighting* module.
 
-Contributors
-------------
+## Contributors
 
 New features and bug fixes should be submitted to the
-[zsh-history-substring-search][1] project according to its rules and
+[`zsh-history-substring-search`][1] project according to its rules and
 regulations. This module will be synchronized against it.
 
-Settings
---------
+## Settings
 
 ### Case Sensitivity
 
 To enable case-sensitivity for this module only, add the following line to
-*zpreztorc*:
+*~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:history-substring-search' case-sensitive 'yes'
@@ -34,38 +31,37 @@ If colors are enabled, *history-substring-search* will automatically highlight
 positive results.
 
 To enable highlighting for this module only, add the following line to
-*zpreztorc*:
+*~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:history-substring-search' color 'yes'
 ```
 
-To set the query found color, add the following line to *zpreztorc*:
+To set the query found color, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:history-substring-search:color' found ''
 ```
 
-To set the query not found color, add the following line to *zpreztorc*:
+To set the query not found color, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:history-substring-search:color' not-found ''
 ```
 
-To set the search globbing flags, add the following line to *zpreztorc*:
+To set the search globbing flags, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:history-substring-search' globbing-flags ''
 ```
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Suraj N. Kurapati](https://github.com/sunaku)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Suraj N. Kurapati](https://github.com/sunaku)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-history-substring-search
-[2]: http://fishshell.com
+[2]: https://fishshell.com
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -1,53 +1,48 @@
-History
-=======
+# History
 
 Sets [history][1] options and defines history aliases.
 
-**Note:** Default path of `HISTFILE` has changed from `${ZDOTDIR:-$HOME}/.zhistory`
-to `${ZDOTDIR:-$HOME}/.zsh_history`. The file will be automatically renamed if
+**Note:** Default path of `HISTFILE` has changed from *`${ZDOTDIR:-$HOME}/.zhistory`*
+to *`${ZDOTDIR:-$HOME}/.zsh_history`*. The file will be automatically renamed if
 possible (when the new one doesn't exist). Otherwise, if you want to preserve
-previous history, you will need to move them from `${ZDOTDIR:-$HOME}/.zhistory`
-to `${ZDOTDIR:-$HOME}/.zsh_history`.
+previous history, you will need to move them from *`${ZDOTDIR:-$HOME}/.zhistory`*
+to *`${ZDOTDIR:-$HOME}/.zsh_history`*.
 
-Alternately, you can set `HISTFILE` manually to `${ZDOTDIR:-$HOME}/.zhistory`.
+Alternately, you can set `HISTFILE` manually to *`${ZDOTDIR:-$HOME}/.zhistory`*.
 
-Options
--------
+## Options
 
-  - `BANG_HIST` treats the **!** character specially during expansion.
-  - `EXTENDED_HISTORY` writes the history file in the *:start:elapsed;command* format.
-  - `SHARE_HISTORY` shares history between all sessions. Note that
-    `SHARE_HISTORY`, `INC_APPEND_HISTORY`, and `INC_APPEND_HISTORY_TIME` are
-    mutually exclusive.
-  - `HIST_EXPIRE_DUPS_FIRST` expires a duplicate event first when trimming history.
-  - `HIST_IGNORE_DUPS` does not record an event that was just recorded again.
-  - `HIST_IGNORE_ALL_DUPS` deletes an old recorded event if a new event is a duplicate.
-  - `HIST_FIND_NO_DUPS` does not display a previously found event.
-  - `HIST_IGNORE_SPACE` does not record an event starting with a space.
-  - `HIST_SAVE_NO_DUPS` does not write a duplicate event to the history file.
-  - `HIST_VERIFY` does not execute immediately upon history expansion.
-  - `HIST_BEEP` beeps when accessing non-existent history.
+- `BANG_HIST` treats the **!** character specially during expansion.
+- `EXTENDED_HISTORY` writes the history file in the *:start:elapsed;command* format.
+- `SHARE_HISTORY` shares history between all sessions. Note that
+  `SHARE_HISTORY`, `INC_APPEND_HISTORY`, and `INC_APPEND_HISTORY_TIME` are
+  mutually exclusive.
+- `HIST_EXPIRE_DUPS_FIRST` expires a duplicate event first when trimming history.
+- `HIST_IGNORE_DUPS` does not record an event that was just recorded again.
+- `HIST_IGNORE_ALL_DUPS` deletes an old recorded event if a new event is a duplicate.
+- `HIST_FIND_NO_DUPS` does not display a previously found event.
+- `HIST_IGNORE_SPACE` does not record an event starting with a space.
+- `HIST_SAVE_NO_DUPS` does not write a duplicate event to the history file.
+- `HIST_VERIFY` does not execute immediately upon history expansion.
+- `HIST_BEEP` beeps when accessing non-existent history.
 
-Variables
----------
+## Variables
 
-  - `HISTFILE` stores the path to the history file.
-  - `HISTSIZE` stores the maximum number of events to save in the internal history.
-  - `SAVEHIST` stores the maximum number of events to save in the history file.
+- `HISTFILE` stores the path to the history file.
+- `HISTSIZE` stores the maximum number of events to save in the internal history.
+- `SAVEHIST` stores the maximum number of events to save in the history file.
 
-Aliases
--------
+## Aliases
 
-  - `history-stat` lists the ten most used commands
+- `history-stat` lists the ten most used commands
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Robby Russell](https://github.com/robbyrussell)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Indrajit Raychaudhuri](https://github.com/indrajitr)
+- [Robby Russell](https://github.com/robbyrussell)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
-[1]: http://zsh.sourceforge.net/Guide/zshguide02.html#l16
+[1]: https://zsh.sourceforge.net/Guide/zshguide02.html#l16
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -1,10 +1,8 @@
-Homebrew
-========
+# Homebrew
 
 Defines Homebrew specific environment variables and aliases.
 
-Variables
----------
+## Variables
 
 Execute the following to list the environment variables loaded in the shell:
 
@@ -12,35 +10,34 @@ Execute the following to list the environment variables loaded in the shell:
 brew shellenv
 ```
 
-Aliases
--------
+## Aliases
 
-### Homebrew
+### Homebrew Core
 
-  - `brewc` cleans outdated brews and their cached archives.
-  - `brewi` installs a formula.
-  - `brewL` lists installed formulae that are not dependencies of another installed formula.
-  - `brewl` lists installed formulae.
-  - `brewo` lists brews which have an update available.
-  - `brews` searches for a formula.
-  - `brewu` upgrades outdated formulae.
-  - `brewx` uninstalls a formula.
+- `brewc` cleans outdated brews and their cached archives.
+- `brewi` installs a formula.
+- `brewL` lists installed formulae that are not dependencies of another
+  installed formula.
+- `brewl` lists installed formulae.
+- `brewo` lists brews which have an update available.
+- `brews` searches for a formula.
+- `brewu` upgrades outdated formulae.
+- `brewx` uninstalls a formula.
 
 ### Homebrew Cask
 
-  - `caski` installs a cask.
-  - `caskl` lists installed casks.
-  - `casko` lists casks which have an update available.
-  - `casks` searches for a cask.
-  - `casku` upgrades outdated casks.
-  - `caskx` uninstalls a cask.
+- `caski` installs a cask.
+- `caskl` lists installed casks.
+- `casko` lists casks which have an update available.
+- `casks` searches for a cask.
+- `casku` upgrades outdated casks.
+- `caskx` uninstalls a cask.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Griffin Yourick](https://github.com/tough-griff)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Griffin Yourick](https://github.com/tough-griff)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/macports/README.md
+++ b/modules/macports/README.md
@@ -1,25 +1,22 @@
-MacPorts
-========
+# MacPorts
 
 Defines MacPorts aliases and adds MacPorts directories to path variables.
 
-Aliases
--------
+## Aliases
 
-  - `portc` cleans the files used to build ports.
-  - `porti` installs a port.
-  - `ports` searches for a port.
-  - `portu` upgrades a port.
-  - `portU` upgrades MacPorts, the ports collection, and outdated ports.
-  - `portx` uninstalls a port.
-  - `portX` uninstalls inactive ports.
+- `portc` cleans the files used to build ports.
+- `porti` installs a port.
+- `ports` searches for a port.
+- `portu` upgrades a port.
+- `portU` upgrades MacPorts, the ports collection, and outdated ports.
+- `portx` uninstalls a port.
+- `portX` uninstalls inactive ports.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Matt Cable](https://github.com/curiousstranger)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Matt Cable](https://github.com/curiousstranger)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -1,38 +1,33 @@
-Node.js
-=======
+# Node.js
 
 Provides utility functions for [Node.js][1], loads the Node Version Manager, and
-enables [npm][2] completion.
+enables [*npm*][2] completion.
 
-nvm
----
+## nvm
 
-[nvm][5] allows for managing multiple, isolated Node.js installations in the
+[*nvm*][5] allows for managing multiple, isolated Node.js installations in the
 home directory.
 
 This will be loaded automatically if nvm is installed in `$NVM_DIR`,
-`~/.nvm`, or nvm is installed with homebrew.
+*~/.nvm*, or nvm is installed with homebrew.
 
-nodenv
-------
+## nodenv
 
-[nodenv][6] does one thing well. nodenv is concerned solely with switching
-Node versions. It's simple and predictable, Just Works, and is rock solid in
-production. nodenv is forked from the popular [rbenv][7].
+[*nodenv*][6] does one thing well - it is concerned solely with switching
+Node versions. It is simple and predictable, Just Works, and is rock solid in
+production. nodenv is forked from the popular [*rbenv*][7].
 
 This will be loaded automatically if nodenv is installed in `$NODENV_ROOT`,
-`~/.nodenv`, or `nodenv` is on the path.
+*~/.nodenv*, or `nodenv` is on the path.
 
-Functions
----------
+## Functions
 
-  - `node-doc` opens the Node.js online [API documentation][3] in the default
-    browser.
-  - `node-info` exposes information about the Node.js environment via the
-    `$node_info` associative array.
+- `node-doc` opens the Node.js online [API documentation][3] in the default
+  browser.
+- `node-info` exposes information about the Node.js environment via the
+  `$node_info` associative array.
 
-Theming
--------
+## Theming
 
 To display the version number of the current Node.js version, define the
 following style inside the `prompt_name_setup` function.
@@ -45,13 +40,12 @@ zstyle ':prezto:module:node:info:version' format 'version:%v'
 Then add `$node_info[version]` to either `$PROMPT` or `$RPROMPT` and call
 `node-info` in `prompt_name_preexec` hook function.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][4].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Zeh Rizzatti](https://github.com/zehrizzatti)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Zeh Rizzatti](https://github.com/zehrizzatti)
 
 [1]: http://nodejs.org
 [2]: http://npmjs.org

--- a/modules/ocaml/README.md
+++ b/modules/ocaml/README.md
@@ -1,10 +1,8 @@
-OCaml
-=====
+# OCaml
 
 Initializes [OCaml][1] package management.
 
-OPAM
-----
+## OPAM
 
 [OPAM][2] is a package manager for OCaml.
 
@@ -15,13 +13,12 @@ relevant path and OCaml variables.
 
 Install packages to your local package directory with `opam install`.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sebastian Wiesner](https://github.com/lunaryorn)
+- [Sebastian Wiesner](https://github.com/lunaryorn)
 
-[1]: http://ocaml.org/
+[1]: https://ocaml.org/
 [2]: http://opam.ocamlpro.com/
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -1,50 +1,44 @@
-OSX
-===
+# OSX
 
 Defines [macOS][1] aliases and functions.
 
-Settings
---------
+## Settings
 
 ### Dash Keyword
 
-To change the keyword used by `mand` to open man pages in [_Dash.app_][2] from
-its default value of 'manpages', add the following line in *zpreztorc* and
-replace the **keyword** with the one configured in [_Dash.app_][2].
+To change the keyword used by `mand` to open man pages in [*Dash.app*][2] from
+its default value of 'manpages', add the following line in *~/.zpreztorc* and
+replace the **keyword** with the one configured in [*Dash.app*][2].
 
 ```sh
 zstyle ':prezto:module:osx:man' dash-keyword 'keyword'
 ```
 
-Aliases
--------
+## Aliases
 
-  - `cdf` changes the current working director to the current _Finder_
-    directory.
-  - `pushdf` pushes the current working directory onto the directory queue and
-    changes the current working director to the current _Finder_ directory.
+- `cdf` changes the current working director to the current *Finder* directory.
+- `pushdf` pushes the current working directory onto the directory queue and
+  changes the current working director to the current *Finder* directory.
 
-Functions
----------
+## Functions
 
-  - `mand` opens _man_ pages in [_Dash.app_][2].
-  - `manp` opens _man_ pages in _Preview.app_.
-  - `pfd` prints the current _Finder_ directory.
-  - `pfs` prints the current _Finder_ selection.
-  - `tab` creates a new tab (works in both _Terminal_ and [_iTerm_][3]).
-  - `ql` previews files in Quick Look.
-  - `osx-rm-dir-metadata` deletes .DS\_Store, \_\_MACOSX cruft.
-  - `osx-ls-download-history` displays the macOS download history.
-  - `osx-rm-download-history` deletes the macOS download history.
+- `mand` opens _man_ pages in [*Dash.app*][2].
+- `manp` opens _man_ pages in *Preview.app*.
+- `pfd` prints the current *Finder* directory.
+- `pfs` prints the current *Finder* selection.
+- `tab` creates a new tab (works in both _Terminal_ and [*iTerm.app*][3]).
+- `ql` previews files in Quick Look.
+- `osx-rm-dir-metadata` deletes *.DS_Store*, *__MACOSX* cruft.
+- `osx-ls-download-history` displays the macOS download history.
+- `osx-rm-download-history` deletes the macOS download history.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][4].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.apple.com/macosx/
-[2]: http://kapeli.com/dash
-[3]: http://www.iterm2.com/
+[1]: https://www.apple.com/macos/
+[2]: https://kapeli.com/dash
+[3]: https://www.iterm2.com/
 [4]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/pacman/README.md
+++ b/modules/pacman/README.md
@@ -1,11 +1,9 @@
-Pacman
-======
+# Pacman
 
 Provides aliases and functions for the [Pacman][1] package manager and
 frontends.
 
-Settings
---------
+## Settings
 
 It is possible to use a Pacman frontend with the pacman aliases provided by this
 package as long as that frontend supports the same command line options (The
@@ -17,53 +15,50 @@ supported by Archlinux. It is currently recommended to manually build AUR
 packages using the [provided instructions][3]. The [aurutils][4] project has a
 set of small utilities to make this easier.
 
-To enable a Pacman frontend, add the following line to *zpreztorc*, substituting
-`pacman_frontend` with the name of the frontent:
+To enable a Pacman frontend, add the following line to *~/.zpreztorc*,
+substituting *pacman_frontend* with the name of the frontend:
 
 ```sh
 zstyle ':prezto:module:pacman' frontend 'pacman_frontend'
 ```
 
-Aliases
--------
+## Aliases
 
 ### Pacman
 
-  - `pac` is short for `pacman`.
-  - `paci` installs packages from repositories.
-  - `pacI` installs packages from files.
-  - `pacx` removes packages and unneeded dependencies.
-  - `pacX` removes packages, their configuration, and unneeded dependencies.
-  - `pacq` displays information about a package from the repositories.
-  - `pacQ` displays information about a package from the local database.
-  - `pacs` searches for packages in the repositories.
-  - `pacS` searches for packages in the local database.
-  - `pacu` synchronizes the local package and Arch Build System (requires `abs`)
-    databases against the repositories.
-  - `pacU` synchronizes the local package database against the repositories then
-    upgrades outdated packages.
-  - `pacman-list-orphans` lists orphan packages.
-  - `pacman-remove-orphans` removes orphan packages.
+- `pac` is short for `pacman`.
+- `paci` installs packages from repositories.
+- `pacI` installs packages from files.
+- `pacx` removes packages and unneeded dependencies.
+- `pacX` removes packages, their configuration, and unneeded dependencies.
+- `pacq` displays information about a package from the repositories.
+- `pacQ` displays information about a package from the local database.
+- `pacs` searches for packages in the repositories.
+- `pacS` searches for packages in the local database.
+- `pacu` synchronizes the local package and Arch Build System (requires `abs`)
+  databases against the repositories.
+- `pacU` synchronizes the local package database against the repositories then
+  upgrades outdated packages.
+- `pacman-list-orphans` lists orphan packages.
+- `pacman-remove-orphans` removes orphan packages.
 
 ### Frontends
 
-Functions
----------
+## Functions
 
-  - `aurget` clone an aur package
-  - `pacman-list-explicit` lists explicitly installed pacman packages.
-  - `pacman-list-disowned` lists pacman disowned files.
+- `aurget` clone an aur package.
+- `pacman-list-explicit` lists explicitly installed pacman packages.
+- `pacman-list-disowned` lists pacman disowned files.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][5].*
 
-  - [Benjamin Boudreau](https://github.com/dreur)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Benjamin Boudreau](https://github.com/dreur)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.archlinux.org/pacman/
-[2]: https://wiki.archlinux.org/index.php/AUR_helpers#Comparison_table
-[3]: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
+[1]: https://www.archlinux.org/pacman/
+[2]: https://wiki.archlinux.org/title/AUR_helpers#Comparison_tables
+[3]: https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages
 [4]: https://github.com/AladW/aurutils
 [5]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/perl/README.md
+++ b/modules/perl/README.md
@@ -1,18 +1,16 @@
-Perl
-====
+# Perl
 
 Enables local [Perl][1] module installation on macOS and defines aliases.
 
-Local Module Installation
--------------------------
+## Local Module Installation
 
 Perl versions older than 5.14 do not support the local installation of Perl
 modules natively. This module allows for local installation of Perl modules on
-macOS in *~/Library/Perl/5.12* by altering the environment.
+macOS in *`~/Library/Perl/5.12`* by altering the environment.
 
 ### Usage
 
-For Perl versions older than 5.14, install *local::lib*.
+For Perl versions older than 5.14, install *`local::lib`*.
 
 ```console
 curl -L -C - -O http://search.cpan.org/CPAN/authors/id/A/AP/APEIRON/local-lib-1.008004.tar.gz
@@ -28,67 +26,62 @@ Install *cpanminus*:
 curl -L http://cpanmin.us | perl - --self-upgrade
 ```
 
-Perlbrew
---------
+## Perlbrew
 
 An alternative to the above is to use [Perlbrew][2], which allows for the
 management of multiple, isolated Perl installations in the home directory.
 
-plenv
------
+## plenv
 
-Yet another alternative is [plenv][3]. This is inspired from rbenv and enables
-switching between multiple binary installations.
+Yet another alternative is [*plenv*][3]. This is inspired from *rbenv* and
+enables switching between multiple binary installations.
 
-The subcommands of plenv is similar with rbenv.
+The subcommands of *plenv* is similar with *rbenv*.
 
-Aliases
--------
+## Aliases
 
 ### General
 
-  - `pl` is short for `perl`.
-  - `pld` looks up Perl documentation (`perldoc`).
-  - `ple` executes a one line program in a loop (`perl -wlne`).
+- `pl` is short for `perl`.
+- `pld` looks up Perl documentation (`perldoc`).
+- `ple` executes a one line program in a loop (`perl -wlne`).
 
-### Perlbrew
+### Perlbrew (plb)
 
-  - `plb` manages Perl environments.
-  - `plba` lists available Perl versions.
-  - `plbi` installs a Perl version.
-  - `plbl` lists installed Perl versions.
-  - `plbo` temporarily turns off Perlbrew.
-  - `plbO` turns off Perlbrew.
-  - `plbs` switches to a Perl version.
-  - `plbu` uninstalls a Perl version.
-  - `plbx` temporarily sets the Perl version to use.
+- `plb` manages Perl environments.
+- `plba` lists available Perl versions.
+- `plbi` installs a Perl version.
+- `plbl` lists installed Perl versions.
+- `plbo` temporarily turns off Perlbrew.
+- `plbO` turns off Perlbrew.
+- `plbs` switches to a Perl version.
+- `plbu` uninstalls a Perl version.
+- `plbx` temporarily sets the Perl version to use.
 
-### plenv
+### plenv (plv)
 
-  - `plv` manages Perl environments.
-  - `plvc` List all available plenv commands.
-  - `plvl` Set or show the local application-specific Perl version.
-  - `plvg` Set or show the global Perl version.
-  - `plvs` Set or show the shell-specific Perl version.
-  - `plvi` Install a Perl version using the perl-build plugin.
-  - `plvu` Uninstall a specific Perl version.
-  - `plvr` Rehash plenv shims (run this after installing executables).
-  - `plvv` Show the current Perl version and its origin.
-  - `plvV` List all Perl versions available to plenv.
-  - `plvw` Display the full path to an executable.
-  - `plvW` List all Perl versions that contain the given executable.
-  - `plvm` List cpan modules in current perl.
-  - `plvM` Migrate cpan modules from other version.
-  - `plvI` Install cpanm.
+- `plv` manages Perl environments.
+- `plvc` List all available plenv commands.
+- `plvl` Set or show the local application-specific Perl version.
+- `plvg` Set or show the global Perl version.
+- `plvs` Set or show the shell-specific Perl version.
+- `plvi` Install a Perl version using the perl-build plugin.
+- `plvu` Uninstall a specific Perl version.
+- `plvr` Rehash plenv shims (run this after installing executables).
+- `plvv` Show the current Perl version and its origin.
+- `plvV` List all Perl versions available to plenv.
+- `plvw` Display the full path to an executable.
+- `plvW` List all Perl versions that contain the given executable.
+- `plvm` List cpan modules in current perl.
+- `plvM` Migrate cpan modules from other version.
+- `plvI` Install cpanm.
 
-Functions
----------
+## Functions
 
-  - `perl-info` exposes information about the Perl environment via the
-    `$perl_info` associative array.
+- `perl-info` exposes information about the Perl environment via the
+  `$perl_info` associative array.
 
-Theming
--------
+## Theming
 
 To display the name of the current Perl version in a prompt, define the
 following style in the `prompt_name_setup` function.
@@ -101,14 +94,13 @@ zstyle ':prezto:module:perl:info:version' format 'version:%v'
 Then add `$perl_info[version]` to `$PROMPT` or `$RPROMPT` and call
 `perl-info` in the `prompt_name_precmd` hook function.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][4].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.perl.org
-[2]: http://perlbrew.pl
+[1]: https://www.perl.org
+[2]: https://perlbrew.pl
 [3]: https://github.com/tokuhirom/plenv
 [4]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -1,16 +1,14 @@
-Prompt
-======
+# Prompt
 
 Loads prompt [themes][1].
 
-Settings
---------
+## Settings
 
 ### Prompt Theme
 
-To select a prompt theme, add the following to *zpreztorc*, and replace **name**
-with the name of the theme you wish to load. Setting it to **random** will load
-a random theme.
+To select a prompt theme, add the following to *~/.zpreztorc*, and replace
+**name** with the name of the theme you wish to load. Setting it to **random**
+will load a random theme.
 
 ```sh
 zstyle ':prezto:module:prompt' theme 'name'
@@ -19,8 +17,8 @@ zstyle ':prezto:module:prompt' theme 'name'
 ### Prompt Display Length
 
 To change working directory prompt display length from 'short', set the
-following to 'long' (without `~` expansion) or 'full' (with `~` expansion)
-in *zpreztorc*.
+following to 'long' (without `~` expansion) or 'full' (with `~` expansion) in
+*~/.zpreztorc*.
 
 ```sh
 zstyle ':prezto:module:prompt' pwd-length 'short'
@@ -35,8 +33,7 @@ this can be disabled with the following snippet.
 zstyle ':prezto:module:prompt' show-return-val 'no'
 ```
 
-Theming
--------
+## Theming
 
 A prompt theme is an autoloadable function file with a special name,
 `prompt_name_setup`, placed anywhere in `$fpath`, but for the purpose of this
@@ -46,11 +43,11 @@ directory.
 ### Required Variables
 
 To ensure that your function works with the editor-info module you'll need to
-set the following variable:
+set the following variable in *~/.zpreztorc*:
 
-```
-  # Tell prezto we can manage this prompt
-  zstyle ':prezto:module:prompt' managed 'yes'
+```sh
+# Tell prezto we can manage this prompt
+zstyle ':prezto:module:prompt' managed 'yes'
 ```
 
 This is to ensure compatibility with outside prompts, while allowing prezto
@@ -134,7 +131,8 @@ When calling functions to get information to display in a prompt, do not assume
 that all the dependencies have been loaded. Always check for the availability of
 a function before you calling it.
 
-**Do not register hook functions. They will be registered by the `prompt` function.**
+**Do not register hook functions. They will be automatically registered by the
+`prompt` function.**
 
 The most basic example of this function can be seen below.
 
@@ -146,10 +144,9 @@ function prompt_name_precmd {
 }
 ```
 
-Troubleshooting
----------------
+## Troubleshooting
 
-### Fonts aren't displaying properly.
+### Fonts aren't displaying properly
 
 On most systems, themes which use special characters need to have a patched font
 installed and configured properly.
@@ -157,16 +154,14 @@ installed and configured properly.
 Powerline provides some information on [terminal support][4] and [how to install
 patched fonts][5] which should fix most font issues.
 
-
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Prompt-Themes
-[2]: http://zsh.sourceforge.net/Doc/Release/Functions.html#Hook-Functions
+[1]: https://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Prompt-Themes
+[2]: https://zsh.sourceforge.net/Doc/Release/Functions.html#Hook-Functions
 [3]: https://github.com/sorin-ionescu/prezto/issues
-[4]: http://powerline.readthedocs.io/en/master/usage.html#terminal-emulator-requirements
-[5]: http://powerline.readthedocs.io/en/latest/installation.html#fonts-installation
+[4]: https://powerline.readthedocs.io/en/master/usage.html#terminal-emulator-requirements
+[5]: https://powerline.readthedocs.io/en/latest/installation.html#fonts-installation

--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -1,20 +1,18 @@
-Python
-======
+# Python
 
 Enables local Python and local Python package installation.
 
-Settings
---------
+## Settings
 
-This module supports virtual environments from conda and virtualenvwrapper. By
-default, only virtualenvwrapper is enabled. To disable virtualenvwrapper, add
-the following to *zpreztorc*.
+This module supports virtual environments from conda and
+[*virtualenvwrapper*][2]. By default, only *virtualenvwrapper* is enabled. To
+disable *virtualenvwrapper*, add the following to *~/.zpreztorc*.
 
 ```sh
 zstyle ':prezto:module:python' skip-virtualenvwrapper-init 'on'
 ```
 
-Conda support is enabled by adding the following to *zpreztorc*.
+Conda support is enabled by adding the following to *~/.zpreztorc*.
 
 ```sh
 zstyle ':prezto:module:python' conda-init 'on'
@@ -22,24 +20,22 @@ zstyle ':prezto:module:python' conda-init 'on'
 
 Caution: using conda and virtualenvwrapper at the same time may cause conflicts.
 
-Local Python Installation
--------------------------
+## Local Python Installation
 
-[pyenv][4] builds and installs multiple Python versions locally in the home
+[*pyenv*][4] builds and installs multiple Python versions locally in the home
 directory.
 
-This module prepends the pyenv directory to the path variable to enable the
+This module prepends the *pyenv* directory to the path variable to enable the
 execution of `pyenv`.
 
 ### Usage
 
-Install Python versions with `pyenv install` into `~/.pyenv/versions`.
+Install Python versions with `pyenv install` into *~/.pyenv/versions*.
 
 This will be loaded automatically if pyenv is installed to `$PYENV_ROOT`,
-`~/.pyenv`, or if the `pyenv` command is on the path.
+*~/.pyenv*, or if the `pyenv` command is on the path.
 
-Local Package Installation
---------------------------
+## Local Package Installation
 
 Since version 2.6, Python supports per user package installation, as defined in
 [PEP 370][1].
@@ -52,10 +48,9 @@ documentation.
 
 Install packages into the per user site directory with `pip install --user`.
 
-virtualenvwrapper
------------------
+## virtualenvwrapper
 
-[`virtualenvwrapper`][2] is a frontend to the popular [`virtualenv`][3] utility.
+[*virtualenvwrapper*][2] is a frontend to the popular [*virtualenv*][3] utility.
 
 `virtualenv` creates isolated Python environments and `virtualenvwrapper`
 provides convenient shell functions to create, switch, and manage them.
@@ -64,7 +59,7 @@ provides convenient shell functions to create, switch, and manage them.
 
 Install `virtualenvwrapper`.
 
-Virtual environments are stored in `~/.virtualenvs`.
+Virtual environments are stored in *~/.virtualenvs*.
 
 There are configuration variables that have to be set to enable certain features.
 If you wish to use these features, export the variables in [`zshenv`][6].
@@ -119,27 +114,26 @@ zstyle ':prezto:module:python:virtualenv' auto-switch 'yes'
 zstyle ':prezto:module:python:virtualenv' initialize 'no'
 ```
 
-Aliases
--------
+## Aliases
 
-  - `py` is short for `python`.
-  - `py2` is short for `python2`.
-  - `py3` is short for `python3`.
+- `py` is short for `python`.
+- `py2` is short for `python2`.
+- `py3` is short for `python3`.
 
-Functions
----------
+## Functions
 
-  - `python-info` exposes information about the Python environment via the
-    `$python_info` associative array.
+- `python-info` exposes information about the Python environment via the
+  `$python_info` associative array.
 
-Theming
--------
+## Theming
 
-To display the name of the current virtual enviroment in a prompt, define the
+To display the name of the current virtual environment in a prompt, define the
 following style in the `prompt_name_setup` function.
 
-    # %v - virtualenv name.
-    zstyle ':prezto:module:python:info:virtualenv' format 'virtualenv:%v'
+```sh
+# %v - virtualenv name.
+zstyle ':prezto:module:python:info:virtualenv' format 'virtualenv:%v'
+```
 
 Then add `$python_info[virtualenv]` to `$PROMPT` or `$RPROMPT` and call
 `python-info` in the `prompt_name_preexec` hook function.
@@ -148,17 +142,16 @@ Similarly, you can use `:prezto:module:python:info:version:format` with `%v` for
 the version and add `$python_info[version]` to your prompt for the current
 python version/
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][5].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Sebastian Wiesner](https://github.com/lunaryorn)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sebastian Wiesner](https://github.com/lunaryorn)
 
-[1]: http://www.python.org/dev/peps/pep-0370/
-[2]: http://www.doughellmann.com/projects/virtualenvwrapper/
-[3]: http://pypi.python.org/pypi/virtualenv
+[1]: https://www.python.org/dev/peps/pep-0370/
+[2]: https://www.doughellmann.com/projects/virtualenvwrapper/
+[3]: https://pypi.org/project/virtualenv/
 [4]: https://github.com/yyuu/pyenv
 [5]: https://github.com/sorin-ionescu/prezto/issues
 [6]: https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zshenv

--- a/modules/rails/README.md
+++ b/modules/rails/README.md
@@ -1,34 +1,31 @@
-Ruby on Rails
-=============
+# Ruby on Rails
 
 Defines [Ruby on Rails][1] aliases.
 
-Aliases
--------
+## Aliases
 
-  - `ror` is short for `rails`.
-  - `rorc` starts the Rails console.
-  - `rordc` starts the Rails console connected to the database.
-  - `rordm` migrates the database.
-  - `rordM` migrates the database and recreates the test database.
-  - `rordr` rolls the database schema back to the previous version.
-  - `rorg` generates new code.
-  - `rorl` displays the log.
-  - `rorlc` truncates logs to zero bytes.
-  - `rorp` installs a plugin.
-  - `rorr` runs code in the application environment.
-  - `rors` starts the Rails server.
-  - `rorsd` starts the Rails server with the debugger.
-  - `rorx` destroys newly generated code.
+- `ror` is short for `rails`.
+- `rorc` starts the Rails console.
+- `rordc` starts the Rails console connected to the database.
+- `rordm` migrates the database.
+- `rordM` migrates the database and recreates the test database.
+- `rordr` rolls the database schema back to the previous version.
+- `rorg` generates new code.
+- `rorl` displays the log.
+- `rorlc` truncates logs to zero bytes.
+- `rorp` installs a plugin.
+- `rorr` runs code in the application environment.
+- `rors` starts the Rails server.
+- `rorsd` starts the Rails server with the debugger.
+- `rorx` destroys newly generated code.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Robby Russell](https://github.com/robbyrussell)
-  - [Jake Bell](https://github.com/theunraveler)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Robby Russell](https://github.com/robbyrussell)
+- [Jake Bell](https://github.com/theunraveler)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://rubyonrails.org
+[1]: https://rubyonrails.org
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -1,26 +1,23 @@
-Rsync
-=====
+# Rsync
 
 Defines [rsync][1] aliases.
 
 macOS users are encouraged to use *rsync* from [Homebrew][2] or [MacPorts][3],
 which has additional enhancements including patches from [Bombich][4].
 
-Aliases
--------
+## Aliases
 
-  - `rsync-copy` copies files and directories from *source* to *destination*.
-  - `rsync-move` moves files and directories from *source* to *destination*.
-  - `rsync-update` updates files and directories on *destination*.
-  - `rsync-synchronize` synchronizes files and directories between *source* and
-    *destination*.
+- `rsync-copy` copies files and directories from *source* to *destination*.
+- `rsync-move` moves files and directories from *source* to *destination*.
+- `rsync-update` updates files and directories on *destination*.
+- `rsync-synchronize` synchronizes files and directories between *source* and
+  *destination*.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][5].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://rsync.samba.org
 [2]: https://github.com/Homebrew/homebrew-core

--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -1,21 +1,18 @@
-Ruby
-====
+# Ruby
 
 Configures [Ruby][1] local gem installation, loads version managers, and defines
 aliases.
 
-Local Gem Installation
-----------------------
+## Local Gem Installation
 
 When a Ruby version manager is not detected, local gems are installed in
-`~/.gems`; otherwise, they are installed according to the manager.
+*~/.gems*; otherwise, they are installed according to the manager.
 
-RVM
----
+## rvm
 
-An alternative to the above is to use [The Ruby Version Manager (RVM)][2], which
-allows for managing multiple, isolated Ruby installations and gem sets in the
-home directory.
+An alternative to the above is to use [The Ruby Version Manager (*rvm*)][2],
+which allows for managing multiple, isolated Ruby installations and gem sets in
+the home directory.
 
 Since RVM is loaded into the shell and is known to override shell commands, it
 may conflict with shell scripts.
@@ -23,93 +20,87 @@ may conflict with shell scripts.
 Load this module as late as possible when using RVM since RVM will complain if
 it is not first in `$PATH`.
 
-rbenv
------
+## rbenv
 
-An alternative RVM is to use [rbenv][3], which allows for switching between
+An alternative RVM is to use [*rbenv*][3], which allows for switching between
 multiple, isolated Ruby installations in the home directory.
 
 While it is not as feature rich as RVM, it is not loaded into the shell and is
 not known to cause conflicts with shell scripts.
 
-This will be loaded automatically if rbenv is installed to `$RBENV_ROOT`,
-`~/.rbenv`, or if the `rbenv` command is on the path.
+This will be loaded automatically if *rbenv* is installed to `$RBENV_ROOT`,
+*~/.rbenv*, or if the `rbenv` command is on the path.
 
-chruby
-------
+## chruby
 
-Yet another alternative is [chruby][4], which is simpler than both RVM and
-rbenv.
+Yet another alternative is [*chruby*][4], which is simpler than both *rvm* and
+*rbenv*.
 
 ### Settings
 
 #### Auto-Switch
 
 To enable auto switching the Ruby version on directory change based on the
-`.ruby-version` file, add the following line to [`zpreztorc`][5]:
+`.ruby-version` file, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:ruby:chruby' auto-switch 'yes'
 ```
 
-Bundler
--------
+## Bundler
 
 Manage gems that are not meant to be used as commands, such as application
-dependencies, with [Bundler][6].
+dependencies, with [Bundler][5].
 
-Aliases
--------
+## Aliases
 
 ### General
 
-  - `rb` is short for `ruby`.
+- `rb` is short for `ruby`.
 
 ### Bundler
 
-  - `rbb` manages ruby dependencies (`bundle`).
-  - `rbbc` cleans up unused gems in your bundler directory.
-  - `rbbe` executes a script in the context of the current bundle.
-  - `rbbi` installs the gems specified in the `Gemfile` in `vendor/bundle`.
-  - `rbbI` installs the following:
-    - gems specified in the `Gemfile` in `vendor/bundle`.
-    - packages the gems into `vendor/cache`.
-    - appends bundler directories to  `.gitignore`.
-  - `rbbl` lists all gems in the current bundle.
-  - `rbbo` opens an installed gem in the editor.
-  - `rbbp` packages gem files into `vendor/cache`.
-  - `rbbu` updates gems to their latest version.
+- `rbb` manages ruby dependencies (`bundle`).
+- `rbbc` cleans up unused gems in your bundler directory.
+- `rbbe` executes a script in the context of the current bundle.
+- `rbbi` installs the gems specified in the `Gemfile` in `vendor/bundle`.
+- `rbbI` installs the following:
+  - gems specified in the `Gemfile` in `vendor/bundle`.
+  - packages the gems into `vendor/cache`.
+  - appends bundler directories to  `.gitignore`.
+- `rbbl` lists all gems in the current bundle.
+- `rbbo` opens an installed gem in the editor.
+- `rbbp` packages gem files into `vendor/cache`.
+- `rbbu` updates gems to their latest version.
 
-Functions
----------
+## Functions
 
-  - `ruby-app-root` displays the path to the Ruby application root directory.
-  - `ruby-info` exposes information about the Ruby environment via the
-    `$ruby_info` associative array.
+- `ruby-app-root` displays the path to the Ruby application root directory.
+- `ruby-info` exposes information about the Ruby environment via the
+  `$ruby_info` associative array.
 
-Theming
--------
+## Theming
 
 To display the name of the current Ruby version in a prompt, define the
 following style in the `prompt_name_setup` function.
 
-    # %v - ruby version.
-    zstyle ':prezto:module:ruby:info:version' format 'version:%v'
+```sh
+# %v - ruby version.
+zstyle ':prezto:module:ruby:info:version' format 'version:%v'
+```
 
 Then add `$ruby_info[version]` to `$PROMPT` or `$RPROMPT` and call
 `ruby-info` in the `prompt_name_preexec` hook function.
 
-Authors
--------
+## Authors
 
-*The authors of this module should be contacted via the [issue tracker][7].*
+*The authors of this module should be contacted via the [issue tracker][6].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.ruby-lang.org
+[1]: https://www.ruby-lang.org
 [2]: https://rvm.io
 [3]: https://github.com/sstephenson/rbenv
 [4]: https://github.com/postmodern/chruby
-[5]: https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zpreztorc
-[6]: http://gembundler.com
-[7]: https://github.com/sorin-ionescu/prezto/issues
+[5]: https://gembundler.com
+[6]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -1,44 +1,40 @@
-GNU Screen
-==========
+# GNU Screen
 
 Defines [GNU Screen][1] aliases and provides for auto launching it at start-up.
 
-Settings
---------
+## Settings
 
 ### Auto-Start
 
 Starts a GNU Screen session automatically when Zsh is launched.
 
-To enable this feature when launching Zsh in a local terminal, add the
-following line to *zpreztorc*:
+To enable this feature when launching Zsh in a local terminal, add the following
+line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:screen:auto-start' local 'yes'
 ```
 
-To enable this feature when launching Zsh in a SSH connection, add the
-following line to *zpreztorc*:
+To enable this feature when launching Zsh in a SSH connection, add the following
+line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:screen:auto-start' remote 'yes'
 ```
 
-Aliases
--------
+## Aliases
 
-  - `scr` is short for `screen`.
-  - `scrl` lists sessions/socket directory.
-  - `scrn` starts a new session.
-  - `scrr` attaches to a session if one exists or start a new one.
+- `scr` is short for `screen`.
+- `scrl` lists sessions/socket directory.
+- `scrn` starts a new session.
+- `scrr` attaches to a session if one exists or start a new one.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Georges Discry](https://github.com/gdiscry)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Georges Discry](https://github.com/gdiscry)
 
-[1]: http://www.gnu.org/software/screen/
+[1]: https://www.gnu.org/software/screen/
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/spectrum/README.md
+++ b/modules/spectrum/README.md
@@ -1,16 +1,14 @@
-Spectrum
-========
+# Spectrum
 
 Provides for easier use of 256 colors and effects.
 
 To learn more about text formatting, read [A Guide to 256 Color Codes][1].
 
-Variables
----------
+## Variables
 
-  - `BG` provides background colors.
-  - `FG` provides foreground colors.
-  - `FX` provides effects.
+- `BG` provides background colors.
+- `FG` provides foreground colors.
+- `FX` provides effects.
 
 ### Background and Foreground
 
@@ -79,13 +77,12 @@ Though there are many effects, most terminals support at least bold formatting.
 
 Use `$BG[none]`, `$FG[none]`, or `$FX[none]` to turn off formatting.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [P.C. Shyamshankar](https://github.com/sykora)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [P.C. Shyamshankar](https://github.com/sykora)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: http://lucentbeing.com/writing/archives/a-guide-to-256-color-codes/
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -1,26 +1,23 @@
-SSH
-===
+# SSH
 
-Provides for an easier use of [SSH][1] by setting up [ssh-agent][2].
+Provides for an easier use of [SSH][1] by setting up [*ssh-agent*][2].
 
-Settings
---------
+## Settings
 
 ### Identities
 
-To load multiple identities, add the following line to *zpreztorc*:
+To load multiple identities, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_dsa' 'id_github'
 ```
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+[Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.openssh.com
-[2]: http://www.openbsd.org/cgi-bin/man.cgi?query=ssh-agent&sektion=1
+[1]: https://www.openssh.com
+[2]: https://www.openbsd.org/cgi-bin/man.cgi?query=ssh-agent&sektion=1
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -1,5 +1,4 @@
-Syntax Highlighting
-===================
+# Syntax Highlighting
 
 Integrates [zsh-syntax-highlighting][1] into Prezto.
 
@@ -9,23 +8,21 @@ Additionally, if this module is used in conjunction with the
 *history-substring-search* module, this module must be loaded **before** the
 *history-substring-search* module.
 
-To elaborate: The relative order of loading the modules would be 
+To elaborate: The relative order of loading the modules would be
 'syntax-highlighting', 'history-substring-search' and 'prompt'.
 
-Contributors
-------------
+## Contributors
 
 New features and bug fixes should be submitted to the
 [zsh-syntax-highlighting][1] project according to its rules and regulations.
 This module will be synchronized against it.
 
-Settings
---------
+## Settings
 
 ### Highlighting
 
 To enable highlighting for this module only, add the following line to
-*zpreztorc*:
+*~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' color 'yes'
@@ -36,7 +33,7 @@ zstyle ':prezto:module:syntax-highlighting' color 'yes'
 Syntax highlighting is accomplished by pluggable [highlighters][2]. This module
 only enables the *main* highlighter by default.
 
-To enable all highlighters, add the following to *zpreztorc*:
+To enable all highlighters, add the following to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' highlighters \
@@ -53,7 +50,7 @@ zstyle ':prezto:module:syntax-highlighting' highlighters \
 Each syntax highlighter defines styles used to highlight tokens.
 
 To highlight, for example, builtins, commands, and functions in blue instead of
-green, add the following to *zpreztorc*:
+green, add the following to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' styles \
@@ -62,12 +59,11 @@ zstyle ':prezto:module:syntax-highlighting' styles \
   'function' 'bg=blue'
 ```
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][3].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-syntax-highlighting
 [2]: https://github.com/zsh-users/zsh-syntax-highlighting/tree/master/highlighters

--- a/modules/terminal/README.md
+++ b/modules/terminal/README.md
@@ -1,23 +1,21 @@
-Terminal
-========
+# Terminal
 
 Sets terminal window and tab titles.
 
-Settings
---------
+## Settings
 
 ### Auto-Title
 
 To auto set the terminal window and tab titles with the current command or
-directory, add the following to *zpreztorc*:
+directory, add the following to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:terminal' auto-title 'yes'
 ```
 
-Auto titling is disabled inside terminal multiplexers (except inside dvtm)
-since it interferes with window names defined in configuration files and
-profile managers. This can be overridden by setting it to `always`.
+Auto titling is disabled inside terminal multiplexers (except inside dvtm) since
+it interferes with window names defined in configuration files and profile
+managers. This can be overridden by setting it to `always`.
 
 ```sh
 zstyle ':prezto:module:terminal' auto-title 'always'
@@ -25,7 +23,7 @@ zstyle ':prezto:module:terminal' auto-title 'always'
 
 ### Title formats
 
-To format terminal window and tab titles, add the following to *zpreztorc*:
+To format terminal window and tab titles, add the following to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:terminal:window-title' format '%n@%m: %s'
@@ -38,20 +36,18 @@ executing program name.
 
 For a list of sequences, see [Expansion of Prompt Sequences][1].
 
-Functions
----------
+## Functions
 
 - `set-tab-title` sets the terminal tab title.
 - `set-window-title` sets the terminal window title.
 - `set-multiplexer-title` sets the terminal multiplexer title.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Olaf Conradi](https://github.com/oohlaf)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Olaf Conradi](https://github.com/oohlaf)
 
-[1]: http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Expansion-of-Prompt-Sequences
+[1]: https://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Expansion-of-Prompt-Sequences
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -1,24 +1,22 @@
-Tmux
-====
+# Tmux
 
-Defines [tmux][1] aliases and provides for auto launching it at start-up.
+Defines [*tmux*][1] aliases and provides for auto launching it at start-up.
 
-Settings
---------
+## Settings
 
 ### Auto-Start
 
 Starts a tmux session automatically when Zsh is launched.
 
-To enable this feature when launching Zsh in a local terminal, add the
-following line to *zpreztorc*:
+To enable this feature when launching Zsh in a local terminal, add the following
+line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:tmux:auto-start' local 'yes'
 ```
 
-To enable this feature when launching Zsh in a SSH connection, add the
-following line to *zpreztorc*:
+To enable this feature when launching Zsh in a SSH connection, add the following
+line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:tmux:auto-start' remote 'yes'
@@ -45,7 +43,7 @@ set-option -g destroy-unattached [on | off]
 #### iTerm2 Integration
 
 [iTerm2][6] offers significant integration with tmux. This can be enabled by
-adding the following line to *zpreztorc*:
+adding the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:tmux:iterm' integrate 'yes'
@@ -53,14 +51,12 @@ zstyle ':prezto:module:tmux:iterm' integrate 'yes'
 
 Read [iTerm2 and tmux Integration][7] for more information.
 
-Aliases
--------
+## Aliases
 
-  - `tmuxa` attaches or switches to a tmux session.
-  - `tmuxl` lists sessions managed by the tmux server.
+- `tmuxa` attaches or switches to a tmux session.
+- `tmuxl` lists sessions managed by the tmux server.
 
-Caveats
--------
+## Caveats
 
 On macOS, launching tmux can cause the error **launch_msg(...): Socket is not
 connected** to be displayed, which can be fixed by installing
@@ -74,20 +70,19 @@ set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
 Furthermore, tmux is known to cause **kernel panics** on macOS. A discussion
 about this and Prezto has already been [opened][2].
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][5].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
-  - [Colin Hebert](https://github.com/ColinHebert)
-  - [Georges Discry](https://github.com/gdiscry)
-  - [Xavier Cambar](https://github.com/xcambar)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Colin Hebert](https://github.com/ColinHebert)
+- [Georges Discry](https://github.com/gdiscry)
+- [Xavier Cambar](https://github.com/xcambar)
 
-[1]: http://tmux.sourceforge.net
+[1]: https://tmux.github.io/
 [2]: https://github.com/sorin-ionescu/prezto/issues/62
 [3]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
 [4]: https://github.com/mxcl/homebrew
 [5]: https://github.com/sorin-ionescu/prezto/issues
-[6]: http://iterm2.com
+[6]: https://iterm2.com
 [7]: https://gitlab.com/gnachman/iterm2/wikis/TmuxIntegration

--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -1,68 +1,67 @@
-Utility
-=======
+# Utility
 
 Defines general aliases and functions.
 
-Settings
---------
+## Settings
 
 ### Highlighting
 
-If you have enabled color globally in *zpreztorc*, you may disable it for
+If you have enabled color globally in *~/.zpreztorc*, you may disable it for
 certain commands.
 
-To disable `ls` color, add the following line to *zpreztorc*; when coloring is
-disabled, type indicators (\*, /, =>, @, =, |, %) will be appended to entries.
+To disable `ls` color, add the following line to *~/.zpreztorc*; when coloring
+is disabled, type indicators (`\*`, `/`, `=>`, `@`, `=`, `|`, `%`) will be
+appended to entries.
 
 ```sh
 zstyle ':prezto:module:utility:ls' color 'no'
 ```
 
-To disable GNU coreutils `ls` to list directories grouped first, add the following line to *zpreztorc*:
+To disable GNU coreutils `ls` to list directories grouped first, add the
+following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:utility:ls' dirs-first 'no'
 ```
 
-To disable `diff` highlighting, add the following line to *zpreztorc*:
+To disable `diff` highlighting, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:utility:diff' color 'no'
 ```
 
-To disable `wdiff` highlighting, add the following line to *zpreztorc*:
+To disable `wdiff` highlighting, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:utility:wdiff' color 'no'
 ```
 
-To disable `make` highlighting, add the following line to *zpreztorc*:
+To disable `make` highlighting, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:utility:make' color 'no'
 ```
 
-Aliases
--------
+## Aliases
 
 ### Disabled Spelling Correction
 
-  - `ack`
-  - `cd`
-  - `cp`
-  - `ebuild`
-  - `gcc`
-  - `gist`
-  - `grep`
-  - `heroku`
-  - `ln`
-  - `man`
-  - `mkdir`
-  - `mv`
-  - `mysql`
-  - `rm`
+- `ack`
+- `cd`
+- `cp`
+- `ebuild`
+- `gcc`
+- `gist`
+- `grep`
+- `heroku`
+- `ln`
+- `man`
+- `mkdir`
+- `mv`
+- `mysql`
+- `rm`
 
-To disable all spelling corrections, add the following line to *zpreztorc*:
+To disable all spelling corrections, add the following line to *~/.zpreztorc*:
 
 ```sh
 zstyle ':prezto:module:utility' correct 'no'
@@ -70,122 +69,122 @@ zstyle ':prezto:module:utility' correct 'no'
 
 ### Disabled File Globbing
 
-  - `bower`
-  - `fc`
-  - `find`
-  - `ftp`
-  - `history`
-  - `locate`
-  - `rake`
-  - `rsync` (selectively enabled for local files)
-  - `scp` (selectively enabled for local files)
-  - `sftp`
+- `bower`
+- `fc`
+- `find`
+- `ftp`
+- `history`
+- `locate`
+- `rake`
+- `rsync` (selectively enabled for local files)
+- `scp` (selectively enabled for local files)
+- `sftp`
 
 ### General
 
-  - `_` executes a command as another user (`sudo`).
-  - `b` opens the default web browser.
-  - `diffu` shorthand for `diff --unified`
-  - `e` opens the default editor.
-  - `mkdir` creates directories, including intermediary directories.
-  - `p` opens the default pager.
-  - `po` removes a directory from the stack and changes to it (`popd`).
-  - `pu` changes the directory and pushes the old directory onto the stack
-    (`pushd`).
-  - `sa` search aliases for a word.
-  - `type` displays all the attribute values of a shell parameter.
+- `_` executes a command as another user (`sudo`).
+- `b` opens the default web browser.
+- `diffu` shorthand for `diff --unified`
+- `e` opens the default editor.
+- `mkdir` creates directories, including intermediary directories.
+- `p` opens the default pager.
+- `po` removes a directory from the stack and changes to it (`popd`).
+- `pu` changes the directory and pushes the old directory onto the stack
+  (`pushd`).
+- `sa` search aliases for a word.
+- `type` displays all the attribute values of a shell parameter.
 
 ### Files and Directories
 
-  - `ls` lists with directories grouped first (GNU only).
-  - `l`  lists in one column, hidden files.
-  - `ll` lists human readable sizes.
-  - `lr` lists human readable sizes, recursively.
-  - `la` lists human readable sizes, hidden files.
-  - `lm` lists human readable sizes, hidden files through pager.
-  - `lx` lists sorted by extension (GNU only).
-  - `lk` lists sorted by size, largest last.
-  - `lt` lists sorted by date, most recent last.
-  - `lc` lists sorted by date, most recent last, shows change time.
-  - `lu` lists sorted by date, most recent last, shows access time.
-  - `sl` lists directory contents (`ls`).
+- `ls` lists with directories grouped first (GNU only).
+- `l`  lists in one column, hidden files.
+- `ll` lists human readable sizes.
+- `lr` lists human readable sizes, recursively.
+- `la` lists human readable sizes, hidden files.
+- `lm` lists human readable sizes, hidden files through pager.
+- `lx` lists sorted by extension (GNU only).
+- `lk` lists sorted by size, largest last.
+- `lt` lists sorted by date, most recent last.
+- `lc` lists sorted by date, most recent last, shows change time.
+- `lu` lists sorted by date, most recent last, shows access time.
+- `sl` lists directory contents (`ls`).
 
 ### macOS Everywhere
 
-  - `o` opens files and directories (`open` or `xdg-open`).
-  - `get` downloads files (`curl` or `wget`).
-  - `pbcopy` copies to the pasteboard (`pbcopy`, `xclip` or `xsel`).
-  - `pbpaste` pastes from the pasteboard (`pbcopy`, `xclip` or `xsel`).
-  - `pbc` copies to the pasteboard (`pbcopy`).
-  - `pbp` pastes from the pasteboard (`pbpaste`).
+- `o` opens files and directories (`open` or `xdg-open`).
+- `get` downloads files (`curl` or `wget`).
+- `pbcopy` copies to the pasteboard (`pbcopy`, `xclip` or `xsel`).
+- `pbpaste` pastes from the pasteboard (`pbcopy`, `xclip` or `xsel`).
+- `pbc` copies to the pasteboard (`pbcopy`).
+- `pbp` pastes from the pasteboard (`pbpaste`).
 
 ### Resource Usage
 
-  - `df` displays free disk space using human readable units (aliases to `pydf`,
-    if installed).
-  - `du` displays disk usage using human readable units.
-  - `top` displays information about processes.
-  - `topc` displays information about processes sorted by CPU usage.
-  - `topm` displays information about processes sorted by RAM usage.
+- `df` displays free disk space using human readable units (aliases to `pydf`,
+  if installed).
+- `du` displays disk usage using human readable units.
+- `top` displays information about processes.
+- `topc` displays information about processes sorted by CPU usage.
+- `topm` displays information about processes sorted by RAM usage.
 
 ### Safe ops
 
 By default, `cp`,`ln`, `mv` and `rm` are aliased to their interactive variants.
 If this is not desired, it can be disabled by adding the following line to
-*zpreztorc*:
+*~/.zpreztorc*:
 
-    zstyle ':prezto:module:utility' safe-ops 'no'.
+```sh
+zstyle ':prezto:module:utility' safe-ops 'no'.
+```
 
 In addition, the following aliases have been added:
 
-  - `cpi` copies files and directories interactively.
-  - `lni` links files and directories interactively.
-  - `mvi` moves files and directories interactively.
-  - `rmi` removes files and directories interactively.
+- `cpi` copies files and directories interactively.
+- `lni` links files and directories interactively.
+- `mvi` moves files and directories interactively.
+- `rmi` removes files and directories interactively.
 
 ### Miscellaneous
 
-  - `http-serve` serves a directory via HTTP.
+- `http-serve` serves a directory via HTTP.
 
-Functions
----------
+## Functions
 
 ### General
 
-  - `slit` prints columns *1, 2, 3 ... n*.
+- `slit` prints columns *1, 2, 3 ... n*.
 
 ### Files and Directories
 
-  - `cdls` changes to a directory and lists its contents.
-  - `dut` displays the grand total disk usage using human readable units.
-  - `find-exec` finds files and executes a command on them.
-  - `mkdcd` makes a directory and changes to it.
-  - `popdls` pops an entry off the directory stack and lists its contents.
-  - `pushdls` pushes an entry onto the directory stack and lists its contents.
-  - `noremoteglob` enable local path globbing but disable remote path globbing.
+- `cdls` changes to a directory and lists its contents.
+- `dut` displays the grand total disk usage using human readable units.
+- `find-exec` finds files and executes a command on them.
+- `mkdcd` makes a directory and changes to it.
+- `popdls` pops an entry off the directory stack and lists its contents.
+- `pushdls` pushes an entry onto the directory stack and lists its contents.
+- `noremoteglob` enable local path globbing but disable remote path globbing.
 
 ### Developer
 
-  - `diff` highlights diff output (requires `colordiff`).
-  - `make` highlights make output (requires `colormake`).
-  - `wdiff` highlights wdiff output (requires `wdiff `or `Git`).
+- `diff` highlights diff output (requires `colordiff`).
+- `make` highlights make output (requires `colormake`).
+- `wdiff` highlights wdiff output (requires `wdiff `or `git`).
 
 ### Resource usage
 
-  - `psu` displays user owned processes status.
+- `psu` displays user owned processes status.
 
 ### Search and Replace
 
-  - `prep` provides a grep-like pattern search.
-  - `psub` provides a sed-like pattern substitution.
+- `prep` provides a grep-like pattern search.
+- `psub` provides a sed-like pattern substitution.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][1].*
 
-  - [Robby Russell](https://github.com/robbyrussell)
-  - [Suraj N. Kurapati](https://github.com/sunaku)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Robby Russell](https://github.com/robbyrussell)
+- [Suraj N. Kurapati](https://github.com/sunaku)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/wakeonlan/README.md
+++ b/modules/wakeonlan/README.md
@@ -1,18 +1,16 @@
-Wake-on-LAN
-===========
+# Wake-on-LAN
 
 This module provides a wrapper around the [wakeonlan][1] tool.
 
-Usage
------
+## Usage
 
-To use this wrapper, create the *~/.wakeonlan* directory, and place in it one
+To use this wrapper, create the *`~/.wakeonlan`* directory, and place in it one
 file for each device you would like to be able to wake. Give the file a name
 that describes the device, such as its hostname.
 
 Each file should contain a line with the MAC address of the target device and
 the network broadcast address. For instance, there might be a file
-*~/.wakeonlan/leto* with the following contents:
+`*~/.wakeonlan/leto`* with the following contents:
 
 ```conf
 00:11:22:33:44:55:66 192.168.0.255
@@ -20,21 +18,20 @@ the network broadcast address. For instance, there might be a file
 
 To wake that device, use the following command:
 
-```sh
-$ wake leto
+```console
+wake leto
 ```
 
 For more information on the configuration file format, read the
 [wakeonlan man page][2].
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via [issue tracker][3].*
 
-  - [Paul Dann](https://github.com/giddie)
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Paul Dann](https://github.com/giddie)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: http://gsd.di.uminho.pt/jpo/software/wakeonlan/
-[2]: http://man.cx/wakeonlan
+[2]: https://man.cx/wakeonlan
 [3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/yum/README.md
+++ b/modules/yum/README.md
@@ -1,28 +1,25 @@
-Yum
-===
+# Yum
 
-Defines [yum][1] aliases.
+Defines [*yum*][1] aliases.
 
-Aliases
--------
+## Aliases
 
-  - `yumc` removes package(s) and leaves.
-  - `yumi` installs package(s).
-  - `yumh` displays history.
-  - `yuml` lists packages.
-  - `yumL` lists installed packages.
-  - `yumq` displays package information.
-  - `yumr` removes package(s).
-  - `yums` searches for a package.
-  - `yumu` updates packages.
-  - `yumU` upgrades packages.
+- `yumc` removes package(s) and leaves.
+- `yumi` installs package(s).
+- `yumh` displays history.
+- `yuml` lists packages.
+- `yumL` lists installed packages.
+- `yumq` displays package information.
+- `yumr` removes package(s).
+- `yums` searches for a package.
+- `yumu` updates packages.
+- `yumU` upgrades packages.
 
-Authors
--------
+## Authors
 
 *The authors of this module should be contacted via the [issue tracker][2].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: http://yum.baseurl.org
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/runcoms/README.md
+++ b/runcoms/README.md
@@ -1,34 +1,32 @@
-Configuration Files
-===================
+# Configuration Files
 
 Zsh has several system-wide and user-local configuration files.
 
 Prezto has one user-local configuration file.
 
 System-wide configuration files are installation-dependent but are installed
-in */etc* by default.
+in *`/etc`* by default.
 
 User-local configuration files have the same name as their global counterparts
 but are prefixed with a dot (hidden). Zsh looks for these files in the path
 stored in the `$ZDOTDIR` environment variable. However, if said variable is
 not defined, Zsh will use the user's home directory.
 
-File Descriptions
------------------
+## File Descriptions
 
 The configuration files are read in the following order:
 
-  01. /etc/zshenv
-  02. ~/.zshenv
-  03. /etc/zprofile
-  04. ~/.zprofile
-  05. /etc/zshrc
-  06. ~/.zshrc
-  07. ~/.zpreztorc
-  08. /etc/zlogin
-  09. ~/.zlogin
-  10. ~/.zlogout
-  11. /etc/zlogout
+01. */etc/zshenv*
+02. *~/.zshenv*
+03. */etc/zprofile*
+04. *~/.zprofile*
+05. */etc/zshrc*
+06. *~/.zshrc*
+07. *~/.zpreztorc*
+08. */etc/zlogin*
+09. *~/.zlogin*
+10. *~/.zlogout*
+11. */etc/zlogout*
 
 ### zshenv
 
@@ -37,16 +35,16 @@ small as possible and should only define environment variables.
 
 ### zprofile
 
-This file is similar to zlogin, but it is sourced before zshrc. It was added
-for [KornShell][1] fans. See the description of zlogin below for what it may
+This file is similar to *zlogin*, but it is sourced before *zshrc*. It was added
+for [KornShell][1] fans. See the description of *zlogin* below for what it may
 contain.
 
-zprofile and zlogin are not meant to be used concurrently but can be done so.
+*zprofile* and *zlogin* are not meant to be used together but can be done so.
 
 ### zshrc
 
-This file is sourced by interactive shells. It should define aliases,
-functions, shell options, and key bindings.
+This file is sourced by interactive shells. It should define aliases, functions,
+shell options, and key bindings.
 
 ### zpreztorc
 
@@ -54,9 +52,9 @@ This file configures Prezto.
 
 ### zlogin
 
-This file is sourced by login shells after zshrc, and thus, it should contain
+This file is sourced by login shells after *zshrc*. Thus, it should contain
 commands that need to execute at login. It is usually used for messages such as
-[fortune][2], [msgs][3], or for the creation of files.
+[*fortune*][2], [*msgs*][3], or for the creation of files.
 
 This is not the file to define aliases, functions, shell options, and key
 bindings. It should not change the shell environment.
@@ -64,16 +62,15 @@ bindings. It should not change the shell environment.
 ### zlogout
 
 This file is sourced by login shells during logout. It should be used for
-displaying messages and the deletion of files.
+displaying messages and for deletion of files.
 
-Authors
--------
+## Authors
 
 *The authors of these files should be contacted via the [issue tracker][4].*
 
-  - [Sorin Ionescu](https://github.com/sorin-ionescu)
+- [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: http://www.kornshell.com
-[2]: http://en.wikipedia.org/wiki/Fortune_(Unix)
-[3]: http://www.manpagez.com/man/1/msgs
+[1]: https://www.kornshell.com
+[2]: https://en.wikipedia.org/wiki/Fortune_(Unix)
+[3]: https://www.manpagez.com/man/1/msgs
 [4]: https://github.com/sorin-ionescu/prezto/issues


### PR DESCRIPTION
General purpose reformating and rewording in (a few places). This should also make markdown linting happier.
 
Prefer back-ticks wherever useful and use `console` for code blocks to be executed on terminal.
 
Also, update references links wherever possible (including update from 'http://' to 'https://').