### PR TITLE
adds homebrew to $path for m1 Macs

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -44,6 +44,7 @@ typeset -gU cdpath fpath mailpath path
 # Set the list of directories that Zsh searches for programs.
 path=(
   /usr/local/{bin,sbin}
+  /opt/homebrew/{bin,sbin}
   $path
 )
 


### PR DESCRIPTION
this is to locally add `/opt/homebrew/{bin,sbin}` to `$PATH`