### PR TITLE
Add conda to the list of requirements to search for

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -44,7 +44,7 @@ fi
 unset local_pyenv
 
 # Return if requirements are not found.
-if (( ! $#commands[(i)python[23]#] && ! $+functions[pyenv] )); then
+if (( ! $#commands[(i)python[23]#] && ! $+functions[pyenv] && ! $+commands[conda] )); then
   return 1
 fi
 


### PR DESCRIPTION
If conda is not in the list of requirements, the scripts exit too early in case pyenv is not installed and the module is configured with:

 zstyle ':prezto:module:python' skip-virtualenvwrapper-init 'on' 
 zstyle ':prezto:module:python' conda-init 'on'

Tested on Amazon EC2 Linux for Deeplearning AMI 47.0 and MacOS 11.4
