### PR TITLE
python: fix venv display in pure

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -105,7 +105,7 @@ if (( $+VIRTUALENVWRAPPER_VIRTUALENV || $+commands[virtualenv] )) \
   # pure prompt because there's some additional logic in that prompt which tries
   # to figure out if a user set this variable and disable the python portion of
   # that prompt based on it which is the exact opposite of what we want to do.
-  export VIRTUAL_ENV_DISABLE_PROMPT=12
+  export VIRTUAL_ENV_DISABLE_PROMPT=20
 
   # Create a sorted array of available virtualenv related 'pyenv' commands to
   # look for plugins of interest. Scanning shell '$path' isn't enough as they


### PR DESCRIPTION
The magic value changed from 12 to 20 in pure v1.27.0 via https://github.com/sindresorhus/pure/commit/987ae71a976226d2ccf01dd4df49483ef683d73awhich broke displaying the python venv.