### PR TITLE
Add relative path fix to git-hub-browse

### DIFF
--- a/modules/git/functions/git-hub-browse
+++ b/modules/git/functions/git-hub-browse
@@ -12,6 +12,8 @@ if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   return 1
 fi
 
+root="$(command git rev-parse --show-toplevel)"
+
 local remotes remote references reference file url
 
 remote="${1:-origin}"
@@ -42,7 +44,8 @@ if [[ "$reference" == 'HEAD' ]]; then
   reference="$(command git rev-parse HEAD 2> /dev/null)"
 fi
 
-file="$3"
+file="${3:-$(pwd)}"
+file="$(command realpath "$file" | sed "s|^$root||")"
 
 if [[ -n "$url" ]]; then
   url="$url/tree/$reference/$file"


### PR DESCRIPTION
Fixes path handling for the command `git-hub-browse` to use relative paths.
This enables opening the current working directory or a file in a directory without manually specifying the file path relative to the root.

## Proposed Changes

  - Use `realpath` to get the full path of the file or directory
  - Use `git rev-parse --show-toplevel` to get the root directory
  - Use `sed` to remove the root from the full path, making it root relative.
  - Use the `pwd` (current working directory) as the default path, rather than ""
