### PR TITLE
Fix crash on open caused by incorrect conditional in python module

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -114,33 +114,34 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) \
     pyenv_plugins=(${(@oM)${(f)"$(pyenv commands --no-sh 2> /dev/null)"}:#virtualenv*})
   fi
 
+  # Optionally activate 'virtualenv' plugin when available.
   if (( $pyenv_plugins[(i)virtualenv-init] <= $#pyenv_plugins )); then
-    # Enable 'virtualenv' with 'pyenv'.
     eval "$(pyenv virtualenv-init - zsh)"
-
-    # Optionally activate 'virtualenvwrapper' plugin when available.
-    if (( $pyenv_plugins[(i)virtualenvwrapper(_lazy|)] <= $#pyenv_plugins )); then
-      pyenv "$pyenv_plugins[(R)virtualenvwrapper(_lazy|)]"
-    fi
-  else
-    # Fallback to 'virtualenvwrapper' without 'pyenv' wrapper if 'python' is
-    # available in '$path'.
-    if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $#commands[(i)python[23]#] )); then
-      VIRTUALENVWRAPPER_PYTHON=$commands[(i)python[23]#]
-    fi
-
-    virtenv_sources=(
-      ${(@Ov)commands[(I)virtualenvwrapper(_lazy|).sh]}
-      /usr/share/virtualenvwrapper/virtualenvwrapper(_lazy|).sh(OnN)
-    )
-    if (( $#virtenv_sources )); then
-      source "$virtenv_sources[1]"
-    fi
-
-    unset virtenv_sources
   fi
 
+  # Optionally activate 'virtualenvwrapper' plugin when available.
+  if (( $pyenv_plugins[(i)virtualenvwrapper(_lazy|)] <= $#pyenv_plugins )); then
+    pyenv "$pyenv_plugins[(R)virtualenvwrapper(_lazy|)]"
+  fi
+  
   unset pyenv_plugins
+  
+else
+  # Fallback to 'virtualenvwrapper' without 'pyenv' wrapper if 'python' is
+  # available in '$path'.
+  if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $#commands[(i)python[23]#] )); then
+    VIRTUALENVWRAPPER_PYTHON=$commands[(i)python[23]#]
+  fi
+
+  virtenv_sources=(
+    ${(@Ov)commands[(I)virtualenvwrapper(_lazy|).sh]}
+    /usr/share/virtualenvwrapper/virtualenvwrapper(_lazy|).sh(OnN)
+  )
+  if (( $#virtenv_sources )); then
+    source "$virtenv_sources[1]"
+  fi
+
+  unset virtenv_sources
 fi
 
 # Load conda into the shell session, if requested.


### PR DESCRIPTION
Fixes #1977

The logic currently requires the virtualenv-init plugin to be present in order to properly load the virtualenvwrapper plugin. The virtualenvwrapper plugin does not rely on virtualenv-init though, and the docs claim to load virtualenvwrapper by default, so this is improper behavior. The code begins an 'else' statement if virtualenv-init is not present in which will inevitably discover the script in your pyenv plugins dir and attempt to source it, which will always cause an irrecoverable crash on shell open.

I would call this a fairly major issue. If someone with only one user configured on a linux system with no direct root login capability (as is often default for many distros) would be completely unable to get into their system without mounting it from a boot usb to get rid of the plugin if they closed their current shell after enabling it.

My fix just adds a 'fi' to the proper location, moves up the pyenv_unset plugins, and formats the affected areas to match the scheme of the rest of the file, as it is no longer nested. 

This behavior was already present in the commit referenced by #1949, so this likely will not fix their issue, although, if they had the wrong commit number as the cause, it may. 

