### PR TITLE
Fix steef theme to add the dollar sign back

### DIFF
--- a/modules/prompt/functions/prompt_steeef_setup
+++ b/modules/prompt/functions/prompt_steeef_setup
@@ -93,7 +93,7 @@ function prompt_steeef_setup {
   # Define prompts.
   PROMPT="
 ${_prompt_steeef_colors[3]}%n%f at ${_prompt_steeef_colors[2]}%m%f in ${_prompt_steeef_colors[5]}%~%f "'${vcs_info_msg_0_}'"
-"'$python_info[virtualenv]${editor_info[keymap]} '
+"'$python_info[virtualenv]${editor_info[keymap]}$ '
   RPROMPT=''
 }
 


### PR DESCRIPTION
Fixes the steef prompt theme to add back the dollar sign before the prompt itself, 

