### PR TITLE
screen module: don't try to attach to dead screens

### DIFF
--- a/modules/screen/init.zsh
+++ b/modules/screen/init.zsh
@@ -22,7 +22,7 @@ if [[ -z "$STY" && -z "$EMACS" && -z "$VIM" ]] && ( \
   session="$(
     screen -list 2> /dev/null \
       | sed '1d;$d' \
-      | awk '{print $1}' \
+      | awk '!/Dead/ {print $1}' \
       | head -1)"
 
   if [[ -n "$session" ]]; then


### PR DESCRIPTION
Removes dead screens from the list of candidate screens. Fixes issue 1253, "screen:auto-start problem with dead screens".

Fixes #1253
