### PR TITLE
history: use external `mv` command for HISTFILE migration

### DIFF
--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -46,7 +46,7 @@ NOTICE: Default path of 'HISTFILE' has changed from '${OLD_HISTFILE/#$HOME/~}'
         to '${HISTFILE/#$HOME/~}'.
         Attempting to rename the existing 'HISTFILE' ...
 EON
-    mv -v "$OLD_HISTFILE" "$HISTFILE"
+    command mv -v "$OLD_HISTFILE" "$HISTFILE"
 
   # New 'HISTFILE' does exist and is older than legacy one, just warn.
   elif [[ "$OLD_HISTFILE" -nt "$HISTFILE" ]]; then


### PR DESCRIPTION
This will make sure the actual external command `mv` is used instead of wrapper function.