### PR TITLE
completion: Avoid double-quoting LS_COLORS for completion

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -40,7 +40,7 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 #
 
 # Standard style used by default for 'list-colors'
-LS_COLORS="${LS_COLORS:-'di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'}"
+LS_COLORS=${LS_COLORS:-'di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'}
 
 #
 # Initialization


### PR DESCRIPTION
## Proposed Changes

Double-quoting `LS_COLORS` prevents it from loading in environment, which isn't what we want.

Closes #1936
