### PR TITLE
add zstyle to disable alias sl=ls

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -142,6 +142,15 @@ zstyle ':prezto:module:utility' correct 'no'
 - `lu` lists sorted by date, most recent last, shows access time.
 - `sl` lists directory contents (correction for `ls`).
 
+To disable the correction of `sl` to `ls`, which conflicts with
+[sapling](https://github.com/facebook/sapling), add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_:
+
+```sh
+zstyle ':prezto:module:utility' slls 'no'
+```
+
+
 ### macOS Everywhere
 
 - `o` opens files and directories (`open` or `xdg-open`).

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -122,7 +122,10 @@ alias lk='ll -Sr'        # Lists sorted by size, largest last.
 alias lt='ll -tr'        # Lists sorted by date, most recent last.
 alias lc='lt -c'         # Lists sorted by date, most recent last, shows change time.
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
-alias sl='ls'            # Correction for common spelling error.
+
+if zstyle -T ':prezto:module:utility' slls; then
+    alias sl='ls'            # Correction for common spelling error.
+fi
 
 if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*GNU *} ]]; then
   alias lx='ll -XB'      # Lists sorted by extension (GNU only).


### PR DESCRIPTION
sl is the command alias for [`sapling`](https://github.com/facebook/sapling) so this alias conflicts with it. This PR adds an option to disable the alias.

## Proposed Changes
  - `zstyle -T ':prezto:module:utility' slls 'no'` disables `alias sl=ls`
