### PR TITLE
fix the bugs 'no such file or directory: ../external/async/async.zsh' by windows. change README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ version is **4.3.11**.
     done
     ```
 
+    If you use **windows**, please use this command。
+    
+    ```bat
+    @echo off
+    setlocal enabledelayedexpansion
+    REM YOUR HOME DIR
+    set "HomeDir=%USERPROFILE%"
+    set "sourceDir=%HomeDir%\.zprezto\runcoms"
+    set "linkDir=%HomeDir%"
+    echo "sourceDir = %sourceDir%"
+    echo "linkDir = %linkDir%"
+    
+    if not exist "%linkDir%" mkdir "%linkDir%"
+    for /R "%sourceDir%" %%F in (*) do (
+        set "fileName=%%~nxF"
+        REM echo "filename=!fileName!"
+        REM echo "F=%%F"
+        REM pause
+        if /I not "!fileName!"=="README.md" (
+            mklink "%linkDir%\.!fileName!" "%%F"
+        )
+    )
+    ```
+    
     **Note:** If you already have any of the given configuration files, `ln` in
     the above operation will cause an error. In simple cases, you can load
     Prezto by adding the line `source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"` to
@@ -64,7 +88,7 @@ version is **4.3.11**.
     Zsh configuration intact. For more complicated setups, we recommend that you
     back up your original configs and replace them with the provided Prezto
     [_`runcoms`_][10].
-
+    
 04. Set Zsh as your default shell:
 
     ```console

--- a/modules/prompt/functions/async
+++ b/modules/prompt/functions/async
@@ -1,1 +1,1 @@
-../external/async/async.zsh
+source ${ZPREZTODIR}/modules/prompt/external/async/async.zsh

--- a/modules/prompt/functions/prompt_agnoster_setup
+++ b/modules/prompt/functions/prompt_agnoster_setup
@@ -1,1 +1,1 @@
-../external/agnoster/agnoster.zsh-theme
+source ${ZPREZTODIR}/modules/prompt/external/agnoster/agnoster.zsh-theme

--- a/modules/prompt/functions/prompt_powerlevel10k_setup
+++ b/modules/prompt/functions/prompt_powerlevel10k_setup
@@ -1,1 +1,1 @@
-../external/powerlevel10k/powerlevel10k.zsh-theme
+source ${ZPREZTODIR}/modules/prompt/external/powerlevel10k/powerlevel10k.zsh-theme

--- a/modules/prompt/functions/prompt_powerline_setup
+++ b/modules/prompt/functions/prompt_powerline_setup
@@ -1,1 +1,1 @@
-../external/powerline/prompt_powerline_setup
+source ${ZPREZTODIR}/modules/prompt/external/powerline/prompt_powerline_setup

--- a/modules/prompt/functions/prompt_pure_setup
+++ b/modules/prompt/functions/prompt_pure_setup
@@ -1,1 +1,1 @@
-../external/pure/pure.zsh
+source ${ZPREZTODIR}/modules/prompt/external/pure/pure.zsh


### PR DESCRIPTION
fix the bugs appear 'async:1: no such file or directory: ../external/async/async.zsh' when perzto using by windows,And change README.md to tell how to create linking by windows.

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #2016 

## Proposed Changes

  - fix bugs on windows.
  - use cmd to create linking on windows

I think this pull request would help the developor who use prezto by windows.