### PR TITLE
completion: Detect Homebrew prefix natively instead of idiomatically

### DIFF
--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -7,14 +7,14 @@
 #
 
 # Load command-not-found on Debian-based distributions.
-if [[ -s '/etc/zsh_command_not_found' ]]; then
-  source '/etc/zsh_command_not_found'
+if [[ -s /etc/zsh_command_not_found ]]; then
+  source /etc/zsh_command_not_found
 # Load command-not-found on Arch Linux-based distributions.
-elif [[ -s '/usr/share/doc/pkgfile/command-not-found.zsh' ]]; then
-  source '/usr/share/doc/pkgfile/command-not-found.zsh'
+elif [[ -s /usr/share/doc/pkgfile/command-not-found.zsh ]]; then
+  source /usr/share/doc/pkgfile/command-not-found.zsh
 # Load command-not-found on macOS when Homebrew tap is configured.
 elif (( $+commands[brew] )) \
-      && [[ -s "${hb_cnf_handler::="$(brew --repository 2> /dev/null)"/Library/Taps/homebrew/homebrew-command-not-found/handler.sh}" ]]; then
+      && [[ -s ${hb_cnf_handler::="${HOMEBREW_REPOSITORY:-$commands[brew]:A:h:h}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"} ]]; then
   source "$hb_cnf_handler"
   unset hb_cnf_handler
 # Return if requirements are not found.

--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -14,12 +14,16 @@ fi
 # Add zsh-completions to $fpath.
 fpath=(${0:h}/external/src $fpath)
 
-# Add completion for keg-only brewed curl when available.
-if (( $+commands[brew] )) \
-      && [[ -d "${curl_prefix::="$(brew --prefix 2> /dev/null)"/opt/curl}" ]]; then
-  fpath=($curl_prefix/share/zsh/site-functions $fpath)
+# Add completion for keg-only brewed curl on macOS when available.
+if (( $+commands[brew] )); then
+  brew_prefix=${HOMEBREW_PREFIX:-${HOMEBREW_REPOSITORY:-$commands[brew]:A:h:h}}
+  # $HOMEBREW_PREFIX defaults to $HOMEBREW_REPOSITORY but is explicitly set to
+  # /usr/local when $HOMEBREW_REPOSITORY is /usr/local/Homebrew.
+  # https://github.com/Homebrew/brew/blob/2a850e02d8f2dedcad7164c2f4b95d340a7200bb/bin/brew#L66-L69
+  [[ $brew_prefix == '/usr/local/Homebrew' ]] && brew_prefix=$brew_prefix:h
+  fpath=($brew_prefix/opt/curl/share/zsh/site-functions(/N) $fpath)
+  unset brew_prefix
 fi
-unset curl_prefix
 
 #
 # Options


### PR DESCRIPTION
## Proposed Changes

For performance reasons, we prefer detecting Homebrew prefix internally instead of the more idiomatic form `brew --prefix`.
 
We attempt looking up $HOMEBREW_PREFIX or $HOMEBREW_REPOSITORY first (in case `brew shellenv` has been sourced-in earlier). Else, we look it up by resolving absolute path of $HOMEBREW_REPOSITORY. $HOMEBREW_PREFIX is
same as $HOMEBREW_REPOSITORY except when Homebrew is installed in '/usr/local' ($HOMEBREW_REPOSITORY == '/usr/local/Homebrew'). This is usually the case for Intel Macs.
 
This should work for most standard (and officially documented) Homebrew installations.
 
For implementation details in Homebrew, see: https://github.com/Homebrew/brew/blob/2a850e02d8f2dedcad7164c2f4b95d340a7200bb/bin/brew#L62-L70

Also, there are more details in Homebrew/brew#9177

Fixes #1978, #1979
