### PR TITLE
Only call `pyenv init` once

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -29,9 +29,9 @@ if [[ -s "${local_pyenv::=${PYENV_ROOT:-$HOME/.pyenv}/bin/pyenv}" ]] \
   autoload -Uz is-at-least
   if is-at-least 2 ${"$(pyenv --version 2>&1)"[(w)2]}; then
     eval "$(pyenv init --path zsh)"
+  else
+    eval "$(pyenv init - zsh)"
   fi
-
-  eval "$(pyenv init - zsh)"
 
 # Prepend PEP 370 per user site packages directory, which defaults to
 # ~/Library/Python on macOS and ~/.local elsewhere, to PATH. The


### PR DESCRIPTION
The `python` module calls `pyenv init` twice on each startup.

The bug was introduced here: https://github.com/sorin-ionescu/prezto/commit/afe59b293b5d91353f58a4c786a560242bb43415#diff-414db2cc4cb0c69d0fea2d6304ceb9921bf9d0d96f8d47f545e19bfa217dc39dL20

The change to the logic dropped an `else` resulting in `pyenv init` being called twice.