### PR TITLE
completion: Set standard style used by 'list-colors'

### DIFF
--- a/modules/completion/README.md
+++ b/modules/completion/README.md
@@ -19,6 +19,10 @@ modules that provide completion definitions.
 - `MENU_COMPLETE` do not autoselect the first completion entry.
 - `FLOW_CONTROL` disable start/stop characters in shell editor.
 
+## Variables
+
+- `LS_COLORS` used by default for Zsh [standard style][2] 'list-colors'.
+
 ## Settings
 
 ### Ignore _`/etc/hosts`_ Entries
@@ -42,9 +46,10 @@ its rules and regulations. This module will be synchronized against it.
 
 ## Authors
 
-_The authors of this module should be contacted via the [issue tracker][2]._
+_The authors of this module should be contacted via the [issue tracker][3]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://github.com/zsh-users/zsh-completions
-[2]: https://github.com/sorin-ionescu/prezto/issues
+[2]: https://zsh.sourceforge.net/Doc/Release/Completion-System.html#Standard-Styles
+[3]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -15,9 +15,9 @@ fi
 fpath=("${0:h}/external/src" $fpath)
 
 # Add completion for keg-only brewed curl when available.
-if (( $+commands[brew] && ! $+functions[_curl] )) && \
-      [[ -d "${curl_prefix::="$(brew --prefix curl 2> /dev/null)"}" ]]; then
-  fpath=("${curl_prefix}/share/zsh/site-functions" $fpath)
+if (( $+commands[brew] && ! $+functions[_curl] )) \
+      && [[ -d "${curl_prefix::="$(brew --prefix curl 2> /dev/null)"}" ]]; then
+  fpath=("$curl_prefix/share/zsh/site-functions" $fpath)
   unset curl_prefix
 fi
 
@@ -34,6 +34,17 @@ setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a traili
 setopt EXTENDED_GLOB       # Needed for file modification glob modifiers with compinit.
 unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
 unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
+
+#
+# Variables
+#
+
+# Standard style used by default for 'list-colors'
+LS_COLORS="${LS_COLORS:-'di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'}"
+
+#
+# Initialization
+#
 
 # Load and initialize the completion system ignoring insecure directories with a
 # cache time of 20 hours, so it should almost always regenerate the first time a
@@ -55,6 +66,10 @@ unset _comp_path
 #
 # Styles
 #
+
+# Defaults.
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*:default' list-prompt '%S%M matches%s'
 
 # Use caching to make completion for commands such as dpkg and apt usable.
 zstyle ':completion::complete:*' use-cache on
@@ -78,7 +93,6 @@ zstyle ':completion:*:corrections' format ' %F{green}-- %d (errors: %e) --%f'
 zstyle ':completion:*:descriptions' format ' %F{yellow}-- %d --%f'
 zstyle ':completion:*:messages' format ' %F{purple} -- %d --%f'
 zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
-zstyle ':completion:*:default' list-prompt '%S%M matches%s'
 zstyle ':completion:*' format ' %F{yellow}-- %d --%f'
 zstyle ':completion:*' group-name ''
 zstyle ':completion:*' verbose yes
@@ -99,7 +113,6 @@ zstyle ':completion:*:functions' ignored-patterns '(_*|pre(cmd|exec))'
 zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters
 
 # Directories
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
 zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
 zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
 zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'users' 'expand'


### PR DESCRIPTION
Set `LS_COLORS` if not already available so that it is available as standard style `list-colors`. 

This needs to be explicitly set in completion module to ensure that the variable is available even if 'utility' module is not loaded earlier.

