### PR TITLE
history-substring-search: add fuzzy and unique

### DIFF
--- a/modules/history-substring-search/README.md
+++ b/modules/history-substring-search/README.md
@@ -65,6 +65,24 @@ _`${ZDOTDIR:-$HOME}/.zpreztorc`_:
 zstyle ':prezto:module:history-substring-search' globbing-flags ''
 ```
 
+### Fuzzy search
+
+To enable fuzzy search add the following line to
+`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+
+```sh
+zstyle ':prezto:module:history-substring-search' fuzzy 'yes'
+```
+
+### Unique results
+
+To retrieve only unique results (remove duplicates) add the following line to
+`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+
+```sh
+zstyle ':prezto:module:history-substring-search' ensure-unique 'yes'
+```
+
 ## Authors
 
 _The authors of this module should be contacted via the [issue tracker][5]._

--- a/modules/history-substring-search/init.zsh
+++ b/modules/history-substring-search/init.zsh
@@ -38,6 +38,14 @@ if ! zstyle -t ':prezto:module:history-substring-search' color; then
   unset HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_{FOUND,NOT_FOUND}
 fi
 
+if zstyle -t ':prezto:module:history-substring-search' fuzzy; then
+  HISTORY_SUBSTRING_SEARCH_FUZZY=1
+fi
+
+if zstyle -t ':prezto:module:history-substring-search' ensure-unique; then
+  HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1
+fi
+
 #
 # Key Bindings
 #

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -109,6 +109,12 @@ zstyle ':prezto:module:editor' key-bindings 'emacs'
 # Set the search globbing flags.
 # zstyle ':prezto:module:history-substring-search' globbing-flags ''
 
+# Enable fuzzy search
+# zstyle ':prezto:module:history-substring-search' fuzzy 'yes'
+
+# Retrieve only unique results (removes duplicates)
+# zstyle ':prezto:module:history-substring-search' ensure-unique 'yes'
+
 #
 # macOS
 #


### PR DESCRIPTION
Adds 2 useful options available on the currently linked version (`v1.0.2`) of history-substring-search: fuzzy search and unique results (removes duplicates).
