### PR TITLE
update gSu

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -253,7 +253,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gSl='git submodule status'
   alias gSm='git-submodule-move'
   alias gSs='git submodule sync'
-  alias gSu='git submodule foreach git pull'
+  alias gSu='git submodule update --remote --recursive'
   alias gSx='git-submodule-remove'
 
   # Tag (t)

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -253,7 +253,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gSl='git submodule status'
   alias gSm='git-submodule-move'
   alias gSs='git submodule sync'
-  alias gSu='git submodule foreach git pull origin master'
+  alias gSu='git submodule foreach git pull'
   alias gSx='git-submodule-remove'
 
   # Tag (t)


### PR DESCRIPTION
## Proposed Changes

Remove `origin master` from gSu.
It safe for branches not named "master".

  - Avoid the error "fatal: couldn't find remote ref master" in a repository which the default branch is not "master".
  - And with this method, we can add any remote and branch name after it such as "origin master" or "upstream main".