### PR TITLE
utility: Honor pre-defined COLOR settings for grep

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -130,8 +130,8 @@ fi
 
 # Grep
 if zstyle -t ':prezto:module:utility:grep' color; then
-  export GREP_COLOR='37;45'           # BSD.
-  export GREP_COLORS="mt=$GREP_COLOR" # GNU.
+  export GREP_COLOR=${GREP_COLOR:-'37;45'}            # BSD.
+  export GREP_COLORS=${GREP_COLORS:-"mt=$GREP_COLOR"} # GNU.
 
   alias grep="${aliases[grep]:-grep} --color=auto"
 fi


### PR DESCRIPTION
Honor `GREP_COLOR` or `GREP_COLORS` if already defined for coloring `grep` output.
