### PR TITLE
Fix zcompile race condition

### DIFF
--- a/runcoms/zlogin
+++ b/runcoms/zlogin
@@ -10,7 +10,10 @@
   # Compile the completion dump to increase startup speed.
   zcompdump="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
-    zcompile "$zcompdump"
+    if command mkdir "${zcompdump}.zwc.lock" 2>/dev/null; then
+      zcompile "$zcompdump"
+      command rmdir  "${zcompdump}.zwc.lock" 2>/dev/null
+    fi
   fi
 } &!
 


### PR DESCRIPTION
Fixes #2028

## Proposed Changes

If several login shells are started at the same time, only one should be running `zcompile`.  This is the same fix as https://github.com/ohmyzsh/ohmyzsh/pull/11345