### PR TITLE
Make uutils coreutils ls behave the same as GNU coreutils ls

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -76,7 +76,7 @@ if zstyle -T ':prezto:module:utility' safe-ops; then
 fi
 
 # ls
-if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*(GNU|lsd) *} ]]; then
+if [[ ${(@M)${(f)"$(ls --version 2>&1)"}:#*(GNU|lsd|uutils) *} ]]; then
   # GNU Core Utilities
 
   if zstyle -T ':prezto:module:utility:ls' dirs-first; then


### PR DESCRIPTION
Ubuntu 25.10 uses a rust rewrite of GNU coreutils called `uutils coreutils`. Calling `ls --version` on that config yields `ls (uutils coreutils) 0.2.2`. Since the regex does not match the string, it falls back to the BSD branch. That leads to `ls` being aliased as `ls -G` without any colors in the output.

Since `uutils coreutils` claims that `uutils coreutils aims to be a drop-in replacement for the GNU utils. Differences with GNU are treated as bugs.` it should be safe to treat it the same way in the code.

Adjust the `utility` module to detect `uutils ls` as `GNU ls` by extending the regex pattern.


Fixes #2119
