### PR TITLE
Fix osx module manp function

### DIFF
--- a/modules/osx/functions/manp
+++ b/modules/osx/functions/manp
@@ -9,7 +9,7 @@ function manp {
   local page
   if (( $# > 0 )); then
     for page in "$@"; do
-      man -t "$page" | open -f -a Preview
+      mandoc -T pdf "$(/usr/bin/man -w $page)" | open -fa Preview
     done
   else
     print 'What manual page do you want?' >&2


### PR DESCRIPTION
Opening man pages using Preview.app using `manp` broke in Ventura. There's now a new way to do it. This PR updates the `manp` function in the osx module. See [article](https://scriptingosx.com/2022/11/on-viewing-man-pages-ventura-update/).