### PR TITLE
Allow for explicit path to`rbenv` and `rvm`

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -8,8 +8,8 @@
 #
 
 # Possible lookup locations for manually installed rbenv and rvm.
-local_rbenv_paths=({$RBENV_ROOT,{$XDG_CONFIG_HOME/,$HOME/.}rbenv}/bin/rbenv(N))
-local_rvm_paths=({$RVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}rvm}/scripts/rvm(N))
+local_rbenv_paths=({$RBENV_PATH,{$RBENV_ROOT,{$XDG_CONFIG_HOME/,$HOME/.}rbenv}/bin/rbenv}(N))
+local_rvm_paths=({$RVM_PATH,{$RVM_DIR,{$XDG_CONFIG_HOME/,$HOME/.}rvm}/scripts/rvm}(N))
 
 # Load manually installed or package manager installed rbenv into the shell
 # session.


### PR DESCRIPTION
This adds both `$RBENV_PATH` and `$RVM_PATH` as search locations for those version managers in the `ruby` module.

_Motivation_

Homebrew recently moved the default install location for all of it's binaries from `/usr/local/bin` to `/opt/local/bin`. Due to the way Homebrew symlinks binaries (under version folders), setting `$RBENV_ROOT` is not sufficient.

An alternative approach would be to detect `rbenv` using `which` and searching the path.