### PR TITLE
command-not-found module: add support for homebrew >= 4.6.12

### DIFF
--- a/modules/command-not-found/README.md
+++ b/modules/command-not-found/README.md
@@ -6,18 +6,26 @@ install command.
 
 Debian and Arch Linux based distributions use the [`command-not-found`][1] tool.
 
-macOS uses Homebrew's [`command-not-found` clone][2]. Note that unless you have
-a recent version of Homebrew installed, you might also need to tap the
-`command-not-found` Homebrew repository [following the instructions][3].
+macOS uses Homebrew's [`command-not-found` clone][2]. This module will
+automatically load it without needing to manually source `handler.sh` from
+`.zshrc` per the [instructions][3].
+
+Note: Prior to [Homebrew 4.6.12][4], you may have also needed to tap the
+[`command-not-found` Homebrew repository][5]. This will still work as a
+fallback when the `command-not-found` handler can't be detected in Homebrew
+core, but the repository has been deprecated and may print a warning. After
+upgrading Homebrew, it can be untapped.
 
 ## Authors
 
-_The authors of this module should be contacted via the [issue tracker][4]._
+_The authors of this module should be contacted via the [issue tracker][6]._
 
 - [Joseph Booker](https://github.com/sargas)
 - [Indrajit Raychaudhuri](https://github.com/indrajitr)
 
 [1]: https://code.launchpad.net/command-not-found
-[2]: https://github.com/Homebrew/homebrew-command-not-found
-[3]: https://github.com/Homebrew/homebrew-command-not-found#install
-[4]: https://github.com/sorin-ionescu/prezto/issues
+[2]: https://docs.brew.sh/Command-Not-Found
+[3]: https://docs.brew.sh/Command-Not-Found#install
+[4]: https://github.com/Homebrew/brew/releases/tag/4.6.12
+[5]: https://github.com/Homebrew/homebrew-command-not-found
+[6]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/command-not-found/init.zsh
+++ b/modules/command-not-found/init.zsh
@@ -12,11 +12,22 @@ if [[ -s /etc/zsh_command_not_found ]]; then
 # Load command-not-found on Arch Linux-based distributions.
 elif [[ -s /usr/share/doc/pkgfile/command-not-found.zsh ]]; then
   source /usr/share/doc/pkgfile/command-not-found.zsh
-# Load command-not-found on macOS when Homebrew tap is configured.
-elif (( $+commands[brew] )) \
-      && [[ -s ${hb_cnf_handler::="${HOMEBREW_REPOSITORY:-$commands[brew]:A:h:h}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"} ]]; then
-  source "$hb_cnf_handler"
-  unset hb_cnf_handler
+# Load command-not-found on macOS when Homebrew is present. Check explicitly
+# for MacOS, since homebrew can be installed on Linux as a supplementary PM
+elif [[ "$OSTYPE" =~ ^darwin ]] && (( $+commands[brew] )); then
+  homebrew_repo=${HOMEBREW_REPOSITORY:-$commands[brew]:A:h:h/Library}
+  # Look for handler in Homebrew core (as of >=4.6.12), then in Taps (< 4.6.12)
+  for hb_cnf_handler in "$homebrew_repo"/{Homebrew/command-not-found/handler.sh,Taps/homebrew/homebrew-command-not-found/handler.sh}; do
+    if [ -f "$hb_cnf_handler" ]; then
+      source "$hb_cnf_handler"
+      unset hb_cnf_handler homebrew_repo
+      break
+    fi
+  done
+  if [ -n "$hb_cnf_handler" ]; then
+    unset hb_cnf_handler homebrew_repo
+    return 1
+  fi
 # Return if requirements are not found.
 else
   return 1


### PR DESCRIPTION
As of [Homebrew 4.6.12](https://github.com/Homebrew/brew/releases/tag/4.6.12), command-not-found is built into Homebrew core and the Tap is deprecated, causing Homebrew to print deprecation warnings on init until the tap is uninstalled, after which prezto can't find the helper in its new location.

## Fix

Updated to first look in the new location for handler.sh in the core Homebrew repository, *then* check in Taps. That way it will still work regardless of Homebrew version, but it won't try to access the deprecated Tap if both it and the core `handler.sh` exist.

## Testing for MacOS

I also included a test condition for MacOS using `$OSTYPE`.

Since homebrew can also be installed on Linux as a userland package manager, if the Debian/Arch checks don't pass, it would revert to Homebrew on Linux, which - since there is almost certainly *some* default system package manager - didn't strike me as the ideal behavior. I'm guessing this wasn't intentional given the "Load command-not-found on macOS when Homebrew tap is configured" comment in the code, but happy to pull that behavior back out if I was off base on that front!