### PR TITLE
utility: Make 'http-serve' handler faster for well known cases

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -196,12 +196,14 @@ fi
 # Serves a directory via HTTP.
 if (( $#commands[(i)python(|[23])] )); then
   autoload -Uz is-at-least
-  if is-at-least 3 ${"$(python --version 2>&1)"[(w)2]}; then
-    alias http-serve='python -m http.server'
-  elif (( $+commands[python3] )); then
+  if (( $+commands[python3] )); then
     alias http-serve='python3 -m http.server'
+  elif (( $+commands[python2] )); then
+    alias http-serve='python2 -m SimpleHTTPServer'
+  elif is-at-least 3 ${"$(python --version 2>&1)"[(w)2]}; then
+    alias http-serve='python -m http.server'
   else
-    alias http-serve='$commands[(i)python(|2)] -m SimpleHTTPServer'
+    alias http-serve='python -m SimpleHTTPServer'
   fi
 fi
 


### PR DESCRIPTION
In most systems, python2 or python3 command/soft-link would almost
always exist. In such cases, we don't need to invoke `python` to
detect the version. This should speed things up a bit as well.

This fixes the performance concern raised in #2003.