### PR TITLE
remove alias sl='ls'

### DIFF
--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -140,7 +140,6 @@ zstyle ':prezto:module:utility' correct 'no'
 - `lt` lists sorted by date, most recent last.
 - `lc` lists sorted by date, most recent last, shows change time.
 - `lu` lists sorted by date, most recent last, shows access time.
-- `sl` lists directory contents (correction for `ls`).
 
 ### macOS Everywhere
 

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -122,7 +122,6 @@ alias lk='ll -Sr'        # Lists sorted by size, largest last.
 alias lt='ll -tr'        # Lists sorted by date, most recent last.
 alias lc='lt -c'         # Lists sorted by date, most recent last, shows change time.
 alias lu='lt -u'         # Lists sorted by date, most recent last, shows access time.
-alias sl='ls'            # Correction for common spelling error.
 
 if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*GNU *} ]]; then
   alias lx='ll -XB'      # Lists sorted by extension (GNU only).


### PR DESCRIPTION
replacement for https://github.com/sorin-ionescu/prezto/pull/2064 that removes this alias entirely