### PR TITLE
utility: Detect lsd and honor its GNU ls compatibility

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -76,7 +76,7 @@ if zstyle -T ':prezto:module:utility' safe-ops; then
 fi
 
 # ls
-if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*GNU *} ]]; then
+if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*(GNU|lsd) *} ]]; then
   # GNU Core Utilities
 
   if zstyle -T ':prezto:module:utility:ls' dirs-first; then


### PR DESCRIPTION
lsd (LSDeluxe) is a modern GNU compatibile alternative to ls.

Detect if it is aliased to ls and honor its GNU ls compatibility.

Fixes #2054
