### PR TITLE
Add dir-nav module for browser-style directory navigation

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -27,6 +27,10 @@ completions from the zsh-completions project.
 
 Sets directory options and defines directory aliases.
 
+## Dir-Nav
+
+Provides browser-style directory navigation bound to Alt+Arrow keys.
+
 ## DNF
 
 Defines _dnf_ aliases.

--- a/modules/dir-nav/README.md
+++ b/modules/dir-nav/README.md
@@ -1,0 +1,23 @@
+# Dir-Nav
+
+Browser-style directional directory navigation bound to Alt+Arrow keys.
+
+| Key | Action |
+| --- | --- |
+| `Alt+Left`  | Back to previous directory |
+| `Alt+Right` | Forward (undo back) |
+| `Alt+Up`    | Parent directory |
+| `Alt+Down`  | First child directory (alphabetical) |
+
+`cd`'s issued outside the widgets push onto the back stack and clear the
+forward stack, matching browser history semantics.
+
+## Usage
+
+Add `dir-nav` to the `pmodule` list in `~/.zpreztorc`:
+
+```sh
+zstyle ':prezto:load' pmodule \
+  ... \
+  'dir-nav'
+```

--- a/modules/dir-nav/init.zsh
+++ b/modules/dir-nav/init.zsh
@@ -1,0 +1,78 @@
+#
+# Browser-style directional directory navigation.
+#
+#   Alt+Left  — back to previous directory
+#   Alt+Right — forward (undo back)
+#   Alt+Up    — parent directory
+#   Alt+Down  — first child directory (alphabetical)
+#
+
+pmodload 'editor'
+
+typeset -ga _dir_nav_back _dir_nav_fwd
+typeset -g  _dir_nav_busy=0
+
+# Record cd's done outside the widgets so Alt+Left can rewind them.
+_dir_nav_chpwd() {
+  (( _dir_nav_busy )) && return
+  _dir_nav_back+=("$OLDPWD")
+  _dir_nav_fwd=()
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd _dir_nav_chpwd
+
+dir-nav-back() {
+  (( ${#_dir_nav_back} )) || return
+  _dir_nav_fwd+=("$PWD")
+  _dir_nav_busy=1; builtin cd -- "${_dir_nav_back[-1]}"; _dir_nav_busy=0
+  _dir_nav_back[-1]=()
+  zle reset-prompt
+}
+
+dir-nav-forward() {
+  (( ${#_dir_nav_fwd} )) || return
+  _dir_nav_back+=("$PWD")
+  _dir_nav_busy=1; builtin cd -- "${_dir_nav_fwd[-1]}"; _dir_nav_busy=0
+  _dir_nav_fwd[-1]=()
+  zle reset-prompt
+}
+
+dir-nav-up() {
+  [[ "$PWD" == "/" ]] && return
+  _dir_nav_back+=("$PWD"); _dir_nav_fwd=()
+  _dir_nav_busy=1; builtin cd ..; _dir_nav_busy=0
+  zle reset-prompt
+}
+
+dir-nav-down() {
+  local -a children=( *(/N) )
+  (( ${#children} )) || return
+  _dir_nav_back+=("$PWD"); _dir_nav_fwd=()
+  _dir_nav_busy=1; builtin cd -- "${children[1]}"; _dir_nav_busy=0
+  zle reset-prompt
+}
+
+zle -N dir-nav-back
+zle -N dir-nav-forward
+zle -N dir-nav-up
+zle -N dir-nav-down
+
+#
+# Key bindings. Alt+Arrow is sent as either ESC-prefixed (ESC ESC [ X) or
+# the CSI modifier form (ESC [ 1 ; 3 X); bind both for portability.
+#
+
+if [[ -n "$key_info" ]]; then
+  for keymap in emacs viins; do
+    bindkey -M "$keymap" "$key_info[Escape]$key_info[Left]"  dir-nav-back
+    bindkey -M "$keymap" "$key_info[Escape]$key_info[Right]" dir-nav-forward
+    bindkey -M "$keymap" "$key_info[Escape]$key_info[Up]"    dir-nav-up
+    bindkey -M "$keymap" "$key_info[Escape]$key_info[Down]"  dir-nav-down
+
+    bindkey -M "$keymap" '^[[1;3D' dir-nav-back
+    bindkey -M "$keymap" '^[[1;3C' dir-nav-forward
+    bindkey -M "$keymap" '^[[1;3A' dir-nav-up
+    bindkey -M "$keymap" '^[[1;3B' dir-nav-down
+  done
+  unset keymap
+fi


### PR DESCRIPTION
I've been using the [dirhistory](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/dirhistory) plugin from oh-my-zsh for a while and missed it after switching to Prezto, so helping with claude code, I ported the idea as a new module.

It binds Alt+Arrow keys to browser-style directory navigation:

| Key | Action |
| --- | --- |
| `Alt+Left`  | Back to previous directory |
| `Alt+Right` | Forward (undo back) |
| `Alt+Up`    | Parent directory |
| `Alt+Down`  | First child directory (alphabetical) |

Regular `cd` commands also push onto the back stack and clear the forward stack, so the history stays consistent regardless of how you navigate.

## Implementation notes
- Depends on the `editor` module for `$key_info`