### PR TITLE
zprofile: Don't exit 'less' when everything fits the screen

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -53,8 +53,8 @@ path=(
 
 # Set the default Less options.
 # Mouse-wheel scrolling has been disabled by -X (disable screen clearing).
-# Remove -X and -F (exit if the content fits on one screen) to enable it.
-export LESS='-F -g -i -M -R -S -w -X -z-4'
+# Remove -X to enable it.
+export LESS='-g -i -M -R -S -w -X -z-4'
 
 # Set the Less input preprocessor.
 # Try both `lesspipe` and `lesspipe.sh` as either might exist on a system.


### PR DESCRIPTION
This aligns better with default `less` behavior and allows for 'growable content' when `less` is used as a substitute for `tail`.
