### PR TITLE
node: Revamp and optimize 'node' module

### DIFF
--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -27,6 +27,25 @@ _`$XDG_CONFIG_HOME/nvm`_, _`~/.nvm`_, or is installed with homebrew.
 
 - `N_PREFIX` stores the path to [_n_][8] cache.
 
+## Aliases
+
+### npm
+
+- `npmi` install a package.
+- `npml` list installed packages.
+- `npmo` check for outdated packages.
+- `npmp` publish a package.
+- `npmP` remove extraneous packages.
+- `npmr` run arbitrary package scripts.
+- `npms` search for packages.
+- `npmt` test a package.
+- `npmu` update packages.
+- `npmx` uninstalls a package.
+
+- `npmci` install a project with a clean slate.
+- `npmcit` install a project with a clean slate and run tests.
+- `npmit` install package(s) and run tests.
+
 ## Functions
 
 - `node-doc` opens the Node.js online [API documentation][3] in the default

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -3,22 +3,22 @@
 Provides utility functions for [Node.js][1], loads the Node Version Manager, and
 enables [_npm_][2] completion.
 
+## nodenv
+
+[_nodenv_][5] does one thing well - it is concerned solely with switching
+Node versions. It is simple and predictable, Just Works, and is rock solid in
+production. nodenv is forked from the popular [_rbenv_][6].
+
+This will be loaded automatically if nodenv is installed in `$NODENV_ROOT`,
+_`$XDG_CONFIG_HOME/nodenv`_, _`~/.nodenv`_, or `nodenv` is on the path.
+
 ## nvm
 
-[_nvm_][5] allows for managing multiple, isolated Node.js installations in the
+[_nvm_][7] allows for managing multiple, isolated Node.js installations in the
 home directory.
 
 This will be loaded automatically if nvm is installed in `$NVM_DIR`,
 _`$XDG_CONFIG_HOME/nvm`_, _`~/.nvm`_, or is installed with homebrew.
-
-## nodenv
-
-[_nodenv_][6] does one thing well - it is concerned solely with switching
-Node versions. It is simple and predictable, Just Works, and is rock solid in
-production. nodenv is forked from the popular [_rbenv_][7].
-
-This will be loaded automatically if nodenv is installed in `$NODENV_ROOT`,
-_`$XDG_CONFIG_HOME/nodenv`_, _`~/.nodenv`_, or `nodenv` is on the path.
 
 ## Functions
 
@@ -52,6 +52,6 @@ _The authors of this module should be contacted via the [issue tracker][4]._
 [2]: http://npmjs.org
 [3]: http://nodejs.org/api
 [4]: https://github.com/sorin-ionescu/prezto/issues
-[5]: https://github.com/nvm-sh/nvm
-[6]: https://github.com/nodenv/nodenv
-[7]: https://github.com/sstephenson/rbenv
+[5]: https://github.com/nodenv/nodenv
+[6]: https://github.com/sstephenson/rbenv
+[7]: https://github.com/nvm-sh/nvm

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -23,6 +23,10 @@ home directory.
 This will be loaded automatically if nvm is installed in `$NVM_DIR`,
 _`$XDG_CONFIG_HOME/nvm`_, _`~/.nvm`_, or is installed with homebrew.
 
+## Variables
+
+- `N_PREFIX` stores the path to [_n_][8] cache.
+
 ## Functions
 
 - `node-doc` opens the Node.js online [API documentation][3] in the default
@@ -58,3 +62,4 @@ _The authors of this module should be contacted via the [issue tracker][4]._
 [5]: https://github.com/nodenv/nodenv
 [6]: https://github.com/sstephenson/rbenv
 [7]: https://github.com/nvm-sh/nvm
+[8]: https://github.com/tj/n

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -9,7 +9,7 @@ enables [_npm_][2] completion.
 home directory.
 
 This will be loaded automatically if nvm is installed in `$NVM_DIR`,
-_`~/.nvm`_, or nvm is installed with Homebrew.
+_`$XDG_CONFIG_HOME/nvm`_, _`~/.nvm`_, or is installed with homebrew.
 
 ## nodenv
 
@@ -18,7 +18,7 @@ Node versions. It is simple and predictable, Just Works, and is rock solid in
 production. nodenv is forked from the popular [_rbenv_][7].
 
 This will be loaded automatically if nodenv is installed in `$NODENV_ROOT`,
-_`~/.nodenv`_, or `nodenv` is on the path.
+_`$XDG_CONFIG_HOME/nodenv`_, _`~/.nodenv`_, or `nodenv` is on the path.
 
 ## Functions
 
@@ -46,11 +46,12 @@ _The authors of this module should be contacted via the [issue tracker][4]._
 
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 - [Zeh Rizzatti](https://github.com/zehrizzatti)
+- [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
 [1]: http://nodejs.org
 [2]: http://npmjs.org
 [3]: http://nodejs.org/api
 [4]: https://github.com/sorin-ionescu/prezto/issues
-[5]: https://github.com/creationix/nvm
+[5]: https://github.com/nvm-sh/nvm
 [6]: https://github.com/nodenv/nodenv
 [7]: https://github.com/sstephenson/rbenv

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -3,6 +3,9 @@
 Provides utility functions for [Node.js][1], loads the Node Version Manager, and
 enables [_npm_][2] completion.
 
+This module must be loaded _before_ the _`completion`_ module so that the
+provided completion definitions are loaded.
+
 ## nodenv
 
 [_nodenv_][5] does one thing well - it is concerned solely with switching

--- a/modules/node/functions/_grunt
+++ b/modules/node/functions/_grunt
@@ -1,0 +1,15 @@
+#compdef grunt
+#autoload
+
+#
+# Grunt completion, delegating to grunt to do all the completion work.
+#
+# Authors:
+#   Indrajit Raychaudhuri <irc@indrajit.com>
+#
+
+if (( $+commands[grunt] )); then
+  eval "$(grunt --completion=zsh)"
+
+  _grunt_completion "$@"
+fi

--- a/modules/node/functions/_gulp
+++ b/modules/node/functions/_gulp
@@ -1,0 +1,15 @@
+#compdef gulp
+#autoload
+
+#
+# Gulp completion, delegating to gulp to do all the completion work.
+#
+# Authors:
+#   Indrajit Raychaudhuri <irc@indrajit.com>
+#
+
+if (( $+commands[gulp] )); then
+  eval "$(gulp --completion=zsh)"
+
+  _gulp_completion "$@"
+fi

--- a/modules/node/functions/node-doc
+++ b/modules/node/functions/node-doc
@@ -13,6 +13,6 @@ if [[ -z "$BROWSER" ]]; then
 fi
 
 # TODO: Make the sections easier to use.
-"$BROWSER" "http://nodejs.org/docs/$(node --version | sed 's/-.*//')/api/all.html#${1}"
+"$BROWSER" "https://nodejs.org/docs/${$(node --version 2> /dev/null)/%-*}/api/all.html#${1}"
 
 # }

--- a/modules/node/functions/node-info
+++ b/modules/node/functions/node-info
@@ -15,12 +15,12 @@ local version_formatted
 unset node_info
 typeset -gA node_info
 
-if (( $+functions[nvm_version] )); then
-  version="${$(nvm_version)#v}"
-elif (( $+commands[nodenv] )); then
+if (( $+commands[nodenv] )); then
   version="${${$(nodenv version)#v}[(w)0]}"
+elif (( $+functions[nvm_version] )); then
+  version="${$(nvm_version)#v}"
 elif (( $+commands[node] )) ; then
-  version="${$(node -v)#v}"  
+  version="${$(node -v)#v}"
 fi
 
 if [[ "$version" != (none|system) ]]; then

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -43,3 +43,23 @@ fi
 #
 
 N_PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}/n"  # The path to 'n' cache.
+
+#
+# Aliases
+#
+
+# npm
+alias npmi='npm install'
+alias npml='npm list'
+alias npmo='npm outdated'
+alias npmp='npm publish'
+alias npmP='npm prune'
+alias npmr='npm run'
+alias npms='npm search'
+alias npmt='npm test'
+alias npmu='npm update'
+alias npmx='npm uninstall'
+
+alias npmci='npm ci'
+alias npmcit='npm cit'
+alias npmit='npm it'

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -37,3 +37,9 @@ elif (( $+commands[brew] )) \
 elif (( ! $+commands[node] )); then
   return 1
 fi
+
+#
+# Variables
+#
+
+N_PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}/n"  # The path to 'n' cache.

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -8,11 +8,21 @@
 #
 
 # Possible lookup locations.
-local_nvm_paths=({$NVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}nvm}/nvm.sh(N))
 local_nodenv_paths=({$NODENV_ROOT,{$XDG_CONFIG_HOME/,$HOME/.}nodenv}/bin/nodenv(N))
+local_nvm_paths=({$NVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}nvm}/nvm.sh(N))
+
+# Load manually installed nodenv into the shell session.
+if [[ -s ${local_nodenv::=$local_nodenv_paths[1]} ]]; then
+  path=("$local_nodenv:h" $path)
+  eval "$(nodenv init - --no-rehash zsh)"
+  unset local_nodenv{,_paths}
+
+# Load package manager installed nodenv into the shell session.
+elif (( $+commands[nodenv] )); then
+  eval "$(nodenv init - --no-rehash zsh)"
 
 # Load manually installed NVM into the shell session.
-if [[ -s ${local_nvm::=$local_nvm_paths[1]} ]]; then
+elif [[ -s ${local_nvm::=$local_nvm_paths[1]} ]]; then
   source "$local_nvm --no-use"
   unset local_nvm{,_paths}
 
@@ -21,16 +31,6 @@ elif (( $+commands[brew] )) \
       && [[ -d "${nvm_prefix::="$(brew --prefix nvm 2> /dev/null)"}" ]]; then
   source "$nvm_prefix/nvm.sh --no-use"
   unset nvm_prefix
-
-# Load manually installed nodenv into the shell session.
-elif [[ -s ${local_nodenv::=$local_nodenv_paths[1]} ]]; then
-  path=("$local_nodenv:h" $path)
-  eval "$(nodenv init - --no-rehash zsh)"
-  unset local_nodenv{,_paths}
-
-# Load package manager installed nodenv into the shell session.
-elif (( $+commands[nodenv] )); then
-  eval "$(nodenv init - --no-rehash zsh)"
 
 # Return if requirements are not found.
 elif (( ! $+commands[node] )); then

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -1,25 +1,32 @@
 #
-# Loads the Node Version Manager and enables npm completion.
+# Configures Node local installation, loads version managers, and defines
+# variables and aliases.
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #   Zeh Rizzatti <zehrizzatti@gmail.com>
 #
 
+# Possible lookup locations.
+local_nvm_paths=({$NVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}nvm}/nvm.sh(N))
+local_nodenv_paths=({$NODENV_ROOT,{$XDG_CONFIG_HOME/,$HOME/.}nodenv}/bin/nodenv(N))
+
 # Load manually installed NVM into the shell session.
-if [[ -s "${NVM_DIR:=$HOME/.nvm}/nvm.sh" ]]; then
-  source "${NVM_DIR}/nvm.sh"
+if [[ -s ${local_nvm::=$local_nvm_paths[1]} ]]; then
+  source "$local_nvm --no-use"
+  unset local_nvm{,_paths}
 
 # Load package manager installed NVM into the shell session.
-elif (( $+commands[brew] )) && \
-      [[ -d "${nvm_prefix::="$(brew --prefix nvm 2> /dev/null)"}" ]]; then
-  source "${nvm_prefix}/nvm.sh"
+elif (( $+commands[brew] )) \
+      && [[ -d "${nvm_prefix::="$(brew --prefix nvm 2> /dev/null)"}" ]]; then
+  source "$nvm_prefix/nvm.sh --no-use"
   unset nvm_prefix
 
 # Load manually installed nodenv into the shell session.
-elif [[ -s "${NODENV_ROOT:=$HOME/.nodenv}/bin/nodenv" ]]; then
-  path=("${NODENV_ROOT}/bin" $path)
+elif [[ -s ${local_nodenv::=$local_nodenv_paths[1]} ]]; then
+  path=("$local_nodenv:h" $path)
   eval "$(nodenv init - --no-rehash zsh)"
+  unset local_nodenv{,_paths}
 
 # Load package manager installed nodenv into the shell session.
 elif (( $+commands[nodenv] )); then
@@ -31,22 +38,22 @@ elif (( ! $+commands[node] )); then
 fi
 
 # Load NPM and known helper completions.
-typeset -A compl_commands=(
+typeset -A _compl_commands=(
   npm   'npm completion'
   grunt 'grunt --completion=zsh'
   gulp  'gulp --completion=zsh'
 )
 
-for compl_command in "${(k)compl_commands[@]}"; do
-  if (( $+commands[$compl_command] )); then
-    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/$compl_command-cache.zsh"
+for _compl_command in "${(k)_compl_commands[@]}"; do
+  if (( $+commands[$_compl_command] )); then
+    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/${_compl_command}-cache.zsh"
 
     # Completion commands are slow; cache their output if old or missing.
-    if [[ "$commands[$compl_command]" -nt "$cache_file" \
+    if [[ "$commands[$_compl_command]" -nt "$cache_file" \
           || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
           || ! -s "$cache_file" ]]; then
       mkdir -p "$cache_file:h"
-      command ${=compl_commands[$compl_command]} >! "$cache_file" 2> /dev/null
+      command ${=_compl_commands[$_compl_command]} >! "$cache_file" 2> /dev/null
     fi
 
     source "$cache_file"
@@ -55,4 +62,4 @@ for compl_command in "${(k)compl_commands[@]}"; do
   fi
 done
 
-unset compl_command{s,}
+unset _compl_command{s,}

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -5,6 +5,7 @@
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
 #   Zeh Rizzatti <zehrizzatti@gmail.com>
+#   Indrajit Raychaudhuri <irc@indrajit.com>
 #
 
 # Possible lookup locations.
@@ -36,30 +37,3 @@ elif (( $+commands[brew] )) \
 elif (( ! $+commands[node] )); then
   return 1
 fi
-
-# Load NPM and known helper completions.
-typeset -A _compl_commands=(
-  npm   'npm completion'
-  grunt 'grunt --completion=zsh'
-  gulp  'gulp --completion=zsh'
-)
-
-for _compl_command in "${(k)_compl_commands[@]}"; do
-  if (( $+commands[$_compl_command] )); then
-    cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/${_compl_command}-cache.zsh"
-
-    # Completion commands are slow; cache their output if old or missing.
-    if [[ "$commands[$_compl_command]" -nt "$cache_file" \
-          || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
-          || ! -s "$cache_file" ]]; then
-      mkdir -p "$cache_file:h"
-      command ${=_compl_commands[$_compl_command]} >! "$cache_file" 2> /dev/null
-    fi
-
-    source "$cache_file"
-
-    unset cache_file
-  fi
-done
-
-unset _compl_command{s,}


### PR DESCRIPTION
### Proposed changes:
- nodenv and nvm now honors (and prioritizes) `$XDG_CONFIG_HOME` over `$HOME` to lookup local nodenv/nvm installation.
- Make `nvm` loading lazy (via `--no-use` argument).
- Remove redundant NODENV_ROOT or NVM_DIR, respective script already set them up.
- Adhere to more idiomatic Zsh operation and minimize external command usage (like `sed`).
- Reverse `nodenv` vs `nvm` selection order, preferring `nodenv` instead.
- Optimize completions for loading lazily on demand avoiding the overhead during Zsh initialization.
- Remove `npm` completion since it is bundled with Zsh now.
- Add environment variable to store ['n' cache](https://github.com/tj/n#installation).