### PR TITLE
[suggestion/zprofile] Less: use --redraw-on-quit

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -60,10 +60,11 @@ path=(
 #
 
 # Set the default Less options.
-# Mouse-wheel scrolling has been disabled by -X (disable screen clearing).
-# Remove -X to enable it.
+# We used '-X' to disable screen capturing, which disabled termcap init and
+# deinit, instead now we use --redraw-on-quit to make the contents persist,
+# while still supporting mouse-wheel scrolling.
 if [[ -z "$LESS" ]]; then
-  export LESS='-g -i -M -R -S -w -X -z-4'
+  export LESS='-g -i -M -R -S -w -z-4 --redraw-on-quit'
 fi
 
 # Set the Less input preprocessor.


### PR DESCRIPTION
Less has an option to redraw the screen after quitting, which might mean you get the behaviour you want using `-X` (have the last [manpage? etc] screen visible after quit) while still supporting scroll.

```shell
# From man less(1)
       --redraw-on-quit
              When quitting, after sending the terminal  deinitialization  string,  redraws
              the  entire last screen.  On terminals whose terminal deinitialization string
              causes the terminal to switch from an alternate screen, this makes  the  last
              screenful of the current file remain visible after less has quit.
```

This is just a suggestion, if you have a different reason to use `-x` then this doesn't have to go in, but maybe I should still update the comment so that others know of --redraw-on-quit too