### PR TITLE
Update Python virtualenvwrapper documentation

### DIFF
--- a/modules/python/README.md
+++ b/modules/python/README.md
@@ -13,7 +13,7 @@ disable _virtualenvwrapper_, add the following to
 _`${ZDOTDIR:-$HOME}/.zpreztorc`_.
 
 ```sh
-zstyle ':prezto:module:python' skip-virtualenvwrapper-init 'on'
+zstyle ':prezto:module:python:virtualenv' initialize 'no'
 ```
 
 Conda support can be enabled by adding the following to


### PR DESCRIPTION
Update Python module documentation wrt virtualenvwrapper.

The `skip-virtualenvwrapper-init` option seems to be gone already. 