### PR TITLE
Allow overriding _ssh_agent_sock for symmetry to _ssh_agent_env

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -16,8 +16,8 @@ _ssh_dir="$HOME/.ssh"
 # Set the path to the environment file if not set by another module.
 _ssh_agent_env="${_ssh_agent_env:-${XDG_CACHE_HOME:-$HOME/.cache}/prezto/ssh-agent.env}"
 
-# Set the path to the persistent authentication socket.
-_ssh_agent_sock="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/ssh-agent.sock"
+# Set the path to the persistent authentication socket if not set by another module.
+_ssh_agent_sock="${_ssh_agent_sock:-${XDG_CACHE_HOME:-$HOME/.cache}/prezto/ssh-agent.sock}"
 
 # Start ssh-agent if not started.
 if [[ ! -S "$SSH_AUTH_SOCK" ]]; then


### PR DESCRIPTION
`_ssh_agent_env` can be overridden by another module, this change proposes the same treatment to `_ssh_agent_sock`.

Nothing is overridden by default so it shouldn't affect any existing user.

Specifically, I was looking into overriding where the SSH files are stored, without modifying `XDG_CACHE_HOME` (because a bunch of other stuff uses that), and overriding `_ssh_agent_env` and `_ssh_agent_sock` seems like the cleanest.