### PR TITLE
utility: Add support for 'aria2c' in 'get' alias

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -64,6 +64,16 @@ _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 zstyle ':prezto:module:utility:make' color 'no'
 ```
 
+### Download Helper
+
+To configure the download helper to be used with alias `get`, add the following
+to _`${ZDOTDIR:-$HOME}/.zpreztorc`_, and replace `'<helper>'` with `'curl'`,
+`'wget'` or `'aria2c'`.
+
+```sh
+zstyle -s ':prezto:module:utility:download' helper '<helper>'
+```
+
 ## Aliases
 
 ### Disabled Spelling Correction
@@ -107,7 +117,7 @@ zstyle ':prezto:module:utility' correct 'no'
 
 - `_` executes a command as another user (`sudo`).
 - `b` opens the default web browser.
-- `diffu` shorthand for `diff --unified`
+- `diffu` shorthand for `diff --unified`.
 - `e` opens the default editor.
 - `mkdir` creates directories, including intermediary directories.
 - `p` opens the default pager.
@@ -135,7 +145,7 @@ zstyle ':prezto:module:utility' correct 'no'
 ### macOS Everywhere
 
 - `o` opens files and directories (`open` or `xdg-open`).
-- `get` downloads files (`curl` or `wget`).
+- `get` downloads files (`curl`, `wget` or `aria2c`).
 - `pbcopy` copies to the pasteboard (`pbcopy`, `xclip` or `xsel`).
 - `pbpaste` pastes from the pasteboard (`pbcopy`, `xclip` or `xsel`).
 - `pbc` copies to the pasteboard (`pbcopy`).

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -163,11 +163,21 @@ alias pbc='pbcopy'
 alias pbp='pbpaste'
 
 # File Download
-if (( $+commands[curl] )); then
-  alias get='curl --continue-at - --location --progress-bar --remote-name --remote-time'
-elif (( $+commands[wget] )); then
-  alias get='wget --continue --progress=bar --timestamping'
+zstyle -s ':prezto:module:utility:download' helper '_download_helper' || _download_helper='curl'
+
+typeset -A _download_helpers=(
+  aria2c  'aria2c --continue --remote-time --max-tries=0'
+  curl    'curl --continue-at - --location --progress-bar --remote-name --remote-time'
+  wget    'wget --continue --progress=bar --timestamping'
+)
+
+if (( $+commands[$_download_helper] && $+_download_helpers[$_download_helper] )); then
+  alias get="$_download_helpers[$_download_helper]"
+elif (( $+commands[curl] )); then
+  alias get="$_download_helpers[curl]"
 fi
+
+unset _download_helper{,s}
 
 # Resource Usage
 alias df='df -kh'


### PR DESCRIPTION
`get` alias now supports `aria2c` via optional `zstyle`.

To configure `aria2c` to be used for `get`, use:
zstyle -s ':prezto:module:utility:download' helper 'aria2c'

Note that we still fall back to `curl` when the desired download helper isn't available.