### PR TITLE
ruby: Cleanup and optimize 'ruby' module

### DIFF
--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -6,11 +6,22 @@ aliases.
 ## Local Gem Installation
 
 When a Ruby version manager is not detected, local gems are installed in
-_`~/.gems`_; otherwise, they are installed according to the manager.
+_`~/.gem`_; otherwise, they are installed according to the manager.
+
+## rbenv
+
+An alternative RVM is to use [_rbenv_][2], which allows for switching between
+multiple, isolated Ruby installations in the home directory.
+
+While it is not as feature rich as RVM, it is not loaded into the shell and is
+not known to cause conflicts with shell scripts.
+
+This will be loaded automatically if _rbenv_ is installed to `$RBENV_ROOT`,
+_`~/.rbenv`_, or if the `rbenv` command is on the path.
 
 ## rvm
 
-An alternative to the above is to use [The Ruby Version Manager (_rvm_)][2],
+An alternative to the above is to use [The Ruby Version Manager (_rvm_)][3],
 which allows for managing multiple, isolated Ruby installations and gem sets in
 the home directory.
 
@@ -19,17 +30,6 @@ may conflict with shell scripts.
 
 Load this module as late as possible when using RVM since RVM will complain if
 it is not first in `$PATH`.
-
-## rbenv
-
-An alternative RVM is to use [_rbenv_][3], which allows for switching between
-multiple, isolated Ruby installations in the home directory.
-
-While it is not as feature rich as RVM, it is not loaded into the shell and is
-not known to cause conflicts with shell scripts.
-
-This will be loaded automatically if _rbenv_ is installed to `$RBENV_ROOT`,
-_`~/.rbenv`_, or if the `rbenv` command is on the path.
 
 ## chruby
 
@@ -99,8 +99,8 @@ _The authors of this module should be contacted via the [issue tracker][6]._
 - [Sorin Ionescu](https://github.com/sorin-ionescu)
 
 [1]: https://www.ruby-lang.org
-[2]: https://rvm.io
-[3]: https://github.com/sstephenson/rbenv
+[2]: https://github.com/rbenv/rbenv
+[3]: https://rvm.io
 [4]: https://github.com/postmodern/chruby
 [5]: https://gembundler.com
 [6]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -1,27 +1,32 @@
 #
-# Configures Ruby local gem installation, loads version managers, and defines
+# Configures Ruby local installation, loads version managers, and defines
 # aliases.
 #
-# Authors: Sorin Ionescu <sorin.ionescu@gmail.com>
+# Authors:
+#   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Indrajit Raychaudhuri <irc@indrajit.com>
 #
 
-# Load RVM into the shell session.
-if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
+# Possible lookup locations for manually installed rbenv and rvm.
+local_rbenv_paths=({$RBENV_ROOT,{$XDG_CONFIG_HOME/,$HOME/.}rbenv}/bin/rbenv(N))
+local_rvm_paths=({$RVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}rvm}/scripts/rvm(N))
+
+# Load manually installed or package manager installed rbenv into the shell
+# session.
+if (( $#local_rbenv_paths || $+commands[rbenv] )); then
+
+  # Ensure manually installed rbenv is added to path when present.
+  [[ -s $local_rbenv_paths[1] ]] && path=($local_rbenv_paths[1]:h $path)
+
+  eval "$(rbenv init - zsh)"
+
+# Load manually installed rvm into the shell session.
+elif (( $#local_rvm_paths )); then
   # Unset AUTO_NAME_DIRS since auto adding variable-stored paths to ~ list
-  # conflicts with RVM.
+  # conflicts with rvm.
   unsetopt AUTO_NAME_DIRS
 
-  # Source RVM.
-  source "$HOME/.rvm/scripts/rvm"
-
-# Load manually installed rbenv into the shell session.
-elif [[ -s "${RBENV_ROOT:=$HOME/.rbenv}/bin/rbenv" ]]; then
-  path=("${RBENV_ROOT}/bin" $path)
-  eval "$(rbenv init - --no-rehash zsh)"
-
-# Load package manager installed rbenv into the shell session.
-elif (( $+commands[rbenv] )); then
-  eval "$(rbenv init - --no-rehash zsh)"
+  source "$local_rvm_paths[1]"
 
 # Load package manager installed chruby into the shell session.
 elif (( $+commands[chruby-exec] )); then
@@ -34,7 +39,7 @@ elif (( $+commands[chruby-exec] )); then
       source "${commands[chruby-exec]:h:h}/share/chruby/auto.sh"
     fi
 
-    # If a default Ruby is set, switch to it.
+    # If a default ruby is set, switch to it.
     chruby_auto
   fi
 
@@ -43,8 +48,10 @@ else
   path=($HOME/.gem/ruby/*/bin(N) $path)
 fi
 
+unset local_rbenv
+
 # Return if requirements are not found.
-if (( ! $+commands[ruby] && ! ( $+commands[rvm] || $+commands[rbenv] ) )); then
+if (( ! $+commands[ruby] && ! $#functions[(i)r(benv|vm)] )); then
   return 1
 fi
 


### PR DESCRIPTION
Changes:
- rbenv now honors (and prioritizes) `$XDG_CONFIG_HOME` over `$HOME` to lookup local rbenv installation.
- Reverse `rbenv` vs `rvm` selection order, preferring `rbenv` instead.
- Adhere to more idiomatic Zsh operation and minimize redundant syntaxes.
