### PR TITLE
general: Update documentation better qualifying runcom paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,32 @@ version is **4.3.11**.
     git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
     ```
 
-03. Create a new Zsh configuration by copying the Zsh configuration files
-    provided:
+    <details>
+      <summary><em>Optional: Installing in <code>$XDG_CONFIG_HOME</code></em></summary>
+
+      Optionally, if you already have `$XDG_CONFIG_HOME` configured (usually as
+      _`$HOME/.config`_ by default) and intend to install Prezto under
+      _`$XDG_CONFIG_HOME/zsh`_ instead, you can clone the repository there and
+      configure `$ZDOTDIR` separately if not already configured.
+
+      - Clone the repository:
+
+        ```console
+        git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh}/.zprezto"
+        ```
+
+      - Configure `$XDG_CONFIG_HOME` and `$ZDOTDIR` in _`${$HOME}/.zshenv`_:
+
+        ```sh
+        export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:=$HOME/.config}"
+        export ZDOTDIR="${ZDOTDIR:=$XDG_CONFIG_HOME/zsh}"
+        source "$ZDOTDIR/.zshenv"
+        ```
+
+    </details>
+
+03. Create a new Zsh configuration by copying/linking the Zsh configuration
+    files provided:
 
     ```console
     setopt EXTENDED_GLOB
@@ -34,10 +58,10 @@ version is **4.3.11**.
     **Note:** If you already have any of the given configuration files, `ln` in
     the above operation will cause an error. In simple cases, you can load
     Prezto by adding the line `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"` to
-    the bottom of your *${ZDOTDIR:-$HOME}/.zshrc* and keep the rest of your Zsh
-    configuration intact. For more complicated setups, we recommend that you
+    the bottom of your _`${ZDOTDIR:-$HOME}/.zshrc`_ and keep the rest of your
+    Zsh configuration intact. For more complicated setups, we recommend that you
     back up your original configs and replace them with the provided Prezto
-    *runcoms*.
+    [_`runcoms`_][10].
 
 04. Set Zsh as your default shell:
 
@@ -50,7 +74,7 @@ version is **4.3.11**.
 ### Troubleshooting
 
 If you are not able to find certain commands after switching to Prezto, modify
-the `PATH` variable in *${ZDOTDIR:-$HOME}/.zprofile* then open a new Zsh
+the `PATH` variable in _`${ZDOTDIR:-$HOME}/.zprofile`_ then open a new Zsh
 terminal window or tab.
 
 ## Updating
@@ -76,33 +100,33 @@ accompanying README files to learn about what is available.
 
 ### Modules
 
-01. Browse */modules* to see what is available.
-02. Load the modules you need in *${ZDOTDIR:-$HOME}/.zpreztorc* then open a new
-    Zsh terminal window or tab.
+01. Browse [_`modules`_][9] to see what is available.
+02. Load the modules you need in _`${ZDOTDIR:-$HOME}/.zpreztorc`_ and then open
+    a new Zsh terminal window or tab.
 
 ### Themes
 
 01. For a list of themes, type `prompt -l`.
 02. To preview a theme, type `prompt -p name`.
-03. Load the theme you like in *${ZDOTDIR:-$HOME}/.zpreztorc* then open a new
-    Zsh terminal window or tab.
+03. Load the theme you like in _`${ZDOTDIR:-$HOME}/.zpreztorc`_ and then
+    open a new Zsh terminal window or tab.
 
     ![sorin theme][2]
-    Note that the *git* module may be required for special symbols to appear,
-    such as those on the right of the above image. Add `'git'` to the `pmodule`
-    list (under `zstyle ':prezto:load' pmodule \` in your
-    *${ZDOTDIR:-$HOME}/.zpreztorc*) to enable this module.
+    Note that the [_`git`_][11] module may be required for special symbols to
+    appear, such as those on the right of the above image. Add `'git'` to the
+    `pmodule` list (under `zstyle ':prezto:load' pmodule \` in your
+    _`${ZDOTDIR:-$HOME}/.zpreztorc`_) to enable this module.
 
 ### External Modules
 
-01. By default modules will be loaded from */modules* and */contrib*.
+01. By default modules will be loaded from [_`/modules`_][9] and _`/contrib`_.
 02. Additional module directories can be added to the
-    `:prezto:load:pmodule-dirs` setting in *${ZDOTDIR:-$HOME}/.zpreztorc*.
+    `:prezto:load:pmodule-dirs` setting in _`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
     Note that module names need to be unique or they will cause an error when
     loading.
 
-    ```console
+    ```sh
     zstyle ':prezto:load' pmodule-dirs $HOME/.zprezto-contrib
     ```
 
@@ -129,3 +153,6 @@ This project is licensed under the MIT License.
 [6]: https://git.github.io/git-reference/
 [7]: http://www.bash2zsh.com/zsh_refcard/refcard.pdf
 [8]: https://grml.org/zsh/zsh-lovers.html
+[9]: modules#readme
+[10]: runcoms#readme
+[11]: modules/git#readme

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,6 +1,6 @@
 # Modules
 
-Load modules in *~/.zpreztorc*. The order matters.
+Load modules in _`${ZDOTDIR:-$HOME}/.zpreztorc`_. The order matters.
 
 ```sh
 zstyle ':prezto:load' pmodule 'environment' 'terminal'
@@ -29,11 +29,11 @@ Sets directory options and defines directory aliases.
 
 ## DNF
 
-Defines *dnf* aliases.
+Defines _dnf_ aliases.
 
 ## Dpkg
 
-Defines *dpkg* aliases and functions.
+Defines _dpkg_ aliases and functions.
 
 ## Editor
 

--- a/modules/archive/README.md
+++ b/modules/archive/README.md
@@ -2,6 +2,10 @@
 
 Provides functions to create, list, and extract archives.
 
+This module must be loaded _before_ the [_`completion`_][1] module so that the
+provided completion definitions are loaded automatically by _`completion`_
+module.
+
 ## Functions
 
 - `archive` creates an archive based on the provided archive name.
@@ -13,20 +17,20 @@ Provides functions to create, list, and extract archives.
 The following archive formats are supported when the required utilities are
 installed:
 
-- *.tar.gz*, *.tgz* require `tar` (optionally `pigz`).
-- *.tar.bz2*, *.tbz* require `tar` (optionally `pbzip2`).
-- *.tar.xz*, *.txz* require `tar` with *xz* support.
-- *.tar.zma*, *.tlz* require `tar` with *lzma* support.
-- *.tar* requires `tar`.
-- *.gz* requires `gunzip`.
-- *.bz2* requires `bunzip2`.
-- *.xz* requires `unxz`.
-- *.lzma* requires `unlzma`.
-- *.Z* requires `uncompress`.
-- *.zip*, *.jar* requires `unzip`.
-- *.rar* requires `rar` (needed for `archive` support), `unrar` or `lsar` and `unar`.
-- *.7z* requires `7za`.
-- *.deb* requires `ar`, `tar`.
+- _.tar.gz_, _.tgz_ require `tar` (optionally `pigz`).
+- _.tar.bz2_, _.tbz_ require `tar` (optionally `pbzip2`).
+- _.tar.xz_, _.txz_ require `tar` with _xz_ support.
+- _.tar.zma_, _.tlz_ require `tar` with _lzma_ support.
+- _.tar_ requires `tar`.
+- _.gz_ requires `gunzip`.
+- _.bz2_ requires `bunzip2`.
+- _.xz_ requires `unxz`.
+- _.lzma_ requires `unlzma`.
+- _.Z_ requires `uncompress`.
+- _.zip_, _.jar_ requires `unzip`.
+- _.rar_ requires `rar` (needed for `archive` support), `unrar` or `lsar` and `unar`.
+- _.7z_ requires `7za`.
+- _.deb_ requires `ar`, `tar`.
 
 Additionally, if `pigz` and/or `pbzip2` are installed, `archive` will use them
 over their traditional counterparts, `gzip` and `bzip2` respectively, to take
@@ -34,14 +38,16 @@ full advantage of all available CPU cores for compression.
 
 ## Alternatives
 
-Specifically on macOS, [The Unarchiver][1] provides a similar command line tool
+Specifically on macOS, [The Unarchiver][2] provides a similar command line tool
 which doesn't depend on a number of other programs being installed.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Matt Hamilton](https://github.com/Eriner)
 
-[1]: https://theunarchiver.com/command-line
+[1]: ../completion#readme
+[2]: https://theunarchiver.com/command-line
+[3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/autosuggestions/README.md
+++ b/modules/autosuggestions/README.md
@@ -5,12 +5,15 @@ Integrates [zsh-autosuggestions][1] into Prezto, which implements the
 of a previously entered command and Zsh suggests commands as you type based on
 history and completions.
 
-If this module is used in conjunction with the *syntax-highlighting* module,
-this module must be loaded **after** the *syntax-highlighting* module.
+If this module is used in conjunction with the [_`syntax-highlighting`_][3]
+module, this module must be loaded _after_ the _`syntax-highlighting`_ module.
 
-If this module is used in conjunction with the *history-substring-search*
-module, this module must be loaded **after** the *history-substring-search*
+If this module is used in conjunction with the [_`history-substring-search`_][4]
+module, this module must be loaded _after_ the _`history-substring-search`_
 module.
+
+To elaborate, the relative order of loading the modules would be
+_`autosuggestions`_, _`syntax-highlighting`_ and _`history-substring-search`_.
 
 ## Contributors
 
@@ -22,17 +25,18 @@ against it.
 
 ### Highlighting
 
-If colors are enabled, *autosuggestions* will automatically highlight
+If colors are enabled, _autosuggestions_ will automatically highlight
 positive results.
 
 To enable highlighting for this module only, add the following line to
-*~/.zpreztorc*:
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:autosuggestions' color 'yes'
 ```
 
-To set the query found color, add the following line to *~/.zpreztorc*:
+To set the query found color, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:autosuggestions:color' found ''
@@ -47,10 +51,12 @@ also have the `history` module enabled.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/tarruda/zsh-autosuggestions
 [2]: https://fishshell.com
-[3]: https://github.com/sorin-ionescu/prezto/issues
+[3]: ../syntax-highlighting#readme
+[4]: ../history-substring-search#readme
+[5]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -12,7 +12,7 @@ a recent version of Homebrew installed, you might also need to tap the
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][4].*
+_The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Joseph Booker](https://github.com/sargas)
 - [Indrajit Raychaudhuri](https://github.com/indrajitr)

--- a/modules/completion/README.md
+++ b/modules/completion/README.md
@@ -3,7 +3,8 @@
 Loads and configures <kbd>TAB</kbd> completion and provides additional
 completions from the [zsh-completions][1] project.
 
-This module must be loaded **after** the *utility* module.
+This module must be loaded late _after_ the _`utility`_ module and all other
+modules that provide completion definitions.
 
 ## Options
 
@@ -14,24 +15,24 @@ This module must be loaded **after** the *utility* module.
 - `AUTO_LIST` automatically list choices on ambiguous completion.
 - `AUTO_PARAM_SLASH` if completed parameter is a directory, add a trailing
   slash (`/`).
-- `EXTENDED_GLOB` needed for file modification glob modifiers with *compinit*.
+- `EXTENDED_GLOB` needed for file modification glob modifiers with _compinit_.
 - `MENU_COMPLETE` do not autoselect the first completion entry.
 - `FLOW_CONTROL` disable start/stop characters in shell editor.
 
 ## Settings
 
-### Ignore */etc/hosts* Entries
+### Ignore _`/etc/hosts`_ Entries
 
-To ignore certain entries from static */etc/hosts* for host completion, add the
-following lines in *~/.zpreztorc* with the IP addresses of the hosts as they
-appear in */etc/hosts*. Both IP address and the corresponding hostname will be
-ignored during host completion. However, some of the entries ignored from
-*/etc/hosts* still might appear during completion because of their presence in
-*ssh* configuration or history).
+To ignore certain entries from static _`/etc/hosts`_ for host completion, add
+the following lines in _`${ZDOTDIR:-$HOME}/.zpreztorc`_ with the IP addresses of
+the hosts as they appear in _`/etc/hosts`_. Both IP address and the associated
+hostname(s) will be ignored during host completion. However, some of the entries
+ignored from _`/etc/hosts`_ still might appear during completion because of
+their presence in _ssh_ configuration or history).
 
 ```sh
 zstyle ':prezto:module:completion:*:hosts' etc-host-ignores \
-  '0.0.0.0' '127.0.0.1'
+    '0.0.0.0' '127.0.0.1'
 ```
 
 ## Contributors
@@ -41,7 +42,7 @@ its rules and regulations. This module will be synchronized against it.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/directory/README.md
+++ b/modules/directory/README.md
@@ -22,7 +22,7 @@ Sets directory options and defines directory aliases.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][1]._
 
 - [James Cox](https://github.com/imajes)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/dnf/README.md
+++ b/modules/dnf/README.md
@@ -17,7 +17,7 @@ Defines [dnf][1] aliases.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/docker/README.md
+++ b/modules/docker/README.md
@@ -134,8 +134,10 @@ Defines [Docker][1] aliases and functions.
 - `dkm` is short for `docker-machine`
 - `dkma` Get or set the active machine
 - `dkmcp` Copy files between machines
-- `dkmd` Set up the default machine ; alowing you to use `dkme` without arguments
-- `dkme` Set up the environment for the Docker client (eg: `dkme staging` to toggle to staging)
+- `dkmd` Set up the default machine ; alowing you to use `dkme` without
+  arguments
+- `dkme` Set up the environment for the Docker client (eg: `dkme staging` to
+  toggle to staging)
 - `dkmin` Inspect information about a machine
 - `dkmip` Get the IP address of a machine
 - `dkmk` Kill a machine
@@ -175,8 +177,8 @@ Defines [Docker][1] aliases and functions.
 - `dkcsc` Set number of containers for a service
 - `dkcS` Restart services
 - `dkcu` Create and start containers
-- `dkcU` Create and start containers in detached mode:
-           Run containers in the background, print new container names
+- `dkcU` Create and start containers in detached mode: Run containers in the
+  background, print new container names
 - `dkcV` Show the Docker-Compose version information
 - `dkcx` Stop services
 

--- a/modules/dpkg/README.md
+++ b/modules/dpkg/README.md
@@ -1,6 +1,6 @@
 # Dpkg
 
-Defines [*dpkg*][1] aliases and functions.
+Defines [_dpkg_][1] aliases and functions.
 
 ## Aliases
 
@@ -27,7 +27,7 @@ Defines [*dpkg*][1] aliases and functions.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Daniel Bolton](https://github.com/dbb)
 - [Benjamin Boudreau](https://github.com/dreur)

--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -14,17 +14,17 @@ Sets editor specific key bindings options and variables.
 
 ### Key bindings
 
-To enable key bindings, add the following to *~/.zpreztorc*, and replace
-'bindings' with 'emacs' or 'vi'.
+To enable key bindings, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_,
+and replace `'<bindings>'` with `'emacs'` or `'vi'`.
 
 ```sh
-zstyle ':prezto:module:editor' key-bindings 'bindings'
+zstyle ':prezto:module:editor' key-bindings '<bindings>'
 ```
 
 ### Dot Expansion
 
 To enable the auto conversion of .... to ../.., add the following to
-*~/.zpreztorc*.
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:editor' dot-expansion 'yes'
@@ -32,8 +32,8 @@ zstyle ':prezto:module:editor' dot-expansion 'yes'
 
 ### PS Context
 
-To enable the prompt context to be set, add the following to your
-*~/.zpreztorc*.
+To enable the prompt context to be set, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:editor' ps-context 'yes'
@@ -76,26 +76,26 @@ To indicate when the editor is completing, add the following to your
 zstyle ':prezto:module:editor:info:completing' format '...'
 ```
 
-Then add `$editor_info[context]`, where context is *keymap*, *insert*, or
-*overwrite*, to `$PROMPT` or `$RPROMPT`.
+Then add `$editor_info[context]`, where context is _keymap_, _insert_, or
+_overwrite_, to `$PROMPT` or `$RPROMPT`.
 
 ## Convenience Functions
 
 ### bindkey-all
 
-Provides a function `bindkey-all` which can be useful for checking how all of the
-keys are bound. Normal `bindkey` command will only list the keys bound for one
-keymap, which is not as useful if you want to grep through the output. The
-keymap's names go to stderr so when you grep through bindkey-all's output you
+Provides a function `bindkey-all` which can be useful for checking how all of
+the keys are bound. Normal `bindkey` command will only list the keys bound for
+one keymap, which is not as useful if you want to grep through the output. The
+keymap's names go to stderr so when you grep through `bindkey-all`'s output you
 will still see the headings and can tell which keymap each binding goes to.
 
 It will also pass through arguments so you can use bindkey-all to set bindings
-for all keymaps at once. If provided arguments it will *not* print out the
+for all keymaps at once. If provided arguments it will _not_ print out the
 names of each of the keymaps, and just run the command for each keymap.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][1]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/emacs/README.md
+++ b/modules/emacs/README.md
@@ -21,7 +21,7 @@ execution of `carton`.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sebastian Wiesner](https://github.com/lunaryorn)
 

--- a/modules/environment/README.md
+++ b/modules/environment/README.md
@@ -6,9 +6,10 @@ This module must be loaded first.
 
 ## Contributors
 
-This module **MUST NOT** rely on any command not built in Zsh.
+This module **MUST NOT** rely on any command that is not built in Zsh.
 
-Non-interactive environment variables should be defined in [`zshenv`][1].
+Non-interactive environment variables should be defined in
+[_`${ZDOTDIR:-$HOME}/.zshenv`_][1].
 
 ## Options
 
@@ -43,9 +44,9 @@ Non-interactive environment variables should be defined in [`zshenv`][1].
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zshenv
+[1]: ../../runcoms#zshenv
 [2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -2,11 +2,11 @@
 
 [Fasd][1] is a command-line productivity booster, inspired by tools like
 [autojump][2], [z][3] and [v][4], it offers quick access to files and
-directories by keeping track of files and directories  that were previously
+directories by keeping track of files and directories that were previously
 accessed.
 
-For completion to work, this module must be loaded **after** the *completion*
-module.
+For shell completion to work, this module must be loaded _after_ the
+[_`completion`_][5] module.
 
 The Prezto Fasd configuration differs from the default. The default aliases have
 been disabled.
@@ -23,12 +23,12 @@ instead of the bundled version.
 
 ## Completion
 
-Type `,`, `f,`, `d,` in front of a comma-separated query or type `,,`,  `,,f`,
+Type `,`, `f,`, `d,` in front of a comma-separated query or type `,,`, `,,f`,
 `,,d` at the end of a comma-separated query then hit <kbd>TAB</kbd>.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][5].*
+_The authors of this module should be contacted via the [issue tracker][6]._
 
 - [Wei Dai](https://github.com/clvv)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
@@ -37,4 +37,5 @@ Type `,`, `f,`, `d,` in front of a comma-separated query or type `,,`,  `,,f`,
 [2]: https://github.com/joelthelion/autojump
 [3]: https://github.com/rupa/z
 [4]: https://github.com/rupa/v
-[5]: https://github.com/sorin-ionescu/prezto/issues
+[5]: ../completion#readme
+[6]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -3,34 +3,42 @@
 Enhances the [Git][1] distributed version control system by providing aliases,
 functions and by exposing repository status information to prompts.
 
-Git **1.7.2** is the [minimum required version][7].
+This module must be loaded _before_ the [_`completion`_][13] module so that the
+provided completion definitions are loaded automatically by _`completion`_
+module.
+
+**Note:** Git **1.7.2** is the [minimum required version][7].
 
 ## Settings
 
 ### Log
 
-The format of the [git-log][8] output is configurable via the following style,
-where context is *brief*, *oneline*, and *medium*, which will be passed to the
-`--pretty=format:` switch.
+To configure the format of the [git-log][8] output, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_, and replace `'<context>'` with `'brief'`,
+`'oneline'`, and `'medium'`. This will be passed to the `--pretty=format:`
+switch.
 
 ```sh
-zstyle ':prezto:module:git:log:context' format ''
+zstyle ':prezto:module:git:log:context' format '<context>'
 ```
 
 ### Status
 
-Retrieving the status of a repository with submodules can take a long time.
-Submodules may be ignored when they are *dirty*, *untracked*, *all*, or *none*.
+Retrieving the status of a repository with [git-submodule][9] can take a long
+time. To configure the submodules to ignore, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_, and replace `'<state>'` with `'dirty'`,
+`'untracked'`, `'all'`, or `'none'`.
 
 ```sh
-zstyle ':prezto:module:git:status:ignore' submodules 'all'
+zstyle ':prezto:module:git:status:ignore' submodules '<state>'
 ```
 
 This setting affects all aliases and functions that call `git-status`.
 
 ## Aliases
 
-Aliases are enabled by default. You can disable them with:
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:git:alias' skip 'yes'
@@ -68,15 +76,15 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 - `gco` checks out a branch or paths to work tree.
 - `gcO` checks out hunks from the index or the tree interactively.
 - `gcf` amends the tip of the current branch using the same log message as
-  *HEAD*.
+  _HEAD_.
 - `gcSf` amends the tip of the current branch using the same log message as
-  *HEAD*. (Signed)
+  _HEAD_. (Signed)
 - `gcF` amends the tip of the current branch.
 - `gcSF` amends the tip of the current branch. (Signed)
 - `gcp` applies changes introduced by existing commits.
 - `gcP` applies changes introduced by existing commits without committing.
 - `gcr` reverts existing commits by reverting patches and recording new commits.
-- `gcR` removes the *HEAD* commit.
+- `gcR` removes the _HEAD_ commit.
 - `gcs` displays various types of objects.
 - `gcsS` displays commits with GPG signature.
 - `gcl` lists lost commits.
@@ -239,13 +247,13 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 - `gpa` updates remote branches along with associated objects.
 - `gpA` updates remote branches and tags along with associated objects.
 - `gpt` updates remote tags along with associated objects.
-- `gpc` updates remote refs along with associated objects and adds *origin* as
+- `gpc` updates remote refs along with associated objects and adds _origin_ as
   an upstream reference for the current branch.
 - `gpp` pulls and pushes from origin to origin.
 
 ### Rebase (r)
 
-- `gr` forward-ports local commits to the updated upstream head.
+- `gr` forward-ports local commits to the updated upstream _HEAD_.
 - `gra` aborts the rebase.
 - `grc` continues the rebase after merge conflicts are resolved.
 - `gri` makes a list of commits to be rebased and opens the editor.
@@ -288,7 +296,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 - `gSl` lists the commits of all submodules.
 - `gSm` moves a submodule.
 - `gSs` synchronizes submodules' remote URL to the value specified in
-  *.gitmodules*.
+  _.gitmodules_.
 - `gSu` fetches and merges the latest changes for all submodule.
 - `gSx` removes a submodule.
 
@@ -318,7 +326,7 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 
 The following aliases may shadow system commands:
 
-- `gb` shadows the [GB][9].
+- `gb` shadows the [GB][10].
 - `gm` shadows the [GraphicsMagick image processor][11].
 - `gpt` shadows the [GUID partition table maintenance utility][4].
 - `gs` shadows the [Ghostscript interpreter and previewer][5].
@@ -335,7 +343,7 @@ You can temporarily bypass an alias by prefixing it with a backward slash:
 - `git-commit-lost` lists lost commits.
 - `git-dir` displays the path to the Git directory.
 - `git-hub-browse` opens the [GitHub][3] repository in the default browser.
-- `git-hub-shorten-url` shortens [GitHub URLs][10].
+- `git-hub-shorten-url` shortens [GitHub URLs][12].
 - `git-info` exposes repository information via the `$git_info` associative
   array.
 - `git-root` displays the path to the working tree root.
@@ -357,26 +365,26 @@ zstyle ':prezto:module:git:info:context:subcontext' format 'string'
 
 ### Main Contexts
 
-| Name      | Format Code | Description
-| --------- | :---------: | ----------------------------------------------------
-| action    |     %s      | Special action name
-| ahead     |     %A      | Commits ahead of remote count
-| behind    |     %B      | Commits behind of remote count
-| branch    |     %b      | Branch name
-| commit    |     %c      | Commit hash
-| position  |     %p      | Commits from the nearest tag count
-| remote    |     %R      | Remote name
-| stashed   |     %S      | Stashed states count
+| Name     | Format Code | Description                        |
+| -------- | :---------: | ---------------------------------- |
+| action   |     %s      | Special action name                |
+| ahead    |     %A      | Commits ahead of remote count      |
+| behind   |     %B      | Commits behind of remote count     |
+| branch   |     %b      | Branch name                        |
+| commit   |     %c      | Commit hash                        |
+| position |     %p      | Commits from the nearest tag count |
+| remote   |     %R      | Remote name                        |
+| stashed  |     %S      | Stashed states count               |
 
 ### Concise Contexts
 
-| Name      | Format Code | Description
-| --------- | :---------: | ----------------------------------------------------
-| clean     |     %C      | Clean state
-| dirty     |     %D      | Dirty files count
-| indexed   |     %i      | Indexed files count
-| unindexed |     %I      | Unindexed files count
-| untracked |     %u      | Untracked files count
+| Name      | Format Code | Description           |
+| --------- | :---------: | --------------------- |
+| clean     |     %C      | Clean state           |
+| dirty     |     %D      | Dirty files count     |
+| indexed   |     %i      | Indexed files count   |
+| unindexed |     %I      | Unindexed files count |
+| untracked |     %u      | Untracked files count |
 
 The following contexts must be enabled with the following zstyle:
 
@@ -386,31 +394,31 @@ zstyle ':prezto:module:git:info' verbose 'yes'
 
 ### Verbose Contexts
 
-| Name      | Format Code | Description
-| --------- | :---------: | ----------------------------------------------------
-| added     |     %a      | Added files count
-| clean     |     %C      | Clean state
-| deleted   |     %d      | Deleted files count
-| dirty     |     %D      | Dirty files count
-| modified  |     %m      | Modified files count
-| renamed   |     %r      | Renamed files count
-| unmerged  |     %U      | Unmerged files count
-| untracked |     %u      | Untracked files count
+| Name      | Format Code | Description           |
+| --------- | :---------: | --------------------- |
+| added     |     %a      | Added files count     |
+| clean     |     %C      | Clean state           |
+| deleted   |     %d      | Deleted files count   |
+| dirty     |     %D      | Dirty files count     |
+| modified  |     %m      | Modified files count  |
+| renamed   |     %r      | Renamed files count   |
+| unmerged  |     %U      | Unmerged files count  |
+| untracked |     %u      | Untracked files count |
 
 ### Special Action Contexts
 
-| Name                 |   Format    | Description
-| -------------------- | :---------: | -----------------------------------------
-| apply                |    value    | Applying patches
-| bisect               |    value    | Binary searching for changes
-| cherry-pick          |    value    | Cherry picking
-| cherry-pick-sequence |    value    | Cherry picking sequence
-| merge                |    value    | Merging
-| rebase               |    value    | Rebasing
-| rebase-interactive   |    value    | Rebasing interactively
-| rebase-merge         |    value    | Rebasing merge
-| revert               |    value    | Reverting
-| revert-sequence      |    value    | Reverting sequence
+| Name                 | Format | Description                  |
+| -------------------- | :----: | ---------------------------- |
+| apply                | value  | Applying patches             |
+| bisect               | value  | Binary searching for changes |
+| cherry-pick          | value  | Cherry picking               |
+| cherry-pick-sequence | value  | Cherry picking sequence      |
+| merge                | value  | Merging                      |
+| rebase               | value  | Rebasing                     |
+| rebase-interactive   | value  | Rebasing interactively       |
+| rebase-merge         | value  | Rebasing merge               |
+| revert               | value  | Reverting                    |
+| revert-sequence      | value  | Reverting sequence           |
 
 First, format the repository state attributes. For example, to format the branch
 and remote names, define the following styles.
@@ -434,19 +442,21 @@ function.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][6].*
+_The authors of this module should be contacted via the [issue tracker][6]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Colin Hebert](https://github.com/ColinHebert)
 
 [1]: https://www.git-scm.com
-[2]: https://github.com/defunkt/hub
+[2]: https://hub.github.com
 [3]: https://www.github.com
 [4]: https://www.manpagez.com/man/8/gpt/
 [5]: https://www.manpagez.com/man/1/gs/
 [6]: https://github.com/sorin-ionescu/prezto/issues
 [7]: https://github.com/sorin-ionescu/prezto/issues/219
-[8]: https://www.kernel.org/pub/software/scm/git/docs/git-log.html
-[9]: https://getgb.io/
-[10]: https://github.com/blog/985-git-io-github-url-shortener
+[8]: https://git-scm.com/docs/git-log
+[9]: https://git-scm.com/docs/git-submodule
+[10]: https://getgb.io/
 [11]: https://www.manpagez.com/man/1/gm/
+[12]: https://github.blog/2011-11-10-git-io-github-url-shortener
+[13]: ../completion#readme

--- a/modules/gnu-utility/README.md
+++ b/modules/gnu-utility/README.md
@@ -9,14 +9,16 @@ utilities will be broken.
 This module wraps GNU utilities in functions without a prefix for interactive
 use.
 
-This module must be loaded **before** the *utility* module.
+This module must be loaded _before_ the [_`utility`_][1] module so that GNU
+utilities enabled in this module are available for configuration in _`utility`_
+module.
 
 ## Settings
 
 ### Prefix
 
-To use a different prefix, add the following to *~/.zpreztorc*, and replace 'g'
-with the desired prefix:
+To use a different prefix, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_, and replace `'g'` with the desired prefix.
 
 ```sh
 zstyle ':prezto:module:gnu-utility' prefix 'g'
@@ -24,8 +26,9 @@ zstyle ':prezto:module:gnu-utility' prefix 'g'
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: https://github.com/sorin-ionescu/prezto/issues
+[1]: ../utility#readme
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/gpg/README.md
+++ b/modules/gpg/README.md
@@ -8,7 +8,7 @@ Provides for an easier use of [GPG][1] by setting up [gpg-agent][2].
 
 To enable OpenSSH Agent protocol emulation, and make `gpg-agent` a drop-in
 replacement for `ssh-agent`, add the following line to
-*`~/.gnupg/gpg-agent.conf`*:
+_`$GNUPGHOME/gpg-agent.conf`_ or _`$$HOME/.gnupg/gpg-agent.conf`_:
 
 ```conf
 enable-ssh-support
@@ -19,7 +19,7 @@ module for additional processing.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/haskell/README.md
+++ b/modules/haskell/README.md
@@ -17,7 +17,7 @@ Install packages into per user directories with `cabal install --user`.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sebastian Wiesner](https://github.com/lunaryorn)
 

--- a/modules/helper/README.md
+++ b/modules/helper/README.md
@@ -19,7 +19,7 @@ Provides helper functions for developing modules.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][1]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -5,8 +5,8 @@ Integrates [`zsh-history-substring-search`][1] into Prezto, which implements the
 a previously entered command and press up and down to cycle through matching
 commands.
 
-If this module is used in conjunction with the *syntax-highlighting* module,
-this module must be loaded **after** the *syntax-highlighting* module.
+If this module is used in conjunction with the [_`syntax-highlighting`_][3]
+module, this module must be loaded _after_ the _`syntax-highlighting`_ module.
 
 ## Contributors
 
@@ -19,7 +19,7 @@ regulations. This module will be synchronized against it.
 ### Case Sensitivity
 
 To enable case-sensitivity for this module only, add the following line to
-*~/.zpreztorc*:
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:history-substring-search' case-sensitive 'yes'
@@ -27,29 +27,32 @@ zstyle ':prezto:module:history-substring-search' case-sensitive 'yes'
 
 ### Highlighting
 
-If colors are enabled, *history-substring-search* will automatically highlight
+If colors are enabled, _history-substring-search_ will automatically highlight
 positive results.
 
-To enable highlighting for this module only, add the following line to
-*~/.zpreztorc*:
+To disable highlighting for this module only, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
-zstyle ':prezto:module:history-substring-search' color 'yes'
+zstyle ':prezto:module:history-substring-search' color 'no'
 ```
 
-To set the query found color, add the following line to *~/.zpreztorc*:
+To set the query found color, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:history-substring-search:color' found ''
 ```
 
-To set the query not found color, add the following line to *~/.zpreztorc*:
+To set the query not found color, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:history-substring-search:color' not-found ''
 ```
 
-To set the search globbing flags, add the following line to *~/.zpreztorc*:
+To set the search globbing flags, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:history-substring-search' globbing-flags ''
@@ -57,11 +60,12 @@ zstyle ':prezto:module:history-substring-search' globbing-flags ''
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Suraj N. Kurapati](https://github.com/sunaku)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-history-substring-search
 [2]: https://fishshell.com
-[3]: https://github.com/sorin-ionescu/prezto/issues
+[3]: ../syntax-highlighting#readme
+[4]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -2,24 +2,26 @@
 
 Sets [history][1] options and defines history aliases.
 
-**Note:** Default path of `HISTFILE` has changed from *`${ZDOTDIR:-$HOME}/.zhistory`*
-to *`${ZDOTDIR:-$HOME}/.zsh_history`*. The file will be automatically renamed if
-possible (when the new one doesn't exist). Otherwise, if you want to preserve
-previous history, you will need to move them from *`${ZDOTDIR:-$HOME}/.zhistory`*
-to *`${ZDOTDIR:-$HOME}/.zsh_history`*.
+**Note:** Default path of `HISTFILE` has changed from
+_`${ZDOTDIR:-$HOME}/.zhistory`_ to _`${ZDOTDIR:-$HOME}/.zsh_history`_. The file
+will be automatically renamed if possible (when the new one doesn't exist).
+Otherwise, if you want to preserve previous history, you will need to move them
+from _`${ZDOTDIR:-$HOME}/.zhistory`_ to _`${ZDOTDIR:-$HOME}/.zsh_history`_.
 
-Alternately, you can set `HISTFILE` manually to *`${ZDOTDIR:-$HOME}/.zhistory`*.
+Alternately, you can set `HISTFILE` manually to _`${ZDOTDIR:-$HOME}/.zhistory`_.
 
 ## Options
 
 - `BANG_HIST` treats the **!** character specially during expansion.
-- `EXTENDED_HISTORY` writes the history file in the *:start:elapsed;command* format.
+- `EXTENDED_HISTORY` writes the history file in the _:start:elapsed;command_
+  format.
 - `SHARE_HISTORY` shares history between all sessions. Note that
   `SHARE_HISTORY`, `INC_APPEND_HISTORY`, and `INC_APPEND_HISTORY_TIME` are
   mutually exclusive.
 - `HIST_EXPIRE_DUPS_FIRST` expires a duplicate event first when trimming history.
 - `HIST_IGNORE_DUPS` does not record an event that was just recorded again.
-- `HIST_IGNORE_ALL_DUPS` deletes an old recorded event if a new event is a duplicate.
+- `HIST_IGNORE_ALL_DUPS` deletes an old recorded event if a new event is a
+  duplicate.
 - `HIST_FIND_NO_DUPS` does not display a previously found event.
 - `HIST_IGNORE_SPACE` does not record an event starting with a space.
 - `HIST_SAVE_NO_DUPS` does not write a duplicate event to the history file.
@@ -38,7 +40,7 @@ Alternately, you can set `HISTFILE` manually to *`${ZDOTDIR:-$HOME}/.zhistory`*.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Robby Russell](https://github.com/robbyrussell)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -35,7 +35,7 @@ brew shellenv
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][1]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Griffin Yourick](https://github.com/tough-griff)

--- a/modules/macports/README.md
+++ b/modules/macports/README.md
@@ -14,7 +14,7 @@ Defines MacPorts aliases and adds MacPorts directories to path variables.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][1].*
+_The authors of this module should be contacted via the [issue tracker][1]._
 
 - [Matt Cable](https://github.com/curiousstranger)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -1,24 +1,24 @@
 # Node.js
 
 Provides utility functions for [Node.js][1], loads the Node Version Manager, and
-enables [*npm*][2] completion.
+enables [_npm_][2] completion.
 
 ## nvm
 
-[*nvm*][5] allows for managing multiple, isolated Node.js installations in the
+[_nvm_][5] allows for managing multiple, isolated Node.js installations in the
 home directory.
 
 This will be loaded automatically if nvm is installed in `$NVM_DIR`,
-*~/.nvm*, or nvm is installed with homebrew.
+_`~/.nvm`_, or nvm is installed with Homebrew.
 
 ## nodenv
 
-[*nodenv*][6] does one thing well - it is concerned solely with switching
+[_nodenv_][6] does one thing well - it is concerned solely with switching
 Node versions. It is simple and predictable, Just Works, and is rock solid in
-production. nodenv is forked from the popular [*rbenv*][7].
+production. nodenv is forked from the popular [_rbenv_][7].
 
 This will be loaded automatically if nodenv is installed in `$NODENV_ROOT`,
-*~/.nodenv*, or `nodenv` is on the path.
+_`~/.nodenv`_, or `nodenv` is on the path.
 
 ## Functions
 
@@ -42,7 +42,7 @@ Then add `$node_info[version]` to either `$PROMPT` or `$RPROMPT` and call
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][4].*
+_The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Zeh Rizzatti](https://github.com/zehrizzatti)

--- a/modules/ocaml/README.md
+++ b/modules/ocaml/README.md
@@ -15,7 +15,7 @@ Install packages to your local package directory with `opam install`.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Sebastian Wiesner](https://github.com/lunaryorn)
 

--- a/modules/osx/README.md
+++ b/modules/osx/README.md
@@ -2,13 +2,18 @@
 
 Defines [macOS][1] aliases and functions.
 
+This module must be loaded _before_ the [_`completion`_][2] module so that the
+provided completion definitions are loaded automatically by _`completion`_
+module.
+
 ## Settings
 
 ### Dash Keyword
 
-To change the keyword used by `mand` to open man pages in [*Dash.app*][2] from
-its default value of 'manpages', add the following line in *~/.zpreztorc* and
-replace the **keyword** with the one configured in [*Dash.app*][2].
+To change the keyword used by `mand` to open man pages in [_Dash.app_][3] from
+its default value of 'manpages', add the following line in
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_ and replace the **keyword** with the one
+configured in [_Dash.app_][3].
 
 ```sh
 zstyle ':prezto:module:osx:man' dash-keyword 'keyword'
@@ -16,29 +21,30 @@ zstyle ':prezto:module:osx:man' dash-keyword 'keyword'
 
 ## Aliases
 
-- `cdf` changes the current working director to the current *Finder* directory.
+- `cdf` changes the current working director to the current _Finder_ directory.
 - `pushdf` pushes the current working directory onto the directory queue and
-  changes the current working director to the current *Finder* directory.
+  changes the current working director to the current _Finder_ directory.
 
 ## Functions
 
-- `mand` opens _man_ pages in [*Dash.app*][2].
-- `manp` opens _man_ pages in *Preview.app*.
-- `pfd` prints the current *Finder* directory.
-- `pfs` prints the current *Finder* selection.
-- `tab` creates a new tab (works in both _Terminal_ and [*iTerm.app*][3]).
+- `mand` opens _man_ pages in [_Dash.app_][3].
+- `manp` opens _man_ pages in _Preview.app_.
+- `pfd` prints the current _Finder_ directory.
+- `pfs` prints the current _Finder_ selection.
+- `tab` creates a new tab (works in both _Terminal_ and [_iTerm.app_][4]).
 - `ql` previews files in Quick Look.
-- `osx-rm-dir-metadata` deletes *.DS_Store*, *__MACOSX* cruft.
+- `osx-rm-dir-metadata` deletes _`.DS_Store`_, _`__MACOSX`_ cruft.
 - `osx-ls-download-history` displays the macOS download history.
 - `osx-rm-download-history` deletes the macOS download history.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][4].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://www.apple.com/macos/
-[2]: https://kapeli.com/dash
-[3]: https://www.iterm2.com/
-[4]: https://github.com/sorin-ionescu/prezto/issues
+[2]: ../completion#readme
+[3]: https://kapeli.com/dash
+[4]: https://www.iterm2.com/
+[5]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/pacman/README.md
+++ b/modules/pacman/README.md
@@ -15,11 +15,12 @@ supported by Archlinux. It is currently recommended to manually build AUR
 packages using the [provided instructions][3]. The [aurutils][4] project has a
 set of small utilities to make this easier.
 
-To enable a Pacman frontend, add the following line to *~/.zpreztorc*,
-substituting *pacman_frontend* with the name of the frontend:
+To enable a different Pacman frontend, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_, and replace `'<frontend>'` with the name
+of the preferred frontend.
 
 ```sh
-zstyle ':prezto:module:pacman' frontend 'pacman_frontend'
+zstyle ':prezto:module:pacman' frontend '<frontend>'
 ```
 
 ## Aliases
@@ -52,7 +53,7 @@ zstyle ':prezto:module:pacman' frontend 'pacman_frontend'
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][5].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Benjamin Boudreau](https://github.com/dreur)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/perl/README.md
+++ b/modules/perl/README.md
@@ -6,11 +6,11 @@ Enables local [Perl][1] module installation on macOS and defines aliases.
 
 Perl versions older than 5.14 do not support the local installation of Perl
 modules natively. This module allows for local installation of Perl modules on
-macOS in *`~/Library/Perl/5.12`* by altering the environment.
+macOS in _`~/Library/Perl/5.12`_ by altering the environment.
 
 ### Usage
 
-For Perl versions older than 5.14, install *`local::lib`*.
+For Perl versions older than 5.14, install _`local::lib`_.
 
 ```console
 curl -L -C - -O http://search.cpan.org/CPAN/authors/id/A/AP/APEIRON/local-lib-1.008004.tar.gz
@@ -20,7 +20,7 @@ perl Makefile.PL --bootstrap=$HOME/Library/Perl/5.12
 make && make test && make install
 ```
 
-Install *cpanminus*:
+Install _cpanminus_:
 
 ```console
 curl -L http://cpanmin.us | perl - --self-upgrade
@@ -33,10 +33,10 @@ management of multiple, isolated Perl installations in the home directory.
 
 ## plenv
 
-Yet another alternative is [*plenv*][3]. This is inspired from *rbenv* and
+Yet another alternative is [_plenv_][3]. This is inspired from _rbenv_ and
 enables switching between multiple binary installations.
 
-The subcommands of *plenv* is similar with *rbenv*.
+The subcommands of _plenv_ is similar with _rbenv_.
 
 ## Aliases
 
@@ -96,7 +96,7 @@ Then add `$perl_info[version]` to `$PROMPT` or `$RPROMPT` and call
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][4].*
+_The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/prompt/README.md
+++ b/modules/prompt/README.md
@@ -6,19 +6,19 @@ Loads prompt [themes][1].
 
 ### Prompt Theme
 
-To select a prompt theme, add the following to *~/.zpreztorc*, and replace
-**name** with the name of the theme you wish to load. Setting it to **random**
-will load a random theme.
+To select a prompt theme, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_,
+and replace `'<name>'` with the name of the theme you wish to load. Setting it
+to `'random'` will load a random theme every time.
 
 ```sh
-zstyle ':prezto:module:prompt' theme 'name'
+zstyle ':prezto:module:prompt' theme '<name>'
 ```
 
 ### Prompt Display Length
 
 To change working directory prompt display length from 'short', set the
 following to 'long' (without `~` expansion) or 'full' (with `~` expansion) in
-*~/.zpreztorc*.
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:prompt' pwd-length 'short'
@@ -37,13 +37,13 @@ zstyle ':prezto:module:prompt' show-return-val 'no'
 
 A prompt theme is an autoloadable function file with a special name,
 `prompt_name_setup`, placed anywhere in `$fpath`, but for the purpose of this
-project, themes **should** be placed in the *modules/prompt/functions*
+project, themes **should** be placed in the _modules/prompt/functions_
 directory.
 
 ### Required Variables
 
 To ensure that your function works with the editor-info module you'll need to
-set the following variable in *~/.zpreztorc*:
+set the following variable in _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 # Tell prezto we can manage this prompt
@@ -119,7 +119,7 @@ function prompt_name_preview {
 
 ### Hook Functions
 
-There are many Zsh [hook][2] functions, but mostly the *precmd* hook will be
+There are many Zsh [hook][2] functions, but mostly the _precmd_ hook will be
 used.
 
 #### `prompt_name_precmd`
@@ -156,7 +156,7 @@ patched fonts][5] which should fix most font issues.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/prompt/functions/prompt_cloud_setup
+++ b/modules/prompt/functions/prompt_cloud_setup
@@ -9,7 +9,7 @@
 #   - The prompt is prefixed by a character sequence of your choice.
 #   - Only displays the current directory instead of the full path.
 #   - Displays the current branch when in a git project (this requires loading
-#     the git module before prompt in ~/.zpreztorc).
+#     the git module before prompt in ${ZDOTDIR:-$HOME}/.zpreztorc).
 #   - Displays a character at the end of the prompt when in a git project with
 #     "dirty" files.
 #
@@ -17,7 +17,7 @@
 #   This prompt's prefix symbol and colors are customizable:
 #     prompt cloud [<symbol>] [<color1>] [<color2>]
 #
-#   In ~/.zpreztorc:
+#   In ${ZDOTDIR:-$HOME}/.zpreztorc:
 #     zstyle ':prezto:module:prompt' theme 'cloud' \
 #       ['<symbol>'] \
 #       ['<color1>'] \
@@ -53,7 +53,7 @@ This prompt's prefix symbol and colors are customizable:
 
   prompt cloud [<symbol>] [<color1>] [<color2>]
 
-In ~/.zpreztorc:
+In ${ZDOTDIR:-$HOME}/.zpreztorc:
   zstyle ':prezto:module:prompt' theme 'cloud' ['<symbol>'] ['<color1>'] ['<color2>']
 
 If these options are not provided, the symbol defaults to ☁ with colors cyan

--- a/modules/prompt/init.zsh
+++ b/modules/prompt/init.zsh
@@ -18,7 +18,7 @@ WARNING: Prezto does not support 'powerlevel9k' anymore as it has
          been deprecated and is not supported by its author.
          Consider migrating to 'powerlevel10k' instead by setting:
          zstyle ':prezto:module:prompt' theme 'powerlevel10k'
-         in ~/.zpreztorc.
+         in ${${ZDOTDIR:-$HOME}/#$HOME/~}/.zpreztorc.
          Switching to prezto default prompt 'sorin'..."
 EOW
   prompt 'sorin'

--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -5,14 +5,16 @@ Enables local Python and local Python package installation.
 ## Settings
 
 This module supports virtual environments from conda and
-[*virtualenvwrapper*][2]. By default, only *virtualenvwrapper* is enabled. To
-disable *virtualenvwrapper*, add the following to *~/.zpreztorc*.
+[_virtualenvwrapper_][2]. By default, only _virtualenvwrapper_ is enabled. To
+disable _virtualenvwrapper_, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:python' skip-virtualenvwrapper-init 'on'
 ```
 
-Conda support is enabled by adding the following to *~/.zpreztorc*.
+Conda support can be enabled by adding the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:python' conda-init 'on'
@@ -22,18 +24,18 @@ Caution: using conda and virtualenvwrapper at the same time may cause conflicts.
 
 ## Local Python Installation
 
-[*pyenv*][4] builds and installs multiple Python versions locally in the home
+[_pyenv_][4] builds and installs multiple Python versions locally in the home
 directory.
 
-This module prepends the *pyenv* directory to the path variable to enable the
+This module prepends the _pyenv_ directory to the path variable to enable the
 execution of `pyenv`.
 
 ### Usage
 
-Install Python versions with `pyenv install` into *~/.pyenv/versions*.
+Install Python versions with `pyenv install` into _`~/.pyenv/versions`_.
 
 This will be loaded automatically if pyenv is installed to `$PYENV_ROOT`,
-*~/.pyenv*, or if the `pyenv` command is on the path.
+_`~/.pyenv`_, or if the `pyenv` command is on the path.
 
 ## Local Package Installation
 
@@ -50,7 +52,7 @@ Install packages into the per user site directory with `pip install --user`.
 
 ## virtualenvwrapper
 
-[*virtualenvwrapper*][2] is a frontend to the popular [*virtualenv*][3] utility.
+[_virtualenvwrapper_][2] is a frontend to the popular [_virtualenv_][3] utility.
 
 `virtualenv` creates isolated Python environments and `virtualenvwrapper`
 provides convenient shell functions to create, switch, and manage them.
@@ -59,14 +61,15 @@ provides convenient shell functions to create, switch, and manage them.
 
 Install `virtualenvwrapper`.
 
-Virtual environments are stored in *~/.virtualenvs*.
+Virtual environments are stored in _`~/.virtualenvs`_.
 
-There are configuration variables that have to be set to enable certain features.
-If you wish to use these features, export the variables in [`zshenv`][6].
+There are configuration variables that have to be set to enable certain
+features. If you wish to use these features, export the variables in
+[_`${ZDOTDIR:-$HOME}/.zshenv`_][6].
 
 The variable `$PROJECT_HOME` tells `virtualenvwrapper` where to place project
 working directories. It must be set and the directory created before `mkproject`
-is used. Replace *Developer* with your projects directory.
+is used. Replace _Developer_ with your projects directory.
 
 ```sh
 export PROJECT_HOME="$HOME/Developer"
@@ -144,7 +147,7 @@ python version/
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][5].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Sebastian Wiesner](https://github.com/lunaryorn)
@@ -154,4 +157,4 @@ python version/
 [3]: https://pypi.org/project/virtualenv/
 [4]: https://github.com/yyuu/pyenv
 [5]: https://github.com/sorin-ionescu/prezto/issues
-[6]: https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zshenv
+[6]: ../../runcoms#zshenv

--- a/modules/rails/README.md
+++ b/modules/rails/README.md
@@ -21,7 +21,7 @@ Defines [Ruby on Rails][1] aliases.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Robby Russell](https://github.com/robbyrussell)
 - [Jake Bell](https://github.com/theunraveler)

--- a/modules/rsync/README.md
+++ b/modules/rsync/README.md
@@ -2,20 +2,20 @@
 
 Defines [rsync][1] aliases.
 
-macOS users are encouraged to use *rsync* from [Homebrew][2] or [MacPorts][3],
+macOS users are encouraged to use _rsync_ from [Homebrew][2] or [MacPorts][3],
 which has additional enhancements including patches from [Bombich][4].
 
 ## Aliases
 
-- `rsync-copy` copies files and directories from *source* to *destination*.
-- `rsync-move` moves files and directories from *source* to *destination*.
-- `rsync-update` updates files and directories on *destination*.
-- `rsync-synchronize` synchronizes files and directories between *source* and
-  *destination*.
+- `rsync-copy` copies files and directories from _source_ to _destination_.
+- `rsync-move` moves files and directories from _source_ to _destination_.
+- `rsync-update` updates files and directories on _destination_.
+- `rsync-synchronize` synchronizes files and directories between _source_ and
+  _destination_.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][5].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -6,11 +6,11 @@ aliases.
 ## Local Gem Installation
 
 When a Ruby version manager is not detected, local gems are installed in
-*~/.gems*; otherwise, they are installed according to the manager.
+_`~/.gems`_; otherwise, they are installed according to the manager.
 
 ## rvm
 
-An alternative to the above is to use [The Ruby Version Manager (*rvm*)][2],
+An alternative to the above is to use [The Ruby Version Manager (_rvm_)][2],
 which allows for managing multiple, isolated Ruby installations and gem sets in
 the home directory.
 
@@ -22,26 +22,26 @@ it is not first in `$PATH`.
 
 ## rbenv
 
-An alternative RVM is to use [*rbenv*][3], which allows for switching between
+An alternative RVM is to use [_rbenv_][3], which allows for switching between
 multiple, isolated Ruby installations in the home directory.
 
 While it is not as feature rich as RVM, it is not loaded into the shell and is
 not known to cause conflicts with shell scripts.
 
-This will be loaded automatically if *rbenv* is installed to `$RBENV_ROOT`,
-*~/.rbenv*, or if the `rbenv` command is on the path.
+This will be loaded automatically if _rbenv_ is installed to `$RBENV_ROOT`,
+_`~/.rbenv`_, or if the `rbenv` command is on the path.
 
 ## chruby
 
-Yet another alternative is [*chruby*][4], which is simpler than both *rvm* and
-*rbenv*.
+Yet another alternative is [_chruby_][4], which is simpler than both _rvm_ and
+_rbenv_.
 
 ### Settings
 
 #### Auto-Switch
 
 To enable auto switching the Ruby version on directory change based on the
-`.ruby-version` file, add the following line to *~/.zpreztorc*:
+`.ruby-version` file, add the following line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:ruby:chruby' auto-switch 'yes'
@@ -67,7 +67,7 @@ dependencies, with [Bundler][5].
 - `rbbI` installs the following:
   - gems specified in the `Gemfile` in `vendor/bundle`.
   - packages the gems into `vendor/cache`.
-  - appends bundler directories to  `.gitignore`.
+  - appends bundler directories to `.gitignore`.
 - `rbbl` lists all gems in the current bundle.
 - `rbbo` opens an installed gem in the editor.
 - `rbbp` packages gem files into `vendor/cache`.
@@ -94,7 +94,7 @@ Then add `$ruby_info[version]` to `$PROMPT` or `$RPROMPT` and call
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][6].*
+_The authors of this module should be contacted via the [issue tracker][6]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -9,14 +9,14 @@ Defines [GNU Screen][1] aliases and provides for auto launching it at start-up.
 Starts a GNU Screen session automatically when Zsh is launched.
 
 To enable this feature when launching Zsh in a local terminal, add the following
-line to *~/.zpreztorc*:
+line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:screen:auto-start' local 'yes'
 ```
 
 To enable this feature when launching Zsh in a SSH connection, add the following
-line to *~/.zpreztorc*:
+line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:screen:auto-start' remote 'yes'
@@ -31,7 +31,7 @@ zstyle ':prezto:module:screen:auto-start' remote 'yes'
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Georges Discry](https://github.com/gdiscry)

--- a/modules/spectrum/README.md
+++ b/modules/spectrum/README.md
@@ -79,7 +79,7 @@ Use `$BG[none]`, `$FG[none]`, or `$FX[none]` to turn off formatting.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [P.C. Shyamshankar](https://github.com/sykora)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -1,12 +1,13 @@
 # SSH
 
-Provides for an easier use of [SSH][1] by setting up [*ssh-agent*][2].
+Provides for an easier use of [SSH][1] by setting up [_ssh-agent_][2].
 
 ## Settings
 
 ### Identities
 
-To load multiple identities, add the following line to *~/.zpreztorc*:
+To load multiple identities, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_dsa' 'id_github'
@@ -14,7 +15,7 @@ zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_dsa' 'id_github'
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/modules/syntax-highlighting/README.md
+++ b/modules/syntax-highlighting/README.md
@@ -2,14 +2,14 @@
 
 Integrates [zsh-syntax-highlighting][1] into Prezto.
 
-This module should be loaded before the *prompt* module.
+This module must be loaded _before_ the _`prompt`_ module.
 
 Additionally, if this module is used in conjunction with the
-*history-substring-search* module, this module must be loaded **before** the
-*history-substring-search* module.
+[_`history-substring-search`_][2] module, this module must be loaded _before_
+the _`history-substring-search`_ module.
 
-To elaborate: The relative order of loading the modules would be
-'syntax-highlighting', 'history-substring-search' and 'prompt'.
+To elaborate, the relative order of loading the modules would be
+_`syntax-highlighting`_, _`history-substring-search`_ and _`prompt`_.
 
 ## Contributors
 
@@ -22,7 +22,7 @@ This module will be synchronized against it.
 ### Highlighting
 
 To enable highlighting for this module only, add the following line to
-*~/.zpreztorc*:
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' color 'yes'
@@ -30,10 +30,11 @@ zstyle ':prezto:module:syntax-highlighting' color 'yes'
 
 ### Highlighters
 
-Syntax highlighting is accomplished by pluggable [highlighters][2]. This module
-only enables the *main* highlighter by default.
+Syntax highlighting is accomplished by pluggable [highlighters][3]. This module
+only enables the _main_ highlighter by default.
 
-To enable all highlighters, add the following to *~/.zpreztorc*:
+To enable all highlighters, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' highlighters \
@@ -50,7 +51,7 @@ zstyle ':prezto:module:syntax-highlighting' highlighters \
 Each syntax highlighter defines styles used to highlight tokens.
 
 To highlight, for example, builtins, commands, and functions in blue instead of
-green, add the following to *~/.zpreztorc*:
+green, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:syntax-highlighting' styles \
@@ -61,10 +62,11 @@ zstyle ':prezto:module:syntax-highlighting' styles \
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][3].*
+_The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-syntax-highlighting
-[2]: https://github.com/zsh-users/zsh-syntax-highlighting/tree/master/highlighters
-[3]: https://github.com/sorin-ionescu/prezto/issues
+[2]: ../history-substring-search#readme
+[3]: https://github.com/zsh-users/zsh-syntax-highlighting/tree/master/highlighters
+[4]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/terminal/README.md
+++ b/modules/terminal/README.md
@@ -7,7 +7,7 @@ Sets terminal window and tab titles.
 ### Auto-Title
 
 To auto set the terminal window and tab titles with the current command or
-directory, add the following to *~/.zpreztorc*:
+directory, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:terminal' auto-title 'yes'
@@ -23,7 +23,8 @@ zstyle ':prezto:module:terminal' auto-title 'always'
 
 ### Title formats
 
-To format terminal window and tab titles, add the following to *~/.zpreztorc*:
+To format terminal window and tab titles, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
 zstyle ':prezto:module:terminal:window-title' format '%n@%m: %s'
@@ -44,7 +45,7 @@ For a list of sequences, see [Expansion of Prompt Sequences][1].
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Olaf Conradi](https://github.com/oohlaf)

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -1,6 +1,6 @@
 # Tmux
 
-Defines [*tmux*][1] aliases and provides for auto launching it at start-up.
+Defines [_tmux_][1] aliases and provides for auto launching it at start-up.
 
 ## Settings
 
@@ -9,14 +9,14 @@ Defines [*tmux*][1] aliases and provides for auto launching it at start-up.
 Starts a tmux session automatically when Zsh is launched.
 
 To enable this feature when launching Zsh in a local terminal, add the following
-line to *~/.zpreztorc*:
+line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:tmux:auto-start' local 'yes'
 ```
 
 To enable this feature when launching Zsh in a SSH connection, add the following
-line to *~/.zpreztorc*:
+line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:tmux:auto-start' remote 'yes'
@@ -34,7 +34,7 @@ zstyle ':prezto:module:tmux:session' name '<YOUR DEFAULT SESSION NAME>'
 With `auto-start` enabled, you may want to control how multiple sessions are
 managed. The `destroy-unattached` option of tmux controls if the unattached
 sessions must be kept alive, making sessions available for later use, configured
-in *tmux.conf*:
+in _tmux.conf_:
 
 ```conf
 set-option -g destroy-unattached [on | off]
@@ -43,7 +43,7 @@ set-option -g destroy-unattached [on | off]
 #### iTerm2 Integration
 
 [iTerm2][6] offers significant integration with tmux. This can be enabled by
-adding the following line to *~/.zpreztorc*:
+adding the following line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:tmux:iterm' integrate 'yes'
@@ -61,7 +61,7 @@ Read [iTerm2 and tmux Integration][7] for more information.
 On macOS, launching tmux can cause the error **launch_msg(...): Socket is not
 connected** to be displayed, which can be fixed by installing
 [reattach-to-user-namespace][3], available in [Homebrew][4], and adding the
-following to *tmux.conf*:
+following to _tmux.conf_:
 
 ```conf
 set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
@@ -72,7 +72,7 @@ about this and Prezto has already been [opened][2].
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][5].*
+_The authors of this module should be contacted via the [issue tracker][5]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Colin Hebert](https://github.com/ColinHebert)

--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -2,46 +2,63 @@
 
 Defines general aliases and functions.
 
+This module must be loaded _before_ the [_`completion`_][1] module so that the
+provided completion definitions are loaded automatically by _`completion`_
+module.
+
 **Note:** Some of the utilities configured in this module might be provided via
 GNU utilities with incompatible arguments on non-GNU systems. In such cases,
-using [*`gnu-utility`*][1] module is recommended and it must be loaded
-**before** this module.
+using [_`gnu-utility`_][2] module is recommended and it must be loaded
+_before_ this module.
+
+To elaborate, the relative order of loading the modules would be
+_`gnu-utility`_, _`utility`_ and _`completion`_.
 
 ## Settings
 
 ### Highlighting
 
-If you have enabled color globally in *~/.zpreztorc*, you may disable it for
-certain commands.
+If you have enabled color globally in _`${ZDOTDIR:-$HOME}/.zpreztorc`_, you may
+disable it selectively for certain commands.
 
-To disable `ls` color, add the following line to *~/.zpreztorc*; when coloring
-is disabled, type indicators (`\*`, `/`, `=>`, `@`, `=`, `|`, `%`) will be
-appended to entries.
+To disable `ls` color, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+When coloring is disabled, type indicators (`\*`, `/`, `=>`, `@`, `=`, `|`, `%`)
+will be appended to entries.
 
 ```sh
 zstyle ':prezto:module:utility:ls' color 'no'
 ```
 
 To disable GNU coreutils `ls` to list directories grouped first, add the
-following line to *~/.zpreztorc*:
+following line to _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility:ls' dirs-first 'no'
 ```
 
-To disable `diff` highlighting, add the following line to *~/.zpreztorc*:
+To disable `grep` highlighting, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+
+```sh
+zstyle ':prezto:module:utility:grep' color 'no'
+```
+
+To disable `diff` highlighting, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility:diff' color 'no'
 ```
 
-To disable `wdiff` highlighting, add the following line to *~/.zpreztorc*:
+To disable `wdiff` highlighting, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility:wdiff' color 'no'
 ```
 
-To disable `make` highlighting, add the following line to *~/.zpreztorc*:
+To disable `make` highlighting, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility:make' color 'no'
@@ -66,7 +83,8 @@ zstyle ':prezto:module:utility:make' color 'no'
 - `mysql`
 - `rm`
 
-To disable all spelling corrections, add the following line to *~/.zpreztorc*:
+To disable all spelling corrections, add the following line to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility' correct 'no'
@@ -102,7 +120,7 @@ zstyle ':prezto:module:utility' correct 'no'
 ### Files and Directories
 
 - `ls` lists with directories grouped first (GNU only).
-- `l`  lists in one column, hidden files.
+- `l` lists in one column, hidden files.
 - `ll` lists human readable sizes.
 - `lr` lists human readable sizes, recursively.
 - `la` lists human readable sizes, hidden files.
@@ -136,7 +154,7 @@ zstyle ':prezto:module:utility' correct 'no'
 
 By default, `cp`,`ln`, `mv` and `rm` are aliased to their interactive variants.
 If this is not desired, it can be disabled by adding the following line to
-*~/.zpreztorc*:
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 
 ```sh
 zstyle ':prezto:module:utility' safe-ops 'no'.
@@ -157,7 +175,7 @@ In addition, the following aliases have been added:
 
 ### General
 
-- `slit` prints columns *1, 2, 3 ... n*.
+- `slit` prints columns _1, 2, 3 ... n_.
 
 ### Files and Directories
 
@@ -173,7 +191,7 @@ In addition, the following aliases have been added:
 
 - `diff` highlights diff output (requires `colordiff`).
 - `make` highlights make output (requires `colormake`).
-- `wdiff` highlights wdiff output (requires `wdiff `or `git`).
+- `wdiff` highlights wdiff output (requires `wdiff` or `git`).
 
 ### Resource usage
 
@@ -186,11 +204,12 @@ In addition, the following aliases have been added:
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Robby Russell](https://github.com/robbyrussell)
 - [Suraj N. Kurapati](https://github.com/sunaku)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: ../gnu-utility#readme
-[2]: https://github.com/sorin-ionescu/prezto/issues
+[1]: ../completion#readme
+[2]: ../gnu-utility#readme
+[3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/wakeonlan/README.md
+++ b/modules/wakeonlan/README.md
@@ -4,13 +4,13 @@ This module provides a wrapper around the [wakeonlan][1] tool.
 
 ## Usage
 
-To use this wrapper, create the *`~/.wakeonlan`* directory, and place in it one
+To use this wrapper, create the _`~/.wakeonlan`_ directory, and place in it one
 file for each device you would like to be able to wake. Give the file a name
 that describes the device, such as its hostname.
 
 Each file should contain a line with the MAC address of the target device and
 the network broadcast address. For instance, there might be a file
-`*~/.wakeonlan/leto`* with the following contents:
+_`~/.wakeonlan/leto`_ with the following contents:
 
 ```conf
 00:11:22:33:44:55:66 192.168.0.255
@@ -27,7 +27,7 @@ For more information on the configuration file format, read the
 
 ## Authors
 
-*The authors of this module should be contacted via [issue tracker][3].*
+_The authors of this module should be contacted via [issue tracker][3]._
 
 - [Paul Dann](https://github.com/giddie)
 - [Sorin Ionescu](https://github.com/sorin-ionescu)

--- a/modules/yum/README.md
+++ b/modules/yum/README.md
@@ -1,6 +1,6 @@
 # Yum
 
-Defines [*yum*][1] aliases.
+Defines [_yum_][1] aliases.
 
 ## Aliases
 
@@ -17,7 +17,7 @@ Defines [*yum*][1] aliases.
 
 ## Authors
 
-*The authors of this module should be contacted via the [issue tracker][2].*
+_The authors of this module should be contacted via the [issue tracker][2]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 

--- a/runcoms/README.md
+++ b/runcoms/README.md
@@ -14,19 +14,19 @@ not defined, Zsh will use the user's home directory.
 
 ## File Descriptions
 
-The configuration files are read in the following order:
+The [configuration files][1] are read in the following order:
 
-01. */etc/zshenv*
-02. *~/.zshenv*
-03. */etc/zprofile*
-04. *~/.zprofile*
-05. */etc/zshrc*
-06. *~/.zshrc*
-07. *~/.zpreztorc*
-08. */etc/zlogin*
-09. *~/.zlogin*
-10. *~/.zlogout*
-11. */etc/zlogout*
+01. *`/etc/zshenv`*
+02. *`${ZDOTDIR:-$HOME}/.zshenv`*
+03. *`/etc/zprofile`*
+04. *`${ZDOTDIR:-$HOME}/.zprofile`*
+05. *`/etc/zshrc`*
+06. *`${ZDOTDIR:-$HOME}/.zshrc`*
+07. *`${ZDOTDIR:-$HOME}/.zpreztorc`*
+08. *`/etc/zlogin`*
+09. *`${ZDOTDIR:-$HOME}/.zlogin`*
+10. *`${ZDOTDIR:-$HOME}/.zlogout`*
+11. *`/etc/zlogout`*
 
 ### zshenv
 
@@ -36,7 +36,7 @@ small as possible and should only define environment variables.
 ### zprofile
 
 This file is similar to *zlogin*, but it is sourced before *zshrc*. It was added
-for [KornShell][1] fans. See the description of *zlogin* below for what it may
+for [KornShell][2] fans. See the description of *zlogin* below for what it may
 contain.
 
 *zprofile* and *zlogin* are not meant to be used together but can be done so.
@@ -54,7 +54,7 @@ This file configures Prezto.
 
 This file is sourced by login shells after *zshrc*. Thus, it should contain
 commands that need to execute at login. It is usually used for messages such as
-[*fortune*][2], [*msgs*][3], or for the creation of files.
+[*fortune*][3], [*msgs*][4], or for the creation of files.
 
 This is not the file to define aliases, functions, shell options, and key
 bindings. It should not change the shell environment.
@@ -66,11 +66,12 @@ displaying messages and for deletion of files.
 
 ## Authors
 
-*The authors of these files should be contacted via the [issue tracker][4].*
+*The authors of these files should be contacted via the [issue tracker][5].*
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
-[1]: https://www.kornshell.com
-[2]: https://en.wikipedia.org/wiki/Fortune_(Unix)
-[3]: https://www.manpagez.com/man/1/msgs
-[4]: https://github.com/sorin-ionescu/prezto/issues
+[1]: http://zsh.sourceforge.net/Intro/intro_3.html#SEC3
+[2]: https://www.kornshell.com
+[3]: https://en.wikipedia.org/wiki/Fortune_(Unix)
+[4]: https://www.manpagez.com/man/1/msgs
+[5]: https://github.com/sorin-ionescu/prezto/issues

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -52,7 +52,7 @@ zstyle ':prezto:load' pmodule \
 # Completions
 #
 
-# Set the entries to ignore in static */etc/hosts* for host completion.
+# Set the entries to ignore in static '/etc/hosts' for host completion.
 # zstyle ':prezto:module:completion:*:hosts' etc-host-ignores \
 #   '0.0.0.0' '127.0.0.1'
 


### PR DESCRIPTION
Zsh and Prezto files don't always reside in `~/`. Instead, they have a more spec compliant location (`${ZDOTDIR:-$HOME}/`). Make them unambiguous in the documentation. Likewise, for `$GNUPGHOME`.
 
Further, add instruction for optionally setting up Prezto in `$XDG_CONFIG_HOME`.
 
While at this, also apply more formatting tweaks and doc improvements.