### PR TITLE
Set `EXTENDED_GLOB` in the python module

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -8,6 +8,12 @@
 #   Indrajit Raychaudhuri <irc@indrajit.com>
 #
 
+#
+# Options
+#
+
+setopt EXTENDED_GLOB
+
 # Load dependencies.
 pmodload 'helper'
 


### PR DESCRIPTION
This is needed to find python. 

It is often already set because a user has the directory or completion module loaded before this, but that's not always true.

See extensive debugging / further explanation here: https://github.com/sorin-ionescu/prezto/issues/1949

This does not fully resolve that issue, as there's another enhancement that I'll put up as a separate PR.