### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ and prompt themes.
 
 ## Installation
 
+### Manual
+
 Prezto will work with any recent release of Zsh, but the minimum required
 version is **4.3.11**.
 
@@ -70,6 +72,14 @@ version is **4.3.11**.
     ```
 
 05. Open a new Zsh terminal window or tab.
+
+### [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `prezto` in just one click.
+
+<a href="https://fig.io/plugins/other/prezto" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Fixes

No fixes, just updating readme.

## Proposed Changes

- Added Fig Plugin Store button  (links [here](https://github.com/sorin-ionescu/prezto)) as an installation method for prezto. 

   [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig. prezto is already listed in the store, so we'd love to have it listed as a download method on your readme. Thanks so much and please let me know if you have any questions!
