### PR TITLE
Improve manp function argument handling

### DIFF
--- a/modules/osx/functions/manp
+++ b/modules/osx/functions/manp
@@ -7,13 +7,22 @@
 
 function manp {
   local page
-  if (( $# > 0 )); then
-    for page in "$@"; do
-      mandoc -T pdf "$(/usr/bin/man -w $page)" | open -fa Preview
-    done
-  else
-    print 'What manual page do you want?' >&2
+  local path
+
+  if (( $# == 0 )); then
+    return 1
   fi
+
+  for page in "$@"; do
+    path="$(/usr/bin/man -w -- "$page" 2>/dev/null)"
+
+    if [[ -z "$path" || ! -f "$path" ]]; then
+      print "No manual entry for $page" >&2
+      continue
+    fi
+
+    mandoc -T pdf -- "$path" | open -fa Preview
+  done
 }
 
 manp "$@"


### PR DESCRIPTION
Refactor `manp` function to handle no arguments and check for valid manual page paths. Check whether `man -w` actually returned to a path before piping into `mandoc`

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

## Proposed Changes

  - Add validation for missing manual pages
  - Suppress error output from `man -w`
