### PR TITLE
Allow users to set a dirty-branch format

### DIFF
--- a/modules/git/functions/git-info
+++ b/modules/git/functions/git-info
@@ -417,6 +417,11 @@ function git-info {
   if (( dirty > 0 )); then
     zstyle -s ':prezto:module:git:info:dirty' format 'dirty_format'
     zformat -f dirty_formatted "$dirty_format" "D:$dirty"
+    # Overwrite branch format to use dirty-branch format
+    zstyle -s ':prezto:module:git:info:dirty-branch' format 'branch_format'
+    if [[ -n "$branch" && -n "$branch_format" ]]; then
+      zformat -f branch_formatted "$branch_format" "b:$branch"
+    fi
   else
     zstyle -s ':prezto:module:git:info:clean' format 'clean_formatted'
   fi


### PR DESCRIPTION
## Proposed Changes

- Implements dirty-branch format which overrides regular branch format when your git status is dirty.  Primarily, this is useful for changing the color of the branch name.
- Taken directly from #639 which implemented this, but also included a change to the sorin prompt.  That change is not present in this PR.
- I have personally had this change applied locally for years.

Example usage, taken from my own prompt:
```sh
zstyle ':prezto:module:git:info:branch' format '%%B%F{183}@%b%f%%b'
zstyle ':prezto:module:git:info:dirty-branch' format '%%B%F{225}@%b%f%%b'
```

Clean:
<img width="215" alt="Screen Shot 2022-03-06 at 4 04 32 PM" src="https://user-images.githubusercontent.com/6633472/156948252-552bc164-1ae0-4154-a7b6-ae4b930c36f2.png">
Dirty:
<img width="202" alt="Screen Shot 2022-03-06 at 4 04 43 PM" src="https://user-images.githubusercontent.com/6633472/156948254-16e8b104-1a8f-42dd-bdff-10442a39842e.png">

