### PR TITLE
prompt: Fix git submodule path for 'pure' with actual path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 [submodule "modules/prompt/external/agnoster"]
 	path = modules/prompt/external/agnoster
 	url = https://github.com/agnoster/agnoster-zsh-theme.git
-[submodule "modules/prompt/functions/pure"]
+[submodule "modules/prompt/external/pure"]
 	path = modules/prompt/external/pure
 	url = https://github.com/sindresorhus/pure.git
 [submodule "modules/fasd/external"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To pull the latest changes and update submodules manually:
 ```console
 cd $ZPREZTODIR
 git pull
+git submodule sync --recursive
 git submodule update --init --recursive
 ```
 

--- a/init.zsh
+++ b/init.zsh
@@ -44,6 +44,7 @@ function zprezto-update {
         printf "There is an update available. Trying to pull.\n\n"
         if git pull --ff-only; then
           printf "Syncing submodules\n"
+          git submodule sync --recursive
           git submodule update --init --recursive
           return $?
         else


### PR DESCRIPTION
In addition to fixing git submodule path for 'pure' with the actual path, we also apply submodules' path change in doc and `zprezto-update` function.
 
Accordingly, updated instruction and `zprezto-update` function to synchronizes submodules' remote URL configuration setting to the updated value automatically.

---
**WARNING:** This will require synchronizing submodules' remote URL configuration setting to the value specified in `.gitmodules` by doing: `git submodule sync --recursive` in your Prezto location.

---
Supersedes and resolves #1827
