### PR TITLE
Adjust case-insensitive completion to use [:upper:] and [:lower:]

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -84,7 +84,7 @@ if zstyle -t ':prezto:module:completion:*' case-sensitive; then
   zstyle ':completion:*' matcher-list 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
   setopt CASE_GLOB
 else
-  zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  zstyle ':completion:*' matcher-list 'm:{[:lower:]}={[:upper:]}' 'm:{[:upper:]}={[:lower:]}'  'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
   unsetopt CASE_GLOB
 fi
 


### PR DESCRIPTION
This fixes #2053.

Previously, in cases where exactly two completion arguments were present, one would match `{a-zA-Z}` and the other would match `{A-Za-z}`, thus causing a first-character "match". The [docs](https://zsh.sourceforge.io/Doc/Release/Completion-Widgets.html#Completion-Matching-Control) recommend using `[:lower:]` and `[:upper:]` over `a-z` as well.