### PR TITLE
Add GNU awk to gnu-utility module

### DIFF
--- a/modules/gnu-utility/init.zsh
+++ b/modules/gnu-utility/init.zsh
@@ -44,8 +44,8 @@ _gnu_utility_cmds=(
   'libtool' 'libtoolize'
 
   # Miscellaneous
-  'egrep' 'fgrep' 'getopt' 'grep' 'indent' 'make' 'sed' 'tar' 'time' 'units'
-  'which'
+  'awk' 'egrep' 'fgrep' 'getopt' 'grep' 'indent' 'make' 'sed' 'tar' 'time'
+  'units' 'which'
 )
 
 # Wrap GNU utilities in functions.


### PR DESCRIPTION
## Proposed Changes

Add GNU awk (gawk) to gnu-utility module.

I needed this when using [gawk](https://www.gnu.org/software/gawk/) downloaded from [Homebrew](https://formulae.brew.sh/formula/gawk).