### PR TITLE
Add zstyle to skip aliases for additional modules

### DIFF
--- a/modules/directory/init.zsh
+++ b/modules/directory/init.zsh
@@ -25,6 +25,8 @@ unsetopt CLOBBER            # Do not overwrite existing files with > and >>.
 # Aliases
 #
 
-alias -- -='cd -'
-alias d='dirs -v'
-for index ({1..9}) alias "$index"="cd +${index}"; unset index
+if ! zstyle -t ':prezto:module:directory:alias' skip; then
+  alias -- -='cd -'
+  alias d='dirs -v'
+  for index ({1..9}) alias "$index"="cd +${index}"; unset index
+fi

--- a/modules/emacs/init.zsh
+++ b/modules/emacs/init.zsh
@@ -19,7 +19,9 @@ source "$HOME/.cask/etc/cask_completion.zsh" 2> /dev/null
 # Aliases
 #
 
-alias cai='cask install'
-alias cau='cask update'
-alias caI='cask init'
-alias cae='cask exec'
+if ! zstyle -t ':prezto:module:emacs:alias' skip; then
+  alias cai='cask install'
+  alias cau='cask update'
+  alias caI='cask init'
+  alias cae='cask exec'
+fi

--- a/modules/fasd/init.zsh
+++ b/modules/fasd/init.zsh
@@ -53,5 +53,7 @@ function fasd_cd {
 # Aliases
 #
 
-# Changes the current working directory interactively.
-alias j='fasd_cd -i'
+if ! zstyle -t ':prezto:module:fasd:alias' skip; then
+  # Changes the current working directory interactively.
+  alias j='fasd_cd -i'
+fi

--- a/modules/history/init.zsh
+++ b/modules/history/init.zsh
@@ -38,8 +38,10 @@ unset _pmh_{hist{file,size},savehist}
 # Aliases
 #
 
-# Lists the ten most used commands.
-alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
+if ! zstyle -t ':prezto:module:history:alias' skip; then
+  # Lists the ten most used commands.
+  alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
+fi
 
 if [[ -s "${OLD_HISTFILE::=${HISTFILE:h}/.zhistory}" ]]; then
 

--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -29,19 +29,21 @@ fi
 #
 
 # Homebrew
-alias brewc='brew cleanup'
-alias brewi='brew install'
-alias brewL='brew leaves'
-alias brewl='brew list'
-alias brewo='brew outdated'
-alias brews='brew search'
-alias brewu='brew upgrade'
-alias brewx='brew uninstall'
+if ! zstyle -t ':prezto:module:homebrew:alias' skip; then
+  alias brewc='brew cleanup'
+  alias brewi='brew install'
+  alias brewL='brew leaves'
+  alias brewl='brew list'
+  alias brewo='brew outdated'
+  alias brews='brew search'
+  alias brewu='brew upgrade'
+  alias brewx='brew uninstall'
 
-# Homebrew Cask
-alias caski='brew install --cask'
-alias caskl='brew list --cask'
-alias casko='brew outdated --cask'
-alias casks='brew search --cask'
-alias casku='brew upgrade --cask'
-alias caskx='brew uninstall --cask'
+  # Homebrew Cask
+  alias caski='brew install --cask'
+  alias caskl='brew list --cask'
+  alias casko='brew outdated --cask'
+  alias casks='brew search --cask'
+  alias casku='brew upgrade --cask'
+  alias caskx='brew uninstall --cask'
+fi

--- a/modules/macports/init.zsh
+++ b/modules/macports/init.zsh
@@ -28,10 +28,12 @@ path=(
 # Aliases
 #
 
-alias portc='sudo port clean --all installed'
-alias porti='sudo port install'
-alias ports='port search'
-alias portU='sudo port selfupdate && sudo port upgrade outdated'
-alias portu='sudo port upgrade'
-alias portX='sudo port -u uninstall'
-alias portx='sudo port uninstall'
+if ! zstyle -t ':prezto:module:macports:alias' skip; then
+  alias portc='sudo port clean --all installed'
+  alias porti='sudo port install'
+  alias ports='port search'
+  alias portU='sudo port selfupdate && sudo port upgrade outdated'
+  alias portu='sudo port upgrade'
+  alias portX='sudo port -u uninstall'
+  alias portx='sudo port uninstall'
+fi

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -48,18 +48,20 @@ N_PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}/n"  # The path to 'n' cache.
 # Aliases
 #
 
-# npm
-alias npmi='npm install'
-alias npml='npm list'
-alias npmo='npm outdated'
-alias npmp='npm publish'
-alias npmP='npm prune'
-alias npmr='npm run'
-alias npms='npm search'
-alias npmt='npm test'
-alias npmu='npm update'
-alias npmx='npm uninstall'
+if ! zstyle -t ':prezto:module:node:alias' skip; then
+  # npm
+  alias npmi='npm install'
+  alias npml='npm list'
+  alias npmo='npm outdated'
+  alias npmp='npm publish'
+  alias npmP='npm prune'
+  alias npmr='npm run'
+  alias npms='npm search'
+  alias npmt='npm test'
+  alias npmu='npm update'
+  alias npmx='npm uninstall'
 
-alias npmci='npm ci'
-alias npmcit='npm cit'
-alias npmit='npm it'
+  alias npmci='npm ci'
+  alias npmcit='npm cit'
+  alias npmit='npm it'
+fi

--- a/modules/perl/init.zsh
+++ b/modules/perl/init.zsh
@@ -61,37 +61,39 @@ fi
 # Aliases
 #
 
-# General
-alias pl='perl'
-alias pld='perldoc'
-alias ple='perl -wlne'
+if ! zstyle -t ':prezto:module:perl:alias' skip; then
+  # General
+  alias pl='perl'
+  alias pld='perldoc'
+  alias ple='perl -wlne'
 
-# Perlbrew
-if (( $+commands[perlbrew] )); then
-  alias plb='perlbrew'
-  alias plba='perlbrew available'
-  alias plbi='perlbrew install'
-  alias plbl='perlbrew list'
-  alias plbo='perlbrew off'
-  alias plbO='perlbrew switch-off'
-  alias plbs='perlbrew switch'
-  alias plbu='perlbrew use'
-  alias plbx='perlbrew uninstall'
+  # Perlbrew
+  if (( $+commands[perlbrew] )); then
+    alias plb='perlbrew'
+    alias plba='perlbrew available'
+    alias plbi='perlbrew install'
+    alias plbl='perlbrew list'
+    alias plbo='perlbrew off'
+    alias plbO='perlbrew switch-off'
+    alias plbs='perlbrew switch'
+    alias plbu='perlbrew use'
+    alias plbx='perlbrew uninstall'
 
-elif (( $+commands[plenv] )); then
-  alias plv='plenv'
-  alias plvc='plenv commands'
-  alias plvl='plenv local'
-  alias plvg='plenv global'
-  alias plvs='plenv shell'
-  alias plvi='plenv install'
-  alias plvu='plenv uninstall'
-  alias plvr='plenv rehash'
-  alias plvv='plenv version'
-  alias plvV='plenv versions'
-  alias plvw='plenv which'
-  alias plvW='plenv whence'
-  alias plvm='plenv list-modules'
-  alias plvM='plenv migrate-modules'
-  alias plvI='plenv install-cpanm'
+  elif (( $+commands[plenv] )); then
+    alias plv='plenv'
+    alias plvc='plenv commands'
+    alias plvl='plenv local'
+    alias plvg='plenv global'
+    alias plvs='plenv shell'
+    alias plvi='plenv install'
+    alias plvu='plenv uninstall'
+    alias plvr='plenv rehash'
+    alias plvv='plenv version'
+    alias plvV='plenv versions'
+    alias plvw='plenv which'
+    alias plvW='plenv whence'
+    alias plvm='plenv list-modules'
+    alias plvM='plenv migrate-modules'
+    alias plvI='plenv install-cpanm'
+  fi
 fi

--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -171,6 +171,8 @@ fi
 # Aliases
 #
 
-alias py='python'
-alias py2='python2'
-alias py3='python3'
+if ! zstyle -t ':prezto:module:python:alias' skip; then
+  alias py='python'
+  alias py2='python2'
+  alias py3='python3'
+fi

--- a/modules/rails/init.zsh
+++ b/modules/rails/init.zsh
@@ -19,17 +19,19 @@ fi
 # Aliases
 #
 
-alias ror='bundle exec rails'
-alias rorc='bundle exec rails console'
-alias rordc='bundle exec rails dbconsole'
-alias rordm='bundle exec rake db:migrate'
-alias rordM='bundle exec rake db:migrate db:test:clone'
-alias rordr='bundle exec rake db:rollback'
-alias rorg='bundle exec rails generate'
-alias rorl='tail -f "$(ruby-app-root)/log/development.log"'
-alias rorlc='bundle exec rake log:clear'
-alias rorp='bundle exec rails plugin'
-alias rorr='bundle exec rails runner'
-alias rors='bundle exec rails server'
-alias rorsd='bundle exec rails server --debugger'
-alias rorx='bundle exec rails destroy'
+if ! zstyle -t ':prezto:module:rails:alias' skip; then
+  alias ror='bundle exec rails'
+  alias rorc='bundle exec rails console'
+  alias rordc='bundle exec rails dbconsole'
+  alias rordm='bundle exec rake db:migrate'
+  alias rordM='bundle exec rake db:migrate db:test:clone'
+  alias rordr='bundle exec rake db:rollback'
+  alias rorg='bundle exec rails generate'
+  alias rorl='tail -f "$(ruby-app-root)/log/development.log"'
+  alias rorlc='bundle exec rake log:clear'
+  alias rorp='bundle exec rails plugin'
+  alias rorr='bundle exec rails runner'
+  alias rors='bundle exec rails server'
+  alias rorsd='bundle exec rails server --debugger'
+  alias rorx='bundle exec rails destroy'
+fi

--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -59,23 +59,25 @@ fi
 # Aliases
 #
 
-# General
-alias rb='ruby'
+if ! zstyle -t ':prezto:module:ruby:alias' skip; then
+  # General
+  alias rb='ruby'
 
-# Bundler
-if (( $+commands[bundle] )); then
-  alias rbb='bundle'
-  alias rbbc='bundle clean'
-  alias rbbe='bundle exec'
-  alias rbbi='bundle install --path vendor/bundle'
-  alias rbbl='bundle list'
-  alias rbbo='bundle open'
-  alias rbbp='bundle package'
-  alias rbbu='bundle update'
-  alias rbbI='rbbi \
-    && bundle package \
-    && print .bundle       >>! .gitignore \
-    && print vendor/assets >>! .gitignore \
-    && print vendor/bundle >>! .gitignore \
-    && print vendor/cache  >>! .gitignore'
+  # Bundler
+  if (( $+commands[bundle] )); then
+    alias rbb='bundle'
+    alias rbbc='bundle clean'
+    alias rbbe='bundle exec'
+    alias rbbi='bundle install --path vendor/bundle'
+    alias rbbl='bundle list'
+    alias rbbo='bundle open'
+    alias rbbp='bundle package'
+    alias rbbu='bundle update'
+    alias rbbI='rbbi \
+      && bundle package \
+      && print .bundle       >>! .gitignore \
+      && print vendor/assets >>! .gitignore \
+      && print vendor/bundle >>! .gitignore \
+      && print vendor/cache  >>! .gitignore'
+  fi
 fi

--- a/modules/screen/init.zsh
+++ b/modules/screen/init.zsh
@@ -36,7 +36,9 @@ fi
 # Aliases
 #
 
-alias scr='screen'
-alias scrl='screen -list'
-alias scrn='screen -U -S'
-alias scrr='screen -a -A -U -D -R'
+if ! zstyle -t ':prezto:module:screen:alias' skip; then
+  alias scr='screen'
+  alias scrl='screen -list'
+  alias scrn='screen -U -S'
+  alias scrr='screen -a -A -U -D -R'
+fi

--- a/modules/tmux/init.zsh
+++ b/modules/tmux/init.zsh
@@ -45,5 +45,7 @@ fi
 # Aliases
 #
 
-alias tmuxa="tmux $_tmux_iterm_integration new-session -A"
-alias tmuxl='tmux list-sessions'
+if ! zstyle -t ':prezto:module:tmux:alias' skip; then
+  alias tmuxa="tmux $_tmux_iterm_integration new-session -A"
+  alias tmuxl='tmux list-sessions'
+fi


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #2036 

## Proposed Changes

Simply adds an optional `zstyle` `if` block to allow skipping alias creation for the following modules:

  - directory
  - emacs
  - fasd
  - history
  - homebrew
  - macports
  - node
  - perl
  - python
  - rails
  - ruby
  - screen
  - tmux

Be sure to view the diff with whitespace ignored (`?w=1`). It is much simpler to see that the only change here is the addition of an `if` block. https://github.com/mattmc3/prezto/commit/a7d6a1a5553d32700c77924a9f0e947c35e61bd9?w=1
