### PR TITLE
Only export env variables in zprofile if unset

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -9,7 +9,7 @@
 # Browser
 #
 
-if [[ "$OSTYPE" == darwin* ]]; then
+if [[ -z "$BROWSER" && "$OSTYPE" == darwin* ]]; then
   export BROWSER='open'
 fi
 
@@ -17,9 +17,15 @@ fi
 # Editors
 #
 
-export EDITOR='nano'
-export VISUAL='nano'
-export PAGER='less'
+if [[ -z "$EDITOR" ]]; then
+  export EDITOR='nano'
+fi
+if [[ -z "$VISUAL" ]]; then
+  export VISUAL='nano'
+fi
+if [[ -z "$PAGER" ]]; then
+  export PAGER='less'
+fi
 
 #
 # Language
@@ -54,10 +60,12 @@ path=(
 # Set the default Less options.
 # Mouse-wheel scrolling has been disabled by -X (disable screen clearing).
 # Remove -X to enable it.
-export LESS='-g -i -M -R -S -w -X -z-4'
+if [[ -z "$LESS" ]]; then
+  export LESS='-g -i -M -R -S -w -X -z-4'
+fi
 
 # Set the Less input preprocessor.
 # Try both `lesspipe` and `lesspipe.sh` as either might exist on a system.
-if (( $#commands[(i)lesspipe(|.sh)] )); then
+if [[ -z "$LESSOPEN" && (( $#commands[(i)lesspipe(|.sh)] )) ]]; then
   export LESSOPEN="| /usr/bin/env $commands[(i)lesspipe(|.sh)] %s 2>&-"
 fi


### PR DESCRIPTION
As per [zsh documentation](https://zsh.sourceforge.io/Intro/intro_3.html) environment variables should be expected to be in `.zshenv` and not be overridden in `.zprofile`. This change modified EDITOR, VISUAL, PAGER, and LESS to only set prezto defaults if they were not previously set in the loading order.

See:
https://github.com/nix-community/home-manager/issues/2739
https://github.com/nix-community/home-manager/issues/2751