### PR TITLE
feat(module/history): add full configurability

### DIFF
--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -38,6 +38,35 @@ Alternately, you can set `HISTFILE` manually to _`${ZDOTDIR:-$HOME}/.zhistory`_.
 
 - `history-stat` lists the ten most used commands
 
+## Settings
+
+### histfile
+
+Can be configured either by setting HISTFILE manually before loading this
+module or by using zstyle:
+
+```sh
+zstyle ':prezto:module:history' histfile "<file_name>"
+```
+
+defaults to "${ZDOTDIR:-$HOME}/.zsh_history".
+
+## histsize
+
+```sh
+zstyle ':prezto:module:history' histsize <number>
+```
+
+defaults to 10000.
+
+## savehist
+
+```sh
+zstyle ':prezto:module:history' savehist <number>
+```
+
+defaults to histsize
+
 ## Authors
 
 _The authors of this module should be contacted via the [issue tracker][2]._

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -26,9 +26,13 @@ setopt HIST_BEEP                 # Beep when accessing non-existent history.
 # Variables
 #
 
-HISTFILE="${HISTFILE:-${ZDOTDIR:-$HOME}/.zsh_history}"  # The path to the history file.
-HISTSIZE=10000                   # The maximum number of events to save in the internal history.
-SAVEHIST=10000                   # The maximum number of events to save in the history file.
+zstyle -s ':prezto:module:history' histfile '_pmh_histfile' || _pmh_histfile="${HISTFILE:-${ZDOTDIR:-$HOME}/.zsh_history}"
+zstyle -s ':prezto:module:history' histsize '_pmh_histsize' || _pmh_histsize=10000
+zstyle -s ':prezto:module:history' savehist '_pmh_savehist' || _pmh_savehist=${_pmh_histsize}
+HISTFILE="${_pmh_histfile}"  # The path to the history file.
+HISTSIZE="${_pmh_histsize}"  # The maximum number of events to save in the internal history.
+SAVEHIST="${_pmh_savehist}"  # The maximum number of events to save in the history file.
+unset _pmh_{hist{file,size},savehist}
 
 #
 # Aliases

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -84,6 +84,19 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # zstyle ':prezto:module:gnu-utility' prefix 'g'
 
 #
+# History
+#
+
+# Set the file to save the history in when an interactive shell exits.
+# zstyle ':prezto:module:history' histfile "${ZDOTDIR:-$HOME}/.zsh_history"
+
+# Set the maximum  number  of  events  stored  in  the  internal history list.
+# zstyle ':prezto:module:history' histsize 10000
+
+# Set the maximum number of history events to save in the history file.
+# zstyle ':prezto:module:history' savehist 10000
+
+#
 # History Substring Search
 #
 


### PR DESCRIPTION
While previusly configurable, it was inconsistent with other
configuration options and it was missing configurability of in memory /
on disc history size.

Signed-off-by: Shea690901 <ginny690901@hotmail.de>