### PR TITLE
utility: Miscellaneous fixes and tweaks

### DIFF
--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -5,13 +5,13 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-function diff {
-  if zstyle -t ':prezto:module:utility:diff' color \
-    && (( $+commands[colordiff] )); then
-      command colordiff "$@"
-  else
-    command diff "$@"
-  fi
-}
+# function diff {
 
-diff "$@"
+if zstyle -t ':prezto:module:utility:diff' color \
+      && (( $+commands[colordiff] )); then
+  command colordiff "$@"
+else
+  command diff "$@"
+fi
+
+# }

--- a/modules/utility/functions/dut
+++ b/modules/utility/functions/dut
@@ -6,22 +6,22 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-function dut {
-  (( $# == 0 )) && set -- *
+# function dut {
 
-  if grep -q -i 'GNU' < <(du --version 2>&1); then
-    du -khsc "$@" | sort -h -r
-  else
-    local line size name
-    local -a record
+(( $# == 0 )) && set -- *
 
-    while IFS=$'\n' read line; do
-      record=(${(z)line})
-      size="$(($record[1] / 1024.0))"
-      name="$record[2,-1]"
-      printf "%9.1LfM    %s\n" "$size" "$name"
-    done < <(du -kcs "$@") | sort -n -r
-  fi
-}
+if [[ ${(@M)${(f)"$(du --version 2>&1)"}:#*GNU *} ]]; then
+  du -khsc "$@" | sort -h -r
+else
+  local line size name
+  local -a record
 
-dut "$@"
+  while IFS=$'\n' read line; do
+    record=(${(z)line})
+    size="$(($record[1] / 1024.0))"
+    name="$record[2,-1]"
+    printf "%9.1LfM    %s\n" "$size" "$name"
+  done < <(du -kcs "$@") | sort -n -r
+fi
+
+# }

--- a/modules/utility/functions/make
+++ b/modules/utility/functions/make
@@ -5,16 +5,13 @@
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #
 
-function make {
-  if zstyle -t ':prezto:module:utility:make' color; then
-    if (( $+commands[colormake] )); then
-      colormake "$@"
-    else
-      command make "$@"
-    fi
-  else
-    command make "$@"
-  fi
-}
+# function make {
 
-make "$@"
+if zstyle -t ':prezto:module:utility:make' color \
+      && (( $+commands[colormake] )); then
+  command colormake "$@"
+else
+  command make "$@"
+fi
+
+# }

--- a/modules/utility/functions/wdiff
+++ b/modules/utility/functions/wdiff
@@ -3,27 +3,30 @@
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Indrajit Raychaudhuri <irc@indrajit.com>
 #
 
-function wdiff {
-  if zstyle -t ':prezto:module:utility:wdiff' color; then
-    if (( $+commands[wdiff] )); then
-      command wdiff \
-        --avoid-wraps \
-        --start-delete="$(print -n $FG[red])" \
-        --end-delete="$(print -n $FG[none])" \
-        --start-insert="$(print -n $FG[green])" \
-        --end-insert="$(print -n $FG[none])" \
-        "$@" \
+# function wdiff {
+
+if zstyle -t ':prezto:module:utility:wdiff' color; then
+  if (( $+commands[wdiff] )); then
+    command wdiff \
+          --avoid-wraps \
+          --start-delete="$(print -n $FG[red])" \
+          --end-delete="$(print -n $FG[none])" \
+          --start-insert="$(print -n $FG[green])" \
+          --end-insert="$(print -n $FG[none])" \
+          "$@" \
       | sed 's/^\(@@\( [+-][[:digit:]]*,[[:digit:]]*\)\{2\} @@\)$/;5;6m\10m/g'
-    elif (( $+commands[git] )); then
-      command git --no-pager diff --color=auto --no-ext-diff --no-index --color-words "$@"
-    else
-      command wdiff "$@"
-    fi
+  elif (( $+commands[git] )); then
+    command git --no-pager diff --no-ext-diff --no-index --color=auto --color-words "$@"
   else
     command wdiff "$@"
   fi
-}
+elif (( ! $+commands[wdiff] && $+commands[git] )); then
+    command git --no-pager diff --no-ext-diff --no-index --color=never "$@"
+else
+  command wdiff "$@"
+fi
 
-wdiff "$@"
+# }


### PR DESCRIPTION
## Proposed Changes

Miscellaneous fixes and tweaks in utility module:

- `wdiff`: Use `git` fallback (if present) even when color is off and `wdiff` is not present.
- `dut`: Skip additional call to `grep` and use Zsh native mechanism to detect GNU version of `du`.
- `make`: Simplify conditional block.
- general: Remove redundant `function` clause as per Prezto convention.

Note: While this is a single PR for multiple changes (for convenience of approvers), the changes have been split into separate commits (for convenience of `git bisect`-ing and `git revert`-ing in future if necessary).