### PR TITLE
fix: extend deflating flag for pixz in unarchive function

### DIFF
--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -41,7 +41,7 @@ else
 fi
 
 if (( $+commands[pixz] )); then
-  _xz_bin='pixz'
+  _xz_bin='pixz -d'
 else
   _xz_bin='xz'
 fi


### PR DESCRIPTION
Fixes 1

## Proposed Changes

  - when the system is checked for the different (un)-archiving binaries, in this function the `pixz` binary should be extended with the deflating flag
  - (missed that one in my former pull request)