### PR TITLE
general: Documentation update for zstyle based alias skipping support

### DIFF
--- a/modules/directory/README.md
+++ b/modules/directory/README.md
@@ -17,6 +17,13 @@ Sets directory options and defines directory aliases.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:directory:alias' skip 'yes'
+```
+
 - `d` prints the contents of the directory stack.
 - `1 ... 9` changes the directory to the **n** previous one.
 

--- a/modules/emacs/README.md
+++ b/modules/emacs/README.md
@@ -12,6 +12,13 @@ execution of `carton`.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:emacs:alias' skip 'yes'
+```
+
 ### Carton
 
 - `cai` installs dependencies.

--- a/modules/fasd/README.md
+++ b/modules/fasd/README.md
@@ -19,6 +19,13 @@ instead of the bundled version.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:fasd:alias' skip 'yes'
+```
+
 - `j` changes the current working directory interactively.
 
 ## Completion

--- a/modules/history/README.md
+++ b/modules/history/README.md
@@ -36,6 +36,13 @@ Alternately, you can set `HISTFILE` manually to _`${ZDOTDIR:-$HOME}/.zhistory`_.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:history:alias' skip 'yes'
+```
+
 - `history-stat` lists the ten most used commands
 
 ## Settings

--- a/modules/homebrew/README.md
+++ b/modules/homebrew/README.md
@@ -12,6 +12,13 @@ brew shellenv
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:homebrew:alias' skip 'yes'
+```
+
 ### Homebrew Core
 
 - `brewc` cleans outdated brews and their cached archives.

--- a/modules/macports/README.md
+++ b/modules/macports/README.md
@@ -4,6 +4,13 @@ Defines MacPorts aliases and adds MacPorts directories to path variables.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:macports:alias' skip 'yes'
+```
+
 - `portc` cleans the files used to build ports.
 - `porti` installs a port.
 - `ports` searches for a port.

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -29,6 +29,13 @@ _`$XDG_CONFIG_HOME/nvm`_, _`~/.nvm`_, or is installed with homebrew.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:node:alias' skip 'yes'
+```
+
 ### npm
 
 - `npmi` install a package.

--- a/modules/perl/README.md
+++ b/modules/perl/README.md
@@ -40,6 +40,13 @@ The subcommands of _plenv_ is similar with _rbenv_.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:perl:alias' skip 'yes'
+```
+
 ### General
 
 - `pl` is short for `perl`.

--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -124,6 +124,13 @@ zstyle ':prezto:module:python:virtualenv' initialize 'no'
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:python:alias' skip 'yes'
+```
+
 - `py` is short for `python`.
 - `py2` is short for `python2`.
 - `py3` is short for `python3`.

--- a/modules/rails/README.md
+++ b/modules/rails/README.md
@@ -4,6 +4,13 @@ Defines [Ruby on Rails][1] aliases.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:rails:alias' skip 'yes'
+```
+
 - `ror` is short for `rails`.
 - `rorc` starts the Rails console.
 - `rordc` starts the Rails console connected to the database.

--- a/modules/ruby/README.md
+++ b/modules/ruby/README.md
@@ -54,6 +54,13 @@ dependencies, with [Bundler][5].
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:ruby:alias' skip 'yes'
+```
+
 ### General
 
 - `rb` is short for `ruby`.

--- a/modules/screen/README.md
+++ b/modules/screen/README.md
@@ -24,6 +24,13 @@ zstyle ':prezto:module:screen:auto-start' remote 'yes'
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:screen:alias' skip 'yes'
+```
+
 - `scr` is short for `screen`.
 - `scrl` lists sessions/socket directory.
 - `scrn` starts a new session.

--- a/modules/tmux/README.md
+++ b/modules/tmux/README.md
@@ -53,6 +53,13 @@ Read [iTerm2 and tmux Integration][7] for more information.
 
 ## Aliases
 
+Aliases are enabled by default. To disable them, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:tmux:alias' skip 'yes'
+```
+
 - `tmuxa` attaches or switches to a tmux session.
 - `tmuxl` lists sessions managed by the tmux server.
 


### PR DESCRIPTION
Add documentation to surface the `zstyle` based alias skipping.

This is a followup for #2037.