### PR TITLE
Add option to disable http-serve in utility module

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -181,6 +181,12 @@ In addition, the following aliases have been added:
 
 - `http-serve` serves a directory via HTTP.
 
+To disable `http-serve`, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:utility' http-serve 'no'
+```
+
 ## Functions
 
 ### General

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -194,14 +194,16 @@ fi
 # Miscellaneous
 
 # Serves a directory via HTTP.
-if (( $#commands[(i)python(|[23])] )); then
-  autoload -Uz is-at-least
-  if is-at-least 3 ${"$(python --version 2>&1)"[(w)2]}; then
-    alias http-serve='python -m http.server'
-  elif (( $+commands[python3] )); then
-    alias http-serve='python3 -m http.server'
-  else
-    alias http-serve='$commands[(i)python(|2)] -m SimpleHTTPServer'
+if zstyle -T ':prezto:module:utility' http-serve; then
+  if (( $#commands[(i)python(|[23])] )); then
+    autoload -Uz is-at-least
+    if is-at-least 3 ${"$(python --version 2>&1)"[(w)2]}; then
+      alias http-serve='python -m http.server'
+    elif (( $+commands[python3] )); then
+      alias http-serve='python3 -m http.server'
+    else
+      alias http-serve='$commands[(i)python(|2)] -m SimpleHTTPServer'
+    fi
   fi
 fi
 


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #

## Proposed Changes

In my machine (MacBook Pro, Monterey), prezto init takes 0.4-0.5s. Here's logs that I put before and after prezto init in zshrc:

```
21:17:08.873183000 before prezto init
21:17:09.342031000 after prezto init
```

It's fast but I want to get it down further. After some debugging, I narrow down to `utility` module, or more specifically the setting up of `http-serve` alias in this module (I think it's due to the call to python to check version number).

Not all people need this alias, so added a toggle to allow disabling `http-serve` entirely. After disabling it, the loading is down to less than 0.2s

```
21:27:22.248647000 before prezto init
21:27:22.407725000 after prezto init
```
