### PR TITLE
Patch python detection to unbreak virtualenvwrapper

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -44,7 +44,7 @@ fi
 unset local_pyenv
 
 # Return if requirements are not found.
-if (( ! $#commands[(i)python[23]#] && ! $+functions[pyenv] && ! $+commands[conda] )); then
+if (( ! $+commands[(i)python[23]] && ! $+functions[pyenv] && ! $+commands[conda] )); then
   return 1
 fi
 
@@ -125,7 +125,7 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) \
   else
     # Fallback to 'virtualenvwrapper' without 'pyenv' wrapper if 'python' is
     # available in '$path'.
-    if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $#commands[(i)python[23]#] )); then
+    if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $+commands[(i)python[23]] )); then
       VIRTUALENVWRAPPER_PYTHON=$commands[(i)python[23]#]
     fi
 


### PR DESCRIPTION
I discovered that my virtualenvwrapper scripts were no longer getting
loaded. After `git bisect` + further debugging, I traced it down to the
first change in this commit.

I also noticed the second change had similar formatting, so I modified
it as well, although I'm not sure that's it's broken.

Note: I researched quite a bit what the `#` is doing here, and I still
don't understand it. All I know is that it worked previously, then it
broke, and now it worked again. So putting up the commit/PR for
discussion.

Fix https://github.com/sorin-ionescu/prezto/issues/1949