### PR TITLE
python: Expand Python command pattern per convention

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -50,7 +50,7 @@ fi
 unset local_pyenv
 
 # Return if requirements are not found.
-if (( ! $#commands[(i)python[23]#] && ! $+functions[pyenv] && ! $+commands[conda] )); then
+if (( ! $+commands[(i)python[0-9.]#] && ! $+functions[pyenv] && ! $+commands[conda] )); then
   return 1
 fi
 
@@ -136,8 +136,8 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) \
 
   if [[ $pyenv_virtualenvwrapper_plugin_found != "true" ]]; then
     # Fallback to standard 'virtualenvwrapper' if 'python' is available in '$path'.
-    if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $#commands[(i)python[23]#] )); then
-      VIRTUALENVWRAPPER_PYTHON=$commands[(i)python[23]#]
+    if (( ! $+VIRTUALENVWRAPPER_PYTHON )) && (( $+commands[(i)python[0-9.]#] )); then
+      VIRTUALENVWRAPPER_PYTHON=$commands[(i)python[0-9.]#]
     fi
 
     virtualenvwrapper_sources=(


### PR DESCRIPTION
Use `(i)python[0-9.]#` as subscript for commands associative array, following the [convention](https://github.com/zsh-users/zsh/blob/858b8de3d70fe76a3637c281bc2c8e3a6d961a2c/Completion/Unix/Command/_python#L1) of detection python more exhaustively.

This is also a follow-up to the previous [discussion](https://github.com/sorin-ionescu/prezto/issues/1949#issuecomment-1291224049) where @jeffwidman wanted me to address this.

