### PR TITLE
fix diff function: conform to GNU diff behaviour for scripting

### DIFF
--- a/modules/utility/functions/diff
+++ b/modules/utility/functions/diff
@@ -10,7 +10,7 @@
 if zstyle -t ':prezto:module:utility:diff' color \
       && [[ -t 1 ]] \
       && (( $+commands[colordiff] )); then
-  command diff "$@" | colordiff --color-term-output-only=yes
+  command diff "$@" | colordiff
   return "${pipestatus[1]}"
 else
   command diff "$@"


### PR DESCRIPTION
Fixes #2121

## Proposed Changes

  - This change changes the behaviour of diff function to conform to GNU diff: return code indicates comparison result, output is not colored when used within a pipeline.