### PR TITLE
git: Alias cleanup, housekeeping and minimum git version requirement

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -66,26 +66,26 @@ zstyle ':prezto:module:git:alias' skip 'yes'
 ### Commit (c)
 
 - `gc` records changes to the repository.
-- `gca` stages all modified and deleted files.
-- `gcm` records changes to the repository with the given message.
 - `gcS` records changes to the repository. (Signed)
-- `gcSa` stages all modified and deleted files. (Signed)
-- `gcSm` records changes to the repository with the given message. (Signed)
+- `gca` stages all modified and deleted files.
+- `gcaS` stages all modified and deleted files. (Signed)
+- `gcm` records changes to the repository with the given message.
+- `gcmS` records changes to the repository with the given message. (Signed)
 - `gcam` stages all modified and deleted files, and records changes to the
   repository with the given message.
 - `gco` checks out a branch or paths to work tree.
 - `gcO` checks out hunks from the index or the tree interactively.
 - `gcf` amends the tip of the current branch using the same log message as
   _HEAD_.
-- `gcSf` amends the tip of the current branch using the same log message as
+- `gcfS` amends the tip of the current branch using the same log message as
   _HEAD_. (Signed)
 - `gcF` amends the tip of the current branch.
-- `gcSF` amends the tip of the current branch. (Signed)
+- `gcFS` amends the tip of the current branch. (Signed)
 - `gcp` applies changes introduced by existing commits.
 - `gcP` applies changes introduced by existing commits without committing.
 - `gcr` reverts existing commits by reverting patches and recording new commits.
 - `gcR` removes the _HEAD_ commit.
-- `gcs` displays various types of objects.
+- `gcs` displays commits with various objects.
 - `gcsS` displays commits with GPG signature.
 - `gcl` lists lost commits.
 - `gcy` displays commits yet to be applied to upstream in the short format.

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -7,7 +7,8 @@ This module must be loaded _before_ the [_`completion`_][13] module so that the
 provided completion definitions are loaded automatically by _`completion`_
 module.
 
-**Note:** Git **1.7.2** is the [minimum required version][7].
+**Note:** Git **2.11** is the minimum required version for better
+[git-rev-list][7] and [git-submodule][14] support.
 
 ## Settings
 
@@ -460,3 +461,4 @@ _The authors of this module should be contacted via the [issue tracker][6]._
 [11]: https://www.manpagez.com/man/1/gm/
 [12]: https://github.blog/2011-11-10-git-io-github-url-shortener
 [13]: ../completion#readme
+[14]: https://github.com/sorin-ionescu/prezto/pull/1929

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -8,25 +8,24 @@
 #
 # Settings
 #
-#
 
 # Log
 zstyle -s ':prezto:module:git:log:medium' format '_git_log_medium_format' \
-  || _git_log_medium_format='%C(bold)Commit:%C(reset) %C(green)%H%C(red)%d%n%C(bold)Author:%C(reset) %C(cyan)%an <%ae>%n%C(bold)Date:%C(reset)   %C(blue)%ai (%ar)%C(reset)%n%+B'
+    || _git_log_medium_format='%C(bold)Commit:%C(reset) %C(green)%H%C(red)%d%n%C(bold)Author:%C(reset) %C(cyan)%an <%ae>%n%C(bold)Date:%C(reset)   %C(blue)%ai (%ar)%C(reset)%n%+B'
 zstyle -s ':prezto:module:git:log:oneline' format '_git_log_oneline_format' \
-  || _git_log_oneline_format='%C(green)%h%C(reset) %s%C(red)%d%C(reset)%n'
+    || _git_log_oneline_format='%C(green)%h%C(reset) %s%C(red)%d%C(reset)%n'
 zstyle -s ':prezto:module:git:log:brief' format '_git_log_brief_format' \
-  || _git_log_brief_format='%C(green)%h%C(reset) %s%n%C(blue)(%ar by %an)%C(red)%d%C(reset)%n'
+    || _git_log_brief_format='%C(green)%h%C(reset) %s%n%C(blue)(%ar by %an)%C(red)%d%C(reset)%n'
 
 # Status
 zstyle -s ':prezto:module:git:status:ignore' submodules '_git_status_ignore_submodules' \
-  || _git_status_ignore_submodules='none'
+    || _git_status_ignore_submodules='none'
 
 #
 # Aliases
 #
 
-if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
+if ! zstyle -t ':prezto:module:git:alias' skip; then
   # Git
   alias g='git'
 
@@ -51,18 +50,18 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
 
   # Commit (c)
   alias gc='git commit --verbose'
+  alias gcS='git commit --verbose --gpg-sign'
   alias gca='git commit --verbose --all'
+  alias gcaS='git commit --verbose --all --gpg-sign'
   alias gcm='git commit --message'
-  alias gcS='git commit -S --verbose'
-  alias gcSa='git commit -S --verbose --all'
-  alias gcSm='git commit -S --message'
+  alias gcmS='git commit --message --gpg-sign'
   alias gcam='git commit --all --message'
   alias gco='git checkout'
   alias gcO='git checkout --patch'
   alias gcf='git commit --amend --reuse-message HEAD'
-  alias gcSf='git commit -S --amend --reuse-message HEAD'
+  alias gcfS='git commit --amend --reuse-message HEAD --gpg-sign'
   alias gcF='git commit --verbose --amend'
-  alias gcSF='git commit -S --verbose --amend'
+  alias gcFS='git commit --verbose --amend --gpg-sign'
   alias gcp='git cherry-pick --ff'
   alias gcP='git cherry-pick --no-commit'
   alias gcr='git revert'
@@ -70,8 +69,8 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gcs='git show'
   alias gcsS='git show --pretty=short --show-signature'
   alias gcl='git-commit-lost'
-  alias gcy='git cherry -v --abbrev'
-  alias gcY='git cherry -v'
+  alias gcy='git cherry --verbose --abbrev'
+  alias gcY='git cherry --verbose'
 
   # Conflict (C)
   alias gCl='git --no-pager diff --name-only --diff-filter=U'
@@ -183,15 +182,15 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
   alias gir='git reset'
   alias giR='git reset --patch'
   alias gix='git rm -r --cached'
-  alias giX='git rm -rf --cached'
+  alias giX='git rm -r --force --cached'
 
   # Log (l)
-  alias gl='git log --topo-order --pretty=format:"${_git_log_medium_format}"'
-  alias gls='git log --topo-order --stat --pretty=format:"${_git_log_medium_format}"'
-  alias gld='git log --topo-order --stat --patch --full-diff --pretty=format:"${_git_log_medium_format}"'
-  alias glo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
-  alias glg='git log --topo-order --graph --pretty=format:"${_git_log_oneline_format}"'
-  alias glb='git log --topo-order --pretty=format:"${_git_log_brief_format}"'
+  alias gl='git log --topo-order --pretty=format:"$_git_log_medium_format"'
+  alias gls='git log --topo-order --stat --pretty=format:"$_git_log_medium_format"'
+  alias gld='git log --topo-order --stat --patch --full-diff --pretty=format:"$_git_log_medium_format"'
+  alias glo='git log --topo-order --pretty=format:"$_git_log_oneline_format"'
+  alias glg='git log --topo-order --graph --pretty=format:"$_git_log_oneline_format"'
+  alias glb='git log --topo-order --pretty=format:"$_git_log_brief_format"'
   alias glc='git shortlog --summary --numbered'
   alias glS='git log --show-signature'
 
@@ -258,19 +257,19 @@ if ! zstyle -t ':prezto:module:git:alias' skip 'yes'; then
 
   # Tag (t)
   alias gt='git tag'
-  alias gtl='git tag -l'
-  alias gts='git tag -s'
+  alias gtl='git tag --list'
+  alias gts='git tag --sign'
   alias gtv='git verify-tag'
 
   # Working Copy (w)
-  alias gws='git status --ignore-submodules=${_git_status_ignore_submodules} --short'
-  alias gwS='git status --ignore-submodules=${_git_status_ignore_submodules}'
+  alias gws='git status --ignore-submodules=$_git_status_ignore_submodules --short'
+  alias gwS='git status --ignore-submodules=$_git_status_ignore_submodules'
   alias gwd='git diff --no-ext-diff'
   alias gwD='git diff --no-ext-diff --word-diff'
   alias gwr='git reset --soft'
   alias gwR='git reset --hard'
-  alias gwc='git clean -n'
-  alias gwC='git clean -f'
+  alias gwc='git clean --dry-run'
+  alias gwC='git clean --force'
   alias gwx='git rm -r'
-  alias gwX='git rm -rf'
+  alias gwX='git rm -r --force'
 fi

--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -252,7 +252,7 @@ if ! zstyle -t ':prezto:module:git:alias' skip; then
   alias gSl='git submodule status'
   alias gSm='git-submodule-move'
   alias gSs='git submodule sync'
-  alias gSu='git submodule foreach git pull origin master'
+  alias gSu='git submodule update --remote --recursive'
   alias gSx='git-submodule-remove'
 
   # Tag (t)

--- a/modules/git/functions/git-hub-browse
+++ b/modules/git/functions/git-hub-browse
@@ -15,7 +15,7 @@ fi
 local remotes remote references reference file url
 
 remote="${1:-origin}"
-remotes=($(command git config --get-regexp 'remote.*.url' | cut -d. -f2))
+remotes=($(command git remote show))
 
 if (( $remotes[(i)$remote] == $#remotes + 1 )); then
   print "$0: remote not found: $remote" >&2
@@ -23,14 +23,14 @@ if (( $remotes[(i)$remote] == $#remotes + 1 )); then
 fi
 
 url=$(
-  command git config --get "remote.${remote}.url" \
-    | sed -En "s/(git|https?)(@|:\/\/)github.com(:|\/)(.+)\/(.+).git/https:\/\/github.com\/\4\/\5/p"
+  command git remote get-url "$remote" \
+      | sed -En "s#(git@|https?://)(github.com)(:|/)(.+)/(.+)\.git#https://\2/\4/\5#p"
 )
 
 reference="${${2:-$(git-branch-current)}:-HEAD}"
 references=(
   HEAD
-  ${$(command git ls-remote --heads --tags "$remote" | awk '{print $2}')##refs/(heads|tags)/}
+  ${${(f)"$(command git ls-remote --heads --tags "$remote")"}##*refs/(heads|tags)/}
 )
 
 if (( $references[(i)$reference] == $#references + 1 )); then
@@ -45,9 +45,9 @@ fi
 file="$3"
 
 if [[ -n "$url" ]]; then
-  url="${url}/tree/${reference}/${file}"
+  url="$url/tree/$reference/$file"
 
-  if (( $+commands[$BROWSER] )); then
+  if [[ -z "$BROWSER" ]]; then
     "$BROWSER" "$url"
     return 0
   else

--- a/modules/git/functions/git-hub-shorten-url
+++ b/modules/git/functions/git-hub-shorten-url
@@ -19,7 +19,7 @@ if [[ -z "$url" || ! "$url" =~ ^https?:\/\/.*github.com\/ ]]; then
 fi
 
 if (( $+commands[curl] )); then
-  curl -s -i 'https://git.io' -F "url=$url" ${(s: :)code:+ -F "code=$code"} | sed -n 's/^Location: //p'
+  print "${${(@M)${(f)"$(curl -s -i 'https://git.io' -F "url=$url" ${(z)code:+ -F "code=$code"})"}:#Location: *}#Location: }"
 else
   print "$0: command not found: curl" >&2
   return 1

--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -22,20 +22,22 @@ function _git-action {
   local revert_sequence_formatted
 
   for action_dir in \
-    "${git_dir}/rebase-apply" \
-    "${git_dir}/rebase" \
-    "${git_dir}/../.dotest"
+    "$git_dir/rebase-apply" \
+    "$git_dir/rebase" \
+    "$git_dir/../.dotest"
   do
     if [[ -d "$action_dir" ]] ; then
-      zstyle -s ':prezto:module:git:info:action:apply' format 'apply_formatted' || apply_formatted='apply'
-      zstyle -s ':prezto:module:git:info:action:rebase' format 'rebase_formatted' || rebase_formatted='rebase'
+      zstyle -s ':prezto:module:git:info:action:apply' format 'apply_formatted' \
+          || apply_formatted='apply'
+      zstyle -s ':prezto:module:git:info:action:rebase' format 'rebase_formatted' \
+          || rebase_formatted='rebase'
 
-      if [[ -f "${action_dir}/rebasing" ]] ; then
+      if [[ -f "$action_dir/rebasing" ]] ; then
         print "$rebase_formatted"
-      elif [[ -f "${action_dir}/applying" ]] ; then
+      elif [[ -f "$action_dir/applying" ]] ; then
         print "$apply_formatted"
       else
-        print "${rebase_formatted}/${apply_formatted}"
+        print "$rebase_formatted/$apply_formatted"
       fi
 
       return 0
@@ -43,59 +45,67 @@ function _git-action {
   done
 
   for action_dir in \
-    "${git_dir}/rebase-merge/interactive" \
-    "${git_dir}/.dotest-merge/interactive"
+    "$git_dir/rebase-merge/interactive" \
+    "$git_dir/.dotest-merge/interactive"
   do
     if [[ -f "$action_dir" ]]; then
-      zstyle -s ':prezto:module:git:info:action:rebase-interactive' format 'rebase_interactive_formatted' || rebase_interactive_formatted='rebase-interactive'
+      zstyle -s ':prezto:module:git:info:action:rebase-interactive' format 'rebase_interactive_formatted' \
+          || rebase_interactive_formatted='rebase-interactive'
       print "$rebase_interactive_formatted"
       return 0
     fi
   done
 
   for action_dir in \
-    "${git_dir}/rebase-merge" \
-    "${git_dir}/.dotest-merge"
+    "$git_dir/rebase-merge" \
+    "$git_dir/.dotest-merge"
   do
     if [[ -d "$action_dir" ]]; then
-      zstyle -s ':prezto:module:git:info:action:rebase-merge' format 'rebase_merge_formatted' || rebase_merge_formatted='rebase-merge'
+      zstyle -s ':prezto:module:git:info:action:rebase-merge' format 'rebase_merge_formatted' \
+          || rebase_merge_formatted='rebase-merge'
       print "$rebase_merge_formatted"
       return 0
     fi
   done
 
-  if [[ -f "${git_dir}/MERGE_HEAD" ]]; then
-    zstyle -s ':prezto:module:git:info:action:merge' format 'merge_formatted' || merge_formatted='merge'
+  if [[ -f "$git_dir/MERGE_HEAD" ]]; then
+    zstyle -s ':prezto:module:git:info:action:merge' format 'merge_formatted' \
+        || merge_formatted='merge'
     print "$merge_formatted"
     return 0
   fi
 
-  if [[ -f "${git_dir}/CHERRY_PICK_HEAD" ]]; then
-    if [[ -d "${git_dir}/sequencer" ]] ; then
-      zstyle -s ':prezto:module:git:info:action:cherry-pick-sequence' format 'cherry_pick_sequence_formatted' || cherry_pick_sequence_formatted='cherry-pick-sequence'
+  if [[ -f "$git_dir/CHERRY_PICK_HEAD" ]]; then
+    if [[ -d "$git_dir/sequencer" ]] ; then
+      zstyle -s ':prezto:module:git:info:action:cherry-pick-sequence' format 'cherry_pick_sequence_formatted' \
+          || cherry_pick_sequence_formatted='cherry-pick-sequence'
       print "$cherry_pick_sequence_formatted"
     else
-      zstyle -s ':prezto:module:git:info:action:cherry-pick' format 'cherry_pick_formatted' || cherry_pick_formatted='cherry-pick'
+      zstyle -s ':prezto:module:git:info:action:cherry-pick' format 'cherry_pick_formatted' \
+          || cherry_pick_formatted='cherry-pick'
       print "$cherry_pick_formatted"
     fi
 
     return 0
   fi
 
-  if [[ -f "${git_dir}/REVERT_HEAD" ]]; then
-    if [[ -d "${git_dir}/sequencer" ]] ; then
-      zstyle -s ':prezto:module:git:info:action:revert-sequence' format 'revert_sequence_formatted' || revert_sequence_formatted='revert-sequence'
+  if [[ -f "$git_dir/REVERT_HEAD" ]]; then
+    if [[ -d "$git_dir/sequencer" ]] ; then
+      zstyle -s ':prezto:module:git:info:action:revert-sequence' format 'revert_sequence_formatted' \
+          || revert_sequence_formatted='revert-sequence'
       print "$revert_sequence_formatted"
     else
-      zstyle -s ':prezto:module:git:info:action:revert' format 'revert_formatted' || revert_formatted='revert'
+      zstyle -s ':prezto:module:git:info:action:revert' format 'revert_formatted' \
+          || revert_formatted='revert'
       print "$revert_formatted"
     fi
 
     return 0
   fi
 
-  if [[ -f "${git_dir}/BISECT_LOG" ]]; then
-    zstyle -s ':prezto:module:git:info:action:bisect' format 'bisect_formatted' || bisect_formatted='bisect'
+  if [[ -f "$git_dir/BISECT_LOG" ]]; then
+    zstyle -s ':prezto:module:git:info:action:bisect' format 'bisect_formatted' \
+        || bisect_formatted='bisect'
     print "$bisect_formatted"
     return 0
   fi

--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -229,8 +229,8 @@ function git-info {
       [[ "$commondir" =~ ^/ ]] || commondir="$(git-dir)/$commondir"
     fi
     if [[ -f "$(git-dir)/refs/stash" || ( -n "$commondir" && -f "$commondir/refs/stash" ) ]]; then
-      stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
-      if [[ -n "$stashed" ]]; then
+      stashed=${#${(f)"$(command git stash list 2> /dev/null)"}}
+      if (( $stashed > 0 )); then
         zformat -f stashed_formatted "$stashed_format" "S:$stashed"
       fi
     fi

--- a/modules/git/functions/git-stash-clear-interactive
+++ b/modules/git/functions/git-stash-clear-interactive
@@ -15,7 +15,7 @@ fi
 local stashed
 
 if [[ -f "$(git-dir)/refs/stash" ]]; then
-  stashed="$(command git stash list 2> /dev/null | wc -l | awk '{print $1}')"
+  stashed=${#${(f)"$(command git stash list 2> /dev/null)"}}
   if (( $stashed > 0 )); then
     if read -q "?Clear $stashed stashed state(s) [y/N]? "; then
       command git stash clear

--- a/modules/git/functions/git-stash-dropped
+++ b/modules/git/functions/git-stash-dropped
@@ -16,7 +16,7 @@ command git fsck --unreachable 2> /dev/null \
   | grep 'commit' \
   | awk '{print $3}' \
   | command git log \
-      --pretty=format:${_git_log_oneline_format} \
+      --pretty=format:$_git_log_oneline_format \
       --extended-regexp \
       --grep="${1:-(WIP )?[Oo]n [^:]+:}" \
       --merges \

--- a/modules/git/functions/git-submodule-move
+++ b/modules/git/functions/git-submodule-move
@@ -26,7 +26,7 @@ if [[ -z "$url" ]]; then
   return 1
 fi
 
-mkdir -p "${dst:h}"
+mkdir -p "$dst:h"
 
 git-submodule-remove "$src"
 command git submodule add "$url" "$dst"

--- a/modules/git/functions/git-submodule-remove
+++ b/modules/git/functions/git-submodule-remove
@@ -22,9 +22,9 @@ command git config --file "$(git-dir)/config" --remove-section "submodule.${1}" 
 command git config --file "$(git-root)/.gitmodules" --remove-section "submodule.${1}" &> /dev/null
 command git add .gitmodules
 
-command git rm --cached -rf "${1}"
-rm -rf "${1}"
-rm -rf "$(git-dir)/modules/${1}"
+command git rm --cached -rf "$1"
+rm -rf "$1"
+rm -rf "$(git-dir)/modules/$1"
 
 return 0
 


### PR DESCRIPTION
## Proposed Changes

- Prefer longer form of git switch for better clarity in aliases.
- Move `-S` (`--gpg-sign`) in all the alias definitions to the end to allow custom keyid.
- Use parameter expansion flag 'z' to split $code into words in `git-hub-shorten-url`.
- Use `update` instead of `foreach` in alias 'gSu' (see: #1929)
- Update minimum required git version to 2.11 (released in 2016!)
- Apply minor reformatting and rearranging

This closes #1929 with the commit cherry-picked here.
Also see discussion in: https://stackoverflow.com/a/33835815
