### PR TITLE
homebrew: Fix shellenv cache empty with Homebrew >= 4.1

### DIFF
--- a/modules/homebrew/init.zsh
+++ b/modules/homebrew/init.zsh
@@ -24,10 +24,11 @@ if (( $+commands[brew] )); then
   cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/prezto/brew-shellenv-cache.zsh"
   if [[ "$commands[brew]" -nt "$cache_file" \
       || "${ZDOTDIR:-$HOME}/.zpreztorc" -nt "$cache_file" \
-      || ! -s "$cache_file" ]]; then
+      || ! -s "$cache_file" \
+      || -z "$(<"$cache_file")" ]]; then
     mkdir -p "$cache_file:h"
-    # Cache the result.
-    echo "${(@M)${(f)"$(brew shellenv 2> /dev/null)"}:#export HOMEBREW*}" >! "$cache_file" 2> /dev/null
+    # Cache the result (with brew off $PATH to always get the full output).
+    echo "${(@M)${(f)"$(PATH='/usr/bin:/bin' "$commands[brew]" shellenv 2> /dev/null)"}:#export HOMEBREW*}" >! "$cache_file" 2> /dev/null
   fi
 
   source "$cache_file"


### PR DESCRIPTION
## Bug

Since [Homebrew 4.1](https://brew.sh/2023/07/24/homebrew-4.1.0/), `brew shellenv` is idempotent: it prints **nothing** when `$HOMEBREW_PREFIX/bin` is already on `$PATH`. By the time `modules/homebrew/init.zsh` runs (via `zshrc`), `$PATH` has been set up in `zprofile`, so the idempotence check always short-circuits.

The cache generation line then writes a single newline into `brew-shellenv-cache.zsh`. That 1-byte file passes the `! -s` staleness check on every subsequent shell, so the cache is considered valid forever and `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR`, `HOMEBREW_REPOSITORY` are never set.

Repro on any machine with Homebrew >= 4.1 and the standard prezto setup:

```console
% echo $HOMEBREW_PREFIX

% wc -c ~/.cache/prezto/brew-shellenv-cache.zsh
       1 …/brew-shellenv-cache.zsh
```

## Fix

- Run `brew shellenv` with brew **off** `$PATH` (`PATH='/usr/bin:/bin'`) during cache generation, so it always emits the full output regardless of the caller's environment.
- Treat a whitespace-only cache as stale (`-z "$(<$cache_file)"`), so existing broken caches self-heal on the next shell without users having to delete them manually.

## Testing

- Seeded a 1-byte cache, sourced the module: cache regenerated with the three `export HOMEBREW_*` lines, variables set.
- Second run: cache reused, no regeneration.
- `zsh -n` clean; verified live on macOS arm64 (`/opt/homebrew`).