### PR TITLE
utility: Pipe diff output through colordiff Instead of aliasing

### DIFF
--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -9,7 +9,7 @@
 
 if zstyle -t ':prezto:module:utility:diff' color \
       && (( $+commands[colordiff] )); then
-  command colordiff "$@"
+  command diff "$@" | colordiff
 else
   command diff "$@"
 fi


### PR DESCRIPTION
### Proposed Changes

`colordiff` behaves better as `stdin` filter. This is useful in retaining color escape sequences when used with `less`.
