### PR TITLE
Correct typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ version is **4.3.11**.
         git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh}/.zprezto"
         ```
 
-      - Configure `$XDG_CONFIG_HOME` and `$ZDOTDIR` in _`${$HOME}/.zshenv`_:
+      - Configure `$XDG_CONFIG_HOME` and `$ZDOTDIR` in _`$HOME/.zshenv`_:
 
         ```sh
         export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:=$HOME/.config}"


### PR DESCRIPTION
The installation instructions reference `${$HOME}`, which fails to evaluate with:

```console
zsh: bad substitution
```