### PR TITLE
completion: Unset local variable outside condition block

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -12,28 +12,28 @@ if [[ $TERM == 'dumb' ]]; then
 fi
 
 # Add zsh-completions to $fpath.
-fpath=("${0:h}/external/src" $fpath)
+fpath=(${0:h}/external/src $fpath)
 
 # Add completion for keg-only brewed curl when available.
 if (( $+commands[brew] )) \
-      && [[ -d "${curl_prefix::="$(brew --prefix curl 2> /dev/null)"}" ]]; then
-  fpath=("$curl_prefix/share/zsh/site-functions" $fpath)
-  unset curl_prefix
+      && [[ -d "${curl_prefix::="$(brew --prefix 2> /dev/null)"/opt/curl}" ]]; then
+  fpath=($curl_prefix/share/zsh/site-functions $fpath)
 fi
+unset curl_prefix
 
 #
 # Options
 #
 
-setopt COMPLETE_IN_WORD    # Complete from both ends of a word.
-setopt ALWAYS_TO_END       # Move cursor to the end of a completed word.
-setopt PATH_DIRS           # Perform path search even on command names with slashes.
-setopt AUTO_MENU           # Show completion menu on a successive tab press.
-setopt AUTO_LIST           # Automatically list choices on ambiguous completion.
-setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a trailing slash.
-setopt EXTENDED_GLOB       # Needed for file modification glob modifiers with compinit.
-unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
-unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
+setopt COMPLETE_IN_WORD     # Complete from both ends of a word.
+setopt ALWAYS_TO_END        # Move cursor to the end of a completed word.
+setopt PATH_DIRS            # Perform path search even on command names with slashes.
+setopt AUTO_MENU            # Show completion menu on a successive tab press.
+setopt AUTO_LIST            # Automatically list choices on ambiguous completion.
+setopt AUTO_PARAM_SLASH     # If completed parameter is a directory, add a trailing slash.
+setopt EXTENDED_GLOB        # Needed for file modification glob modifiers with compinit.
+unsetopt MENU_COMPLETE      # Do not autoselect the first completion entry.
+unsetopt FLOW_CONTROL       # Disable start/stop characters in shell editor.
 
 #
 # Variables


### PR DESCRIPTION
### Proposed Changes
Unset `curl_prefix` outside condition block so that it is always cleared. Also, avoid `brew --prefix <foo>` since it is triggering ruby in fallback flow when `<foo>` is not present.

Also, apply minor formatting tweaks.
