### PR TITLE
gnu-utility: Remove now obsolete egrep and fgrep

### DIFF
--- a/modules/gnu-utility/init.zsh
+++ b/modules/gnu-utility/init.zsh
@@ -44,8 +44,7 @@ _gnu_utility_cmds=(
   'libtool' 'libtoolize'
 
   # Miscellaneous
-  'awk' 'egrep' 'fgrep' 'getopt' 'grep' 'indent' 'make' 'sed' 'tar' 'time'
-  'units' 'which'
+  'awk' 'getopt' 'grep' 'indent' 'make' 'sed' 'tar' 'time' 'units' 'which'
 )
 
 # Wrap GNU utilities in functions.


### PR DESCRIPTION
These were marked deprecated for a while and has now been marked obsolete since gnu-grep 3.8 [1]. They have been removed from POSIX as well [2].

[1] https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html
[2] https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html#tag_20_55_18

Closes #2031