### PR TITLE
Add zstyle configuration for WORDCHARS

### DIFF
--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -12,6 +12,17 @@ Sets editor specific key bindings options and variables.
 
 ## Settings
 
+## Wordchars
+
+To change what characters are considered part of a word, add the following to
+_`${ZDOTDIR:-$HOME}/.zpreztorc`_.
+
+```sh
+zstyle ':prezto:module:editor' wordchars <chars>
+```
+
+Defaults to `*?_-.[]~&;!#$%^(){}<>`.
+
 ### Key bindings
 
 To enable key bindings, add the following to _`${ZDOTDIR:-$HOME}/.zpreztorc`_,

--- a/modules/editor/README.md
+++ b/modules/editor/README.md
@@ -12,7 +12,7 @@ Sets editor specific key bindings options and variables.
 
 ## Settings
 
-## Wordchars
+### Wordchars
 
 To change what characters are considered part of a word, add the following to
 _`${ZDOTDIR:-$HOME}/.zpreztorc`_.

--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -21,7 +21,8 @@ setopt BEEP                     # Beep on error in line editor.
 #
 
 # Treat these characters as part of a word.
-WORDCHARS='*?_-.[]~&;!#$%^(){}<>'
+zstyle -s ':prezto:module:editor' wordchars 'WORDCHARS' \
+  || WORDCHARS='*?_-.[]~&;!#$%^(){}<>'
 
 # Use human-friendly identifiers.
 zmodload zsh/terminfo

--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -60,6 +60,9 @@ zstyle ':prezto:load' pmodule \
 # Editor
 #
 
+# Set the characters that are considered to be part of a word.
+# zstyle ':prezto:module:editor' wordchars '*?_-.[]~&;!#$%^(){}<>'
+
 # Set the key mapping style to 'emacs' or 'vi'.
 zstyle ':prezto:module:editor' key-bindings 'emacs'
 


### PR DESCRIPTION
Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #2067 

## Proposed Changes

This adds a new `zstyle` customization, `wordchars` in the `:prezto:module:editor` context, to configure the `WORDCHARS` parameter that is set by Prezto's `editor` module.
