### PR TITLE
Update init.zsh

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -13,11 +13,11 @@ pmodload 'helper'
 # Load manually installed pyenv into the path
 if [[ -s "${PYENV_ROOT:=$HOME/.pyenv}/bin/pyenv" ]]; then
   path=("${PYENV_ROOT}/bin" $path)
-  eval "$(pyenv init - --no-rehash zsh)"
+  eval "$(pyenv init --path --no-rehash zsh)"
 
 # Load pyenv into the current python session
 elif (( $+commands[pyenv] )); then
-  eval "$(pyenv init - --no-rehash zsh)"
+  eval "$(pyenv init --path --no-rehash zsh)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to
 # ~/Library/Python on macOS and ~/.local elsewhere, to PATH. The


### PR DESCRIPTION
With the pyenv 2.0.0 upgrade, `pyenv init` -no longer sets PATH, therefore we need to use `eval "$(pyenv init --path)"` instead of `eval "$(pyenv init -)"`
Tested on macOS Big Sur 11.4 using zsh 5.8 and pyenv 2.0.0 installed via HomeBrew.
