### PR TITLE
Make the persistent SSH authentication socket symlink creation atomic

### DIFF
--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -34,7 +34,8 @@ fi
 # Create a persistent SSH authentication socket.
 if [[ -S "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$_ssh_agent_sock" ]]; then
   mkdir -p "$_ssh_agent_sock:h"
-  ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
+  ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock.$$"
+  mv -f "$_ssh_agent_sock.$$" "$_ssh_agent_sock"
   export SSH_AUTH_SOCK="$_ssh_agent_sock"
 fi
 


### PR DESCRIPTION
There is a race in the SSH module. Namely, when multiple terminals are launched at the same time, they will all attempt the line
```
ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
```
However, `ln -sf` is not atomic, and, if run in parallel, can collide with multiple syscalls to `symlink`: https://temochka.com/blog/posts/2017/02/17/atomic-symlinks.html

I have observed this many times opening my default window arrangement in iTerm:
<img width="1470" height="462" alt="Screenshot 2026-03-22 at 1 18 07 PM" src="https://github.com/user-attachments/assets/257fe619-2413-4d77-bb7f-0c579fd5caba" />

## Proposed Changes
  - Instead of letting every terminal race to create the same symlink with `ln -s`, first create a symlink with a name unique to the given terminal's PID. Then `mv -f` (atomic) that symlink to the desired filename.