### PR TITLE
Allow .dir_colors to be a symlink

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -88,7 +88,7 @@ if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*(GNU|lsd) *} ]]; then
     if (( ! $+LS_COLORS )); then
       # Try dircolors when available
       if is-callable 'dircolors'; then
-        eval "$(dircolors --sh $HOME/.dir_colors(.N))"
+        eval "$(dircolors --sh $HOME/.dir_colors(N))"
       else
         export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
       fi


### PR DESCRIPTION
prezto currently only uses `~/.dir_colors` to set up `LS_COLORS` if it's a regular file. This change allows it to also be a symlink. I have `.dir_colors` symlinked to my directory of dot files