### PR TITLE
Removing Fig from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,6 @@ version is **4.3.11**.
 
 05. Open a new Zsh terminal window or tab.
 
-### [Fig](https://fig.io)
-
-Fig adds apps, shortcuts, and autocomplete to your existing terminal.
-
-Install `prezto` in just one click.
-
-<a href="https://fig.io/plugins/other/prezto" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
-
 ### Troubleshooting
 
 If you are not able to find certain commands after switching to Prezto, modify


### PR DESCRIPTION
## Proposed Changes

Fig is sunsetting as per https://fig.io/blog/post/fig-is-sunsetting and CodeWhisperer does not support plugins so I've removed the Fig section from the Readme