### PR TITLE
utility: Detect GNU 'ls' before applying the relevant tweaks

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -2,6 +2,11 @@
 
 Defines general aliases and functions.
 
+**Note:** Some of the utilities configured in this module might be provided via
+GNU utilities with incompatible arguments on non-GNU systems. In such cases,
+using [*`gnu-utility`*][1] module is recommended and it must be loaded
+**before** this module.
+
 ## Settings
 
 ### Highlighting
@@ -107,7 +112,7 @@ zstyle ':prezto:module:utility' correct 'no'
 - `lt` lists sorted by date, most recent last.
 - `lc` lists sorted by date, most recent last, shows change time.
 - `lu` lists sorted by date, most recent last, shows access time.
-- `sl` lists directory contents (`ls`).
+- `sl` lists directory contents (correction for `ls`).
 
 ### macOS Everywhere
 
@@ -181,10 +186,11 @@ In addition, the following aliases have been added:
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+*The authors of this module should be contacted via the [issue tracker][2].*
 
 - [Robby Russell](https://github.com/robbyrussell)
 - [Suraj N. Kurapati](https://github.com/sunaku)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: https://github.com/sorin-ionescu/prezto/issues
+[1]: ../gnu-utility#readme
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -64,19 +64,19 @@ alias sa='alias | grep -i'
 alias type='type -a'
 
 # Safe ops. Ask the user before doing anything destructive.
-alias rmi="${aliases[rm]:-rm} -i"
-alias mvi="${aliases[mv]:-mv} -i"
 alias cpi="${aliases[cp]:-cp} -i"
 alias lni="${aliases[ln]:-ln} -i"
+alias mvi="${aliases[mv]:-mv} -i"
+alias rmi="${aliases[rm]:-rm} -i"
 if zstyle -T ':prezto:module:utility' safe-ops; then
-  alias rm="${aliases[rm]:-rm} -i"
-  alias mv="${aliases[mv]:-mv} -i"
   alias cp="${aliases[cp]:-cp} -i"
   alias ln="${aliases[ln]:-ln} -i"
+  alias mv="${aliases[mv]:-mv} -i"
+  alias rm="${aliases[rm]:-rm} -i"
 fi
 
 # ls
-if is-callable 'dircolors'; then
+if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*GNU *} ]]; then
   # GNU Core Utilities
 
   if zstyle -T ':prezto:module:utility:ls' dirs-first; then
@@ -84,12 +84,13 @@ if is-callable 'dircolors'; then
   fi
 
   if zstyle -t ':prezto:module:utility:ls' color; then
-    # Call dircolors to define colors if they're missing
-    if [[ -z "$LS_COLORS" ]]; then
-      if [[ -s "$HOME/.dir_colors" ]]; then
-        eval "$(dircolors --sh "$HOME/.dir_colors")"
+    # Define colors for GNU ls if they're not already defined
+    if (( ! $+LS_COLORS )); then
+      # Try dircolors when available
+      if is-callable 'dircolors'; then
+        eval "$(dircolors --sh $HOME/.dir_colors(.N))"
       else
-        eval "$(dircolors --sh)"
+        export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
       fi
     fi
 
@@ -99,15 +100,11 @@ if is-callable 'dircolors'; then
   fi
 else
   # BSD Core Utilities
+
   if zstyle -t ':prezto:module:utility:ls' color; then
     # Define colors for BSD ls if they're not already defined
-    if [[ -z "$LSCOLORS" ]]; then
+    if (( ! $+LSCOLORS )); then
       export LSCOLORS='exfxcxdxbxGxDxabagacad'
-    fi
-
-    # Define colors for the completion system if they're not already defined
-    if [[ -z "$LS_COLORS" ]]; then
-      export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
     fi
 
     alias ls="${aliases[ls]:-ls} -G"
@@ -121,12 +118,15 @@ alias ll='ls -lh'        # Lists human readable sizes.
 alias lr='ll -R'         # Lists human readable sizes, recursively.
 alias la='ll -A'         # Lists human readable sizes, hidden files.
 alias lm='la | "$PAGER"' # Lists human readable sizes, hidden files through pager.
-alias lx='ll -XB'        # Lists sorted by extension (GNU only).
 alias lk='ll -Sr'        # Lists sorted by size, largest last.
 alias lt='ll -tr'        # Lists sorted by date, most recent last.
 alias lc='lt -c'         # Lists sorted by date, most recent last, shows change time.
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
-alias sl='ls'            # I often screw this up.
+alias sl='ls'            # Correction for common spelling error.
+
+if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*GNU *} ]]; then
+  alias lx='ll -XB'      # Lists sorted by extension (GNU only).
+fi
 
 # Grep
 if zstyle -t ':prezto:module:utility:grep' color; then


### PR DESCRIPTION
Detect `ls` provided by GNU Core Utilities upfront before applying the relevant settings and aliases.

The revised logic takes the following aspects into consideration:
- `is-callable 'dircolors'` is not a sufficient test for verifying if the `ls` in scope is _also_ provided by GNU Core Utilities. `ls` can continue to be the one provided by BSD Core Utilities because of its precedence in `$path`.
- The `ls` in scope anyway can be either GNU Utils provided or BSD Utils provided depending on either `$path` precedence, soft link (via `ln -s`), or wrapper function (via 'gnu-utility' module).
- So instead of '_guessing_' the possible one, just detect if it is from GNU Utils and apply the relevant settings and aliases.
- Note that GNU prefixed `ls` (`gls`) is intentionally not honored in this case to avoid possible conflict/shadowing with other `gls` callable (can happen if 'git' module is used, for example). Besides, honoring `gls` would imply we honor other commands (like `mv`, `rm` etc.) to be consistent. We have a module *`gnu-utils`* dedicated for that after all.

Also closes #1752.