### PR TITLE
Add an AWS module with aws-info function

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -1,0 +1,41 @@
+# AWS
+
+Integrates the [AWS CLI][1] into the shell environment.
+
+## Completions
+
+AWS CLI v2 ships with `aws_completer`. This module enables it automatically when
+present.
+
+## Functions
+
+- `aws-info` exposes information about the AWS environment via the `$aws_info`
+  associative array.
+
+## Theming
+
+To display the active AWS profile and region in a prompt, define the following
+styles in the `prompt_name_setup` function.
+
+```sh
+# %p - profile name.
+zstyle ':prezto:module:aws:info:profile' format 'profile:%p '
+
+# %r - region name.
+zstyle ':prezto:module:aws:info:region' format 'region:%r '
+```
+
+Then add `$aws_info[profile]` and `$aws_info[region]` to `$PROMPT` or `$RPROMPT`
+and call `aws-info` in the `prompt_name_precmd` hook function.
+
+The region is read from `$AWS_REGION` or `$AWS_DEFAULT_REGION`; if neither is set,
+it falls back to the value in `~/.aws/config` for the active profile.
+
+## Authors
+
+_The authors of this module should be contacted via the [issue tracker][2]._
+
+- [David Tagatac](https://github.com/tagatac)
+
+[1]: https://aws.amazon.com/cli/
+[2]: https://github.com/sorin-ionescu/prezto/issues

--- a/modules/aws/functions/aws-info
+++ b/modules/aws/functions/aws-info
@@ -1,0 +1,54 @@
+#
+# Exposes information about the AWS environment via the $aws_info associative
+# array.
+#
+# Authors:
+#   David Tagatac <david@tagatac.net>
+#
+
+# function aws-info {
+
+local profile
+local profile_format
+local profile_formatted
+local region
+local region_format
+local region_formatted
+
+# Clean up previous $aws_info.
+unset aws_info
+typeset -gA aws_info
+
+zstyle -s ':prezto:module:aws:info:profile' format 'profile_format'
+zstyle -s ':prezto:module:aws:info:region' format 'region_format'
+
+# Format profile.
+if [[ -n "$profile_format" ]]; then
+  profile="$AWS_PROFILE"
+  # Fall back to 'default' if the default profile exists in the config file.
+  if [[ -z "$profile" ]]; then
+    local config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+    if [[ -r "$config_file" ]] && grep -q '^\[default\]' "$config_file"; then
+      profile='default'
+    fi
+  fi
+  if [[ -n "$profile" ]]; then
+    zformat -f profile_formatted "$profile_format" "p:$profile"
+    aws_info[profile]="$profile_formatted"
+  fi
+fi
+
+# Format region.
+if [[ -n "$region_format" ]]; then
+  region="${AWS_REGION:-$AWS_DEFAULT_REGION}"
+  # Fall back to the config file value for the active profile.
+  if [[ -z "$region" ]]; then
+    region="$(aws configure get region 2>/dev/null)"
+  fi
+  if [[ -n "$region" ]]; then
+    zformat -f region_formatted "$region_format" "r:$region"
+    aws_info[region]="$region_formatted"
+  fi
+fi
+
+# }

--- a/modules/aws/init.zsh
+++ b/modules/aws/init.zsh
@@ -1,0 +1,17 @@
+#
+# Integrates the AWS CLI into the shell environment.
+#
+# Authors:
+#   David Tagatac <david@tagatac.net>
+#
+
+# Return if requirements are not found.
+if (( ! $+commands[aws] )); then
+  return 1
+fi
+
+# Load AWS CLI completions.
+if (( $+commands[aws_completer] )); then
+  autoload -Uz bashcompinit && bashcompinit
+  complete -C aws_completer aws
+fi


### PR DESCRIPTION
Fixes #2107

## Proposed Changes
  - Add an AWS module.
  - Activate command completion per the [user guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html#cli-command-completion-linux).
  - Add a function that fetches the active AWS profile and region and exposes them as variables for use in RPROMPT.

See an example usage here: https://github.com/tagatac/prezto/commit/129bb9c33f3243f040c084d1c0c89e434923ed64

ohmyzsh reference: https://github.com/ohmyzsh/ohmyzsh/tree/9151236d1e0cb64b2e803d7ec1736c7a717efc33/plugins/aws

Heavily assisted by Claude Code.