### PR TITLE
osx: Add trash function

### DIFF
--- a/modules/osx/functions/trash
+++ b/modules/osx/functions/trash
@@ -1,0 +1,31 @@
+#
+# Moves files to the macOS trash.
+#
+
+# function trash {
+
+emulate -L zsh
+setopt LOCAL_OPTIONS EXTENDED_GLOB
+
+local file
+local -a files=()
+for file in $@; do
+  if [[ -e $file ]]; then
+    # ':a' gets the full path (do not use ':A', which would resolve symlinks)
+    files+=("the POSIX file \"${file:a}\"")
+  else
+    print "trash: No such file or directory '$file'." >&2
+    return 1
+  fi
+done
+
+if (( $#files == 0 )); then
+  print 'usage: trash <files...>' >&2
+  return 64  # Match rm's return code.
+fi
+
+# Join file list with commas, and tell Finder to trash that list.
+local file_list="${(pj., .)files}"
+osascript 2>&1 > /dev/null -e "tell app \"Finder\" to move { "${file_list}" } to trash"
+
+# }


### PR DESCRIPTION
## Proposed Changes
- Adds a trash function to the osx (macOS) module
 
There's a bunch of outdated or overcomplicated/unmaintained cli trash utilities for macOS. This very simple and useful Zsh `trash` function uses oascript to put files in the trash.

## Conflicts

If a user has already installed one of the many (unmaintained?) trash apps from homebrew, having a Zsh trash function would override them. If that's a concern the Prezto maintainers have, this function could be renamed.

They are:
- https://formulae.brew.sh/formula/trash
- https://formulae.brew.sh/formula/trash-cli
- https://formulae.brew.sh/formula/macos-trash
